### PR TITLE
Add React frontend demo scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ build/
 .env
 .env.*
 !.env.example
+src/avatar-speech-demo/node_modules/
+src/avatar-speech-demo/dist/
+frontend/**/node_modules/
+frontend/**/dist/
+frontend/**/.vite/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ Software Development Life Cycle:
 Read task for implementation from project https://github.com/users/mmaideveloper/projects/5 and 
 tasks with status "Ready". 
 
+Frontend tasks: read tasks from project https://github.com/users/mmaideveloper/projects/6 (Ready status) and do not execute conda commands.
+
 Ask for implementation of task.  Create for each task separate branch.
 If you start working move task to in progress.
 Before moving a task to In review:
@@ -30,4 +32,3 @@ If the user asks to close a task:
 - Add a comment to the issue with the review/merge outcome.
 - Delete the feature branch and comment that deletion on the issue.
 - Move the task to Done (closed).
-

--- a/README.md
+++ b/README.md
@@ -238,6 +238,20 @@ python -m http.server 8000
 
 Then open `http://localhost:8000` in a browser. For details, see `docs/CORPORATE_WEB.md`.
 
+## Frontend demo app
+
+The React + TypeScript demo app lives in `frontend/aijurisdictionfronend`.
+
+Quick start:
+
+```bash
+cd frontend/aijurisdictionfronend
+npm install
+npm run dev
+```
+
+Then open `http://localhost:5173` in a browser. For details, see `docs/FRONTEND_DEMO.md`.
+
 ### Deployment
 
 The corporate site is deployed via GitHub Actions (`corporate_web` workflow) using FTP per environment.

--- a/docs/FRONTEND_DEMO.md
+++ b/docs/FRONTEND_DEMO.md
@@ -1,0 +1,39 @@
+# Frontend Demo App
+
+Location: `frontend/aijurisdictionfronend`
+
+This is a basic React + TypeScript app scaffolded with Vite. It is intended as the starting
+point for the AI Jurisdiction client workspace (intake, uploads, and live agent stream).
+
+## Quick start
+
+Requires Node.js 18+.
+
+```bash
+cd frontend/aijurisdictionfronend
+npm install
+npm run dev
+```
+
+Open `http://localhost:5173`.
+
+## Minimal runnable example
+
+From repo root (PowerShell):
+
+```powershell
+.\examples\frontend_demo.ps1
+```
+
+## Build
+
+```bash
+npm run build
+npm run preview
+```
+
+## Layout notes
+
+- Hero header with session status and region
+- Feature cards for intake, orchestration, and outputs
+- Callout panel for upcoming API integration

--- a/examples/frontend_demo.ps1
+++ b/examples/frontend_demo.ps1
@@ -1,0 +1,12 @@
+param(
+    [string]$Root = "."
+)
+
+Set-Location $Root
+Set-Location "frontend/aijurisdictionfronend"
+
+if (-not (Test-Path "node_modules")) {
+    npm install
+}
+
+npm run dev

--- a/frontend/aijurisdictionfronend/README.md
+++ b/frontend/aijurisdictionfronend/README.md
@@ -1,0 +1,22 @@
+# AI Jurisdiction Frontend (Demo)
+
+Basic React + TypeScript scaffold for the AI Jurisdiction frontend.
+
+## Quick start
+
+Requires Node.js 18+.
+
+```bash
+cd frontend/aijurisdictionfronend
+npm install
+npm run dev
+```
+
+Then open `http://localhost:5173`.
+
+## Build
+
+```bash
+npm run build
+npm run preview
+```

--- a/frontend/aijurisdictionfronend/index.html
+++ b/frontend/aijurisdictionfronend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/aj-mark.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Jurisdiction Frontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/aijurisdictionfronend/package.json
+++ b/frontend/aijurisdictionfronend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "aijurisdictionfronend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.55",
+    "@types/react-dom": "^18.2.19",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.12"
+  }
+}

--- a/frontend/aijurisdictionfronend/public/aj-mark.svg
+++ b/frontend/aijurisdictionfronend/public/aj-mark.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#0f172a" />
+  <path d="M18 44h28v4H18z" fill="#fbbf24" />
+  <path d="M32 14v24" stroke="#f8fafc" stroke-width="4" stroke-linecap="round" />
+  <path d="M20 24h24" stroke="#f8fafc" stroke-width="4" stroke-linecap="round" />
+  <circle cx="20" cy="32" r="6" fill="#38bdf8" />
+  <circle cx="44" cy="32" r="6" fill="#38bdf8" />
+</svg>

