### PR TITLE
Project polling for multiple boards

### DIFF
--- a/.github/automation.yml
+++ b/.github/automation.yml
@@ -1,13 +1,46 @@
 {
-  "owner": "mmaideveloper",
-  "repo": "mmaideveloper/aijurisdictionagents",
-  "project_number": 5,
-  "status_field": "Status",
-  "selection_strategy": "oldest_ready",
-  "labels": {
-    "selected": "auto:selected",
-    "in_review": "auto:in-review",
-    "tested": "auto:tested",
-    "merged": "auto:merged"
-  }
+  "projects": [
+    {
+      "name": "core",
+      "owner": "mmaideveloper",
+      "repo": "mmaideveloper/aijurisdictionagents",
+      "project_number": 5,
+      "status_field": "Status",
+      "selection_strategy": "oldest_ready",
+      "labels": {
+        "selected": "auto:selected",
+        "in_review": "auto:in-review",
+        "tested": "auto:tested",
+        "merged": "auto:merged"
+      }
+    },
+    {
+      "name": "frontend",
+      "owner": "mmaideveloper",
+      "repo": "mmaideveloper/aijurisdictionagents",
+      "project_number": 6,
+      "status_field": "Status",
+      "selection_strategy": "oldest_ready",
+      "labels": {
+        "selected": "auto:selected",
+        "in_review": "auto:in-review",
+        "tested": "auto:tested",
+        "merged": "auto:merged"
+      }
+    },
+    {
+      "name": "project-7",
+      "owner": "mmaideveloper",
+      "repo": "mmaideveloper/aijurisdictionagents",
+      "project_number": 7,
+      "status_field": "Status",
+      "selection_strategy": "oldest_ready",
+      "labels": {
+        "selected": "auto:selected",
+        "in_review": "auto:in-review",
+        "tested": "auto:tested",
+        "merged": "auto:merged"
+      }
+    }
+  ]
 }

--- a/.github/workflows/project_polling.yml
+++ b/.github/workflows/project_polling.yml
@@ -26,9 +26,9 @@ jobs:
           python-version: "3.10"
       - name: Poll project items
         run: |
-          python scripts/project_poll.py --config .github/automation.yml --output runs/automation/latest_snapshot.json
+          python scripts/project_poll.py --config .github/automation.yml --output runs/automation/latest_snapshot
       - name: Upload snapshot
         uses: actions/upload-artifact@v4
         with:
           name: project-polling-snapshot
-          path: runs/automation/latest_snapshot.json
+          path: runs/automation/latest_snapshot

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,8 @@ If you finish change status to In review and send me notice.
 Add a comment to the issue: "Implemented by Codex".
 Use scripts/project_status.ps1 when possible and ensure gh has read:project + project scopes.
 
-Activate the conda environment in `./conda` before running first project command and remember that information, for the next command check if conda has been ran.
+Activate the conda environment in `./conda` before running first project command and remember that information, for the next command check if conda has been ran. Run conda only if task if is implementing
+python code.
 
 If the user asks to close a task:
 - Review the PR and perform a code review.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Requirements:
 Project polling automation (scheduled GitHub Action):
 
 ```bash
-python scripts/project_poll.py --config .github/automation.yml --output runs/automation/latest_snapshot.json
+python scripts/project_poll.py --config .github/automation.yml --output runs/automation/latest_snapshot
 ```
 
 Offline fixture demo:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@
 - LLM Clients: `MockLLMClient` for offline runs, `OpenAIClient` for OpenAI, and `AzureFoundryClient` for Azure OpenAI.
 - Logs include the LLM provider name and client class at startup.
 - Azure Foundry logs auth method plus endpoint, deployment, API version, and temperature on client init.
-- Project Polling: `scripts/project_poll.py` snapshots Project V2 items for scheduled automation.
+- Project Polling: `scripts/project_poll.py` snapshots Project V2 items across configured projects for scheduled automation.
 
 ## Message Schema
 

--- a/docs/AUTOMATION_POLLING.md
+++ b/docs/AUTOMATION_POLLING.md
@@ -7,7 +7,7 @@ This repository uses a scheduled polling workflow to drive Project V2 automation
 
 - File: `.github/workflows/project_polling.yml`
 - Triggers: `schedule` (default: every 15 minutes) and `workflow_dispatch`
-- Purpose: fetch Project V2 items and write a snapshot JSON for downstream automation steps
+- Purpose: fetch Project V2 items and write snapshot JSON files for downstream automation steps
 
 ## Configuration
 
