### PR TITLE
Simulated frontend login state

### DIFF
--- a/docs/FRONTEND_DEMO.md
+++ b/docs/FRONTEND_DEMO.md
@@ -17,6 +17,13 @@ npm run dev
 
 Open `http://localhost:5173`.
 
+## Simulated login (frontend-only)
+
+The demo includes an in-memory auth state for UI development. It resets on refresh.
+
+- Email: `admin@admin.com`
+- Password: `admin123`
+
 ## Minimal runnable example
 
 From repo root (PowerShell):

--- a/frontend/aijurisdictionfronend/README.md
+++ b/frontend/aijurisdictionfronend/README.md
@@ -20,6 +20,13 @@ npm run dev
 
 Open `http://localhost:5173`.
 
+## Simulated Login (Frontend-only)
+
+The UI includes an in-memory auth state used for local development. It resets on refresh.
+
+- Email: `admin@admin.com`
+- Password: `admin123`
+
 ## Callback Contract
 
 The frontend expects auth callback requests to hit:

--- a/frontend/aijurisdictionfronend/src/__tests__/mockAuth.test.ts
+++ b/frontend/aijurisdictionfronend/src/__tests__/mockAuth.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { isValidCredentials, MOCK_USER } from "../auth/mockAuth";
+
+describe("mock auth credentials", () => {
+  it("accepts the configured admin credentials", () => {
+    expect(isValidCredentials(MOCK_USER.email, MOCK_USER.password)).toBe(true);
+  });
+
+  it("rejects invalid credentials", () => {
+    expect(isValidCredentials("user@example.com", "badpass")).toBe(false);
+  });
+});

--- a/frontend/aijurisdictionfronend/src/auth/mockAuth.tsx
+++ b/frontend/aijurisdictionfronend/src/auth/mockAuth.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+
+export interface MockUser {
+  email: string;
+  password: string;
+  name: string;
+}
+
+export const MOCK_USER: MockUser = {
+  email: "admin@admin.com",
+  password: "admin123",
+  name: "Admin"
+};
+
+export interface AuthState {
+  isAuthenticated: boolean;
+  user: Omit<MockUser, "password"> | null;
+}
+
+export interface AuthContextValue extends AuthState {
+  signIn: (email: string, password: string) => boolean;
+  signOut: () => void;
+}
+
+export function isValidCredentials(email: string, password: string): boolean {
+  return email === MOCK_USER.email && password === MOCK_USER.password;
+}
+
+const AuthContext = React.createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = React.useState<AuthState>({
+    isAuthenticated: false,
+    user: null
+  });
+
+  const signIn = React.useCallback((email: string, password: string) => {
+    if (!isValidCredentials(email, password)) {
+      setState({ isAuthenticated: false, user: null });
+      return false;
+    }
+
+    setState({
+      isAuthenticated: true,
+      user: {
+        email: MOCK_USER.email,
+        name: MOCK_USER.name
+      }
+    });
+    return true;
+  }, []);
+
+  const signOut = React.useCallback(() => {
+    setState({ isAuthenticated: false, user: null });
+  }, []);
+
+  const value = React.useMemo(
+    () => ({
+      ...state,
+      signIn,
+      signOut
+    }),
+    [state, signIn, signOut]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const context = React.useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider.");
+  }
+  return context;
+}

--- a/frontend/aijurisdictionfronend/src/main.tsx
+++ b/frontend/aijurisdictionfronend/src/main.tsx
@@ -3,15 +3,18 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import { LanguageProvider } from "./components/LanguageProvider";
+import { AuthProvider } from "./auth/mockAuth";
 import "./styles/theme.css";
 import "./styles/app.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <LanguageProvider>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <AuthProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </AuthProvider>
     </LanguageProvider>
   </React.StrictMode>
 );

--- a/frontend/aijurisdictionfronend/src/pages/Auth.tsx
+++ b/frontend/aijurisdictionfronend/src/pages/Auth.tsx
@@ -1,8 +1,33 @@
-﻿import React from "react";
+import React from "react";
 import { useLanguage } from "../components/LanguageProvider";
+import { MOCK_USER, useAuth } from "../auth/mockAuth";
 
 const Auth: React.FC = () => {
   const { t } = useLanguage();
+  const { isAuthenticated, user, signIn, signOut } = useAuth();
+  const [email, setEmail] = React.useState("");
+  const [password, setPassword] = React.useState("");
+  const [message, setMessage] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const handleSignIn = () => {
+    const normalizedEmail = email.trim();
+    const ok = signIn(normalizedEmail, password);
+    if (!ok) {
+      setError("Invalid credentials. Use admin@admin.com / admin123.");
+      setMessage(null);
+      return;
+    }
+    setError(null);
+    setMessage(`Signed in as ${MOCK_USER.email}.`);
+  };
+
+  const handleSignOut = () => {
+    signOut();
+    setMessage("Signed out.");
+    setError(null);
+    setPassword("");
+  };
 
   return (
     <div className="page auth-page">
@@ -14,15 +39,47 @@ const Auth: React.FC = () => {
         <form className="form">
           <label>
             <span>{t("authEmail")}</span>
-            <input type="email" placeholder="name@firm.com" />
+            <input
+              type="email"
+              placeholder="name@firm.com"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+            />
           </label>
           <label>
             <span>{t("authPassword")}</span>
-            <input type="password" placeholder="••••••••" />
+            <input
+              type="password"
+              placeholder="••••••••"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+            />
           </label>
-          <button type="button" className="button primary full">
+          <button
+            type="button"
+            className="button primary full"
+            onClick={handleSignIn}
+          >
             {t("authSignIn")}
           </button>
+          <p className="hint">
+            Simulated login only. Use <strong>{MOCK_USER.email}</strong> /{" "}
+            <strong>{MOCK_USER.password}</strong>.
+          </p>
+          {error ? (
+            <p className="hint" role="alert">
+              {error}
+            </p>
+          ) : null}
+          {message ? <p className="hint">{message}</p> : null}
+          {isAuthenticated ? (
+            <div className="hint">
+              Signed in as <strong>{user?.name ?? MOCK_USER.name}</strong>.{" "}
+              <button type="button" className="button ghost" onClick={handleSignOut}>
+                Reset session
+              </button>
+            </div>
+          ) : null}
         </form>
       </section>
       <section className="auth-aside">


### PR DESCRIPTION
## Summary\n- add in-memory mock auth provider and credentials helper\n- wire auth context into app and update Auth page for sign-in/reset\n- document simulated login credentials\n\n## Testing\n- npm test (frontend/aijurisdictionfronend)