--- a/frontend/aijurisdictionfronend/src/App.tsx
+++ b/frontend/aijurisdictionfronend/src/App.tsx
@@ -1,0 +1,87 @@
+const highlights = [
+  {
+    title: "Secure Intake",
+    body: "Collect user instructions and uploads in a single flow before agents begin."
+  },
+  {
+    title: "Live Orchestration",
+    body: "Stream status updates from judge and lawyer agents in real time."
+  },
+  {
+    title: "Traceable Outputs",
+    body: "Keep decisions and next steps visible, searchable, and export-ready."
+  }
+];
+
+const workflow = [
+  "Authenticate and start a case session",
+  "Upload evidence and set instructions",
+  "Watch the agent dialog unfold",
+  "Stop or export the final summary"
+];
+
+export default function App() {
+  return (
+    <div className="page">
+      <header className="hero">
+        <div className="hero__badge">Frontend demo</div>
+        <h1>AI Jurisdiction Frontend</h1>
+        <p>
+          A React + TypeScript starter for the AI Jurisdiction system. Build the
+          client workspace, orchestrate live sessions, and keep every decision in view.
+        </p>
+        <div className="hero__actions">
+          <button className="btn btn--primary" type="button">Start session</button>
+          <button className="btn btn--ghost" type="button">View agent stream</button>
+        </div>
+        <div className="hero__panel">
+          <div>
+            <span className="label">Status</span>
+            <p className="value">Awaiting intake</p>
+          </div>
+          <div>
+            <span className="label">Region</span>
+            <p className="value">Slovakia (SK)</p>
+          </div>
+          <div>
+            <span className="label">Mode</span>
+            <p className="value">Advice</p>
+          </div>
+        </div>
+      </header>
+
+      <section className="grid">
+        {highlights.map((item) => (
+          <article key={item.title} className="card">
+            <h3>{item.title}</h3>
+            <p>{item.body}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="callout">
+        <div>
+          <h2>Workflow snapshot</h2>
+          <p>
+            This demo layout mirrors the future dashboard: intake on the left,
+            streamed dialogue on the right, and actions pinned for clarity.
+          </p>
+          <ul>
+            {workflow.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ul>
+        </div>
+        <div className="callout__panel">
+          <span className="label">Next milestone</span>
+          <h3>Hook up API events</h3>
+          <p>
+            Connect to the orchestration endpoints and map the messages to this
+            layout in the next iteration.
+          </p>
+          <button className="btn btn--accent" type="button">Open API docs</button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/aijurisdictionfronend/src/main.tsx
+++ b/frontend/aijurisdictionfronend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./styles.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/aijurisdictionfronend/src/styles.css
+++ b/frontend/aijurisdictionfronend/src/styles.css
@@ -1,0 +1,225 @@
+@import url("https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;600&family=Space+Grotesk:wght@400;500;600&display=swap");
+
+:root {
+  color-scheme: light;
+  font-family: "Space Grotesk", system-ui, sans-serif;
+  --font-display: "Playfair Display", "Times New Roman", serif;
+  --bg-deep: #0b1220;
+  --bg-surface: #111c33;
+  --bg-soft: #172548;
+  --accent: #36c6c2;
+  --accent-strong: #f4c24f;
+  --text: #f5f7ff;
+  --text-soft: #c7d3f0;
+  --stroke: rgba(255, 255, 255, 0.12);
+  --shadow: 0 24px 60px rgba(6, 10, 20, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background:
+    radial-gradient(circle at top right, rgba(54, 198, 194, 0.2), transparent 40%),
+    radial-gradient(circle at 10% 20%, rgba(244, 194, 79, 0.18), transparent 45%),
+    linear-gradient(160deg, var(--bg-deep), #0f1b36 45%, #0f172a 100%);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+.page {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 72px 24px 96px;
+  display: grid;
+  gap: 48px;
+}
+
+.hero {
+  background: linear-gradient(135deg, rgba(17, 28, 51, 0.9), rgba(15, 23, 42, 0.95));
+  border: 1px solid var(--stroke);
+  border-radius: 28px;
+  padding: 48px;
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 20px;
+  animation: rise 0.6s ease-out both;
+}
+
+.hero__badge {
+  width: fit-content;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(54, 198, 194, 0.15);
+  color: var(--accent);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(2.4rem, 3vw, 3.4rem);
+}
+
+.hero p {
+  margin: 0;
+  color: var(--text-soft);
+  max-width: 640px;
+  line-height: 1.6;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.btn {
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 10px 18px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:focus {
+  outline: 2px solid rgba(54, 198, 194, 0.6);
+  outline-offset: 2px;
+}
+
+.btn--primary {
+  background: var(--accent);
+  color: #08131d;
+  box-shadow: 0 16px 30px rgba(54, 198, 194, 0.3);
+}
+
+.btn--ghost {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.3);
+  color: var(--text);
+}
+
+.btn--accent {
+  background: var(--accent-strong);
+  color: #221a08;
+  width: fit-content;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+}
+
+.hero__panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+  margin-top: 12px;
+}
+
+.label {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(199, 211, 240, 0.7);
+}
+
+.value {
+  margin: 6px 0 0;
+  font-size: 1.1rem;
+}
+
+.grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+}
+
+.card {
+  padding: 24px;
+  border-radius: 20px;
+  border: 1px solid var(--stroke);
+  background: rgba(17, 28, 51, 0.6);
+  backdrop-filter: blur(6px);
+  animation: fadeIn 0.5s ease-out both;
+}
+
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 8px;
+  font-size: 1.2rem;
+}
+
+.card p {
+  margin: 0;
+  color: var(--text-soft);
+  line-height: 1.6;
+}
+
+.callout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+  align-items: center;
+}
+
+.callout ul {
+  padding-left: 18px;
+  margin: 16px 0 0;
+  color: var(--text-soft);
+  line-height: 1.7;
+}
+
+.callout__panel {
+  border-radius: 22px;
+  padding: 28px;
+  background: rgba(244, 194, 79, 0.12);
+  border: 1px solid rgba(244, 194, 79, 0.4);
+  display: grid;
+  gap: 12px;
+}
+
+@keyframes rise {
+  from {
+    transform: translateY(10px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding: 32px;
+  }
+
+  .hero__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .btn {
+    width: 100%;
+  }
+}

--- a/frontend/aijurisdictionfronend/tsconfig.json
+++ b/frontend/aijurisdictionfronend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/frontend/aijurisdictionfronend/tsconfig.node.json
+++ b/frontend/aijurisdictionfronend/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/aijurisdictionfronend/vite.config.ts
+++ b/frontend/aijurisdictionfronend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- add a basic React + TypeScript demo app under frontend/aijurisdictionfronend
- document the frontend demo and add a runnable PowerShell helper
- update AGENTS.md and .gitignore for frontend workflow

## Testing
- not run (frontend scaffold only)