### PR TITLE
Constrain corporate demo video size

### DIFF
--- a/corporate-web/README.md
+++ b/corporate-web/README.md
@@ -32,6 +32,8 @@ The homepage switches the Jurisdigta avatar video per language:
 - `assets/jurisdigta-ge.mp4` (DE)
 - `assets/jurisdigta-en.mp4` (EN)
 
+The video container constrains height to prevent oversized display on large screens.
+
 ## Minimal runnable example
 
 Repo default: `python examples/minimal_demo.py`

--- a/corporate-web/styles.css
+++ b/corporate-web/styles.css
@@ -256,6 +256,8 @@ main {
   padding: 1.5rem;
   box-shadow: var(--shadow);
   border: 1px solid rgba(19, 28, 52, 0.08);
+  max-width: 960px;
+  margin: 0 auto;
 }
 
 .video-shell video {
@@ -263,6 +265,9 @@ main {
   display: block;
   border-radius: 18px;
   background: #000;
+  height: auto;
+  max-height: min(70vh, 560px);
+  object-fit: contain;
 }
 
 @keyframes floatIn {


### PR DESCRIPTION
## Summary\n- constrain demo video height to prevent oversized rendering on large screens\n- center the video shell within the page and document the constraint\n\n## Testing\n- not run (static CSS change)