@@ -15,17 +15,36 @@ Config file: `.github/automation.yml` (JSON content, YAML-compatible).
 
 ```json
 {
-  "owner": "mmaideveloper",
-  "repo": "mmaideveloper/aijurisdictionagents",
-  "project_number": 5,
-  "status_field": "Status",
-  "selection_strategy": "oldest_ready",
-  "labels": {
-    "selected": "auto:selected",
-    "in_review": "auto:in-review",
-    "tested": "auto:tested",
-    "merged": "auto:merged"
-  }
+  "projects": [
+    {
+      "name": "core",
+      "owner": "mmaideveloper",
+      "repo": "mmaideveloper/aijurisdictionagents",
+      "project_number": 5,
+      "status_field": "Status",
+      "selection_strategy": "oldest_ready",
+      "labels": {
+        "selected": "auto:selected",
+        "in_review": "auto:in-review",
+        "tested": "auto:tested",
+        "merged": "auto:merged"
+      }
+    },
+    {
+      "name": "frontend",
+      "owner": "mmaideveloper",
+      "repo": "mmaideveloper/aijurisdictionagents",
+      "project_number": 6,
+      "status_field": "Status",
+      "selection_strategy": "oldest_ready",
+      "labels": {
+        "selected": "auto:selected",
+        "in_review": "auto:in-review",
+        "tested": "auto:tested",
+        "merged": "auto:merged"
+      }
+    }
+  ]
 }
 ```
 
@@ -41,8 +60,13 @@ The workflow uses `GH_PROJECT_TOKEN` when set, otherwise falls back to `GITHUB_T
 ## Local usage
 
 ```bash
-python scripts/project_poll.py --config .github/automation.yml --output runs/automation/latest_snapshot.json
+python scripts/project_poll.py --config .github/automation.yml --output runs/automation/latest_snapshot
 ```
+
+For multiple projects, the script writes:
+
+- `runs/automation/latest_snapshot/project_<project_number>.json`
+- `runs/automation/latest_snapshot/summary.json`
 
 Offline fixture run:
 

--- a/examples/project_poll_demo.py
+++ b/examples/project_poll_demo.py
@@ -8,7 +8,7 @@ from pathlib import Path
 def main() -> None:
     script = Path("scripts") / "project_poll.py"
     fixture = Path("examples") / "project_poll_fixture.json"
-    output = Path("runs") / "automation" / "example_snapshot.json"
+    output = Path("runs") / "automation" / "example_snapshot"
 
     result = subprocess.run(
         [
@@ -26,7 +26,7 @@ def main() -> None:
     if result.returncode != 0:
         raise SystemExit(result.returncode)
 
-    print(f"Wrote snapshot to {output}")
+    print(f"Wrote snapshots to {output}")
 
 
 if __name__ == "__main__":

--- a/tests/test_project_poll.py
+++ b/tests/test_project_poll.py
@@ -9,7 +9,7 @@ from pathlib import Path
 def test_project_poll_fixture_snapshot(tmp_path: Path) -> None:
     script = Path("scripts") / "project_poll.py"
     fixture = Path("examples") / "project_poll_fixture.json"
-    output = tmp_path / "snapshot.json"
+    output = tmp_path / "snapshots"
 
     result = subprocess.run(
         [
@@ -28,7 +28,15 @@ def test_project_poll_fixture_snapshot(tmp_path: Path) -> None:
     )
 
     assert result.returncode == 0, result.stderr
-    payload = json.loads(output.read_text(encoding="utf-8"))
-    assert payload["summary"]["total"] == 2
-    assert payload["summary"]["by_status"]["In progress"] == 1
-    assert payload["summary"]["by_status"]["Ready"] == 1
+    summary = json.loads((output / "summary.json").read_text(encoding="utf-8"))
+    assert summary["summary"]["total"] == 6
+    assert summary["summary"]["by_status"]["In progress"] == 3
+    assert summary["summary"]["by_status"]["Ready"] == 3
+
+    for project_number in (5, 6, 7):
+        payload = json.loads(
+            (output / f"project_{project_number}.json").read_text(encoding="utf-8")
+        )
+        assert payload["summary"]["total"] == 2
+        assert payload["summary"]["by_status"]["In progress"] == 1
+        assert payload["summary"]["by_status"]["Ready"] == 1


### PR DESCRIPTION
Implements multi-project polling (projects 5, 6, 7) and updates docs/tests.\n\n- Extend automation config to a projects list\n- Update polling script to emit per-project snapshots + summary\n- Update workflow, docs, and demo\n- Adjust tests for multi-project fixtures\n\nCloses #56