### PR TITLE
Stabilize corporate demo video sizing

### DIFF
--- a/corporate-web/index.html
+++ b/corporate-web/index.html
@@ -102,6 +102,8 @@
           controls
           playsinline
           preload="metadata"
+          width="960"
+          height="540"
           aria-label="Jurisdigta demo video"
           data-i18n-aria="video_aria"
         >

--- a/corporate-web/styles.css
+++ b/corporate-web/styles.css
@@ -256,17 +256,19 @@ main {
   padding: 1.5rem;
   box-shadow: var(--shadow);
   border: 1px solid rgba(19, 28, 52, 0.08);
-  max-width: 960px;
   margin: 0 auto;
+  display: flex;
+  justify-content: center;
 }
 
 .video-shell video {
   width: 100%;
+  max-width: 960px;
   display: block;
   border-radius: 18px;
   background: #000;
   height: auto;
-  max-height: min(70vh, 560px);
+  max-height: 70vh;
   object-fit: contain;
 }
 


### PR DESCRIPTION
## Summary\n- avoid CSS min() usage and cap video dimensions via max-width/max-height\n- add width/height attributes to ensure a sane default size if CSS is cached or missing\n\n## Testing\n- not run (static HTML/CSS change)