### PR TITLE
Replace signed-in home with workspace layout

### DIFF
--- a/docs/FRONTEND_DEMO.md
+++ b/docs/FRONTEND_DEMO.md
@@ -45,3 +45,7 @@ npm run preview
 - Feature cards for intake, orchestration, and outputs
 - Callout panel for upcoming API integration
 - Navbar reacts to mock auth state: sign-in link when logged out, profile menu with name + email when logged in
+
+## Signed-in homepage
+
+When authenticated, the home page swaps to a 3-column workspace layout: case sidebar, active workspace, and AI configuration panel. On narrow screens the side panels collapse and the center workspace takes full width.

--- a/frontend/aijurisdictionfronend/README.md
+++ b/frontend/aijurisdictionfronend/README.md
@@ -27,6 +27,10 @@ The UI includes an in-memory auth state used for local development. It resets on
 - Email: `admin@admin.com`
 - Password: `admin123`
 
+## Signed-in Homepage
+
+When authenticated, the home page switches to a 3-column workspace layout (case sidebar, active workspace, AI configuration). On smaller screens the side panels collapse for a single-column layout.
+
 ## Callback Contract
 
 The frontend expects auth callback requests to hit:

--- a/frontend/aijurisdictionfronend/src/pages/Home.tsx
+++ b/frontend/aijurisdictionfronend/src/pages/Home.tsx
@@ -1,9 +1,124 @@
 ﻿import React from "react";
 import { Link } from "react-router-dom";
+import { useAuth } from "../auth/mockAuth";
 import { useLanguage } from "../components/LanguageProvider";
 
 const Home: React.FC = () => {
   const { t } = useLanguage();
+  const { isAuthenticated, user } = useAuth();
+
+  if (isAuthenticated) {
+    return (
+      <div className="page workspace-page">
+        <section className="workspace-shell">
+          <header className="workspace-header">
+            <div>
+              <h1>Workspace</h1>
+              <p className="hint">
+                Welcome back, {user?.name ?? "Admin"}. Pick a case to continue your work.
+              </p>
+            </div>
+            <div className="workspace-meta">
+              <span className="pill active">Signed in</span>
+              <span className="pill">3 active matters</span>
+            </div>
+          </header>
+
+          <div className="workspace-grid">
+            <aside className="workspace-panel workspace-panel--left">
+              <div className="panel-card">
+                <div className="panel-card__header">
+                  <h2>Case Sidebar</h2>
+                  <button type="button" className="button ghost small">+ New case</button>
+                </div>
+                <ul className="case-list">
+                  <li className="case-item active">
+                    <div>
+                      <strong>Keystone Holdings Intake</strong>
+                      <span className="case-meta">Due in 2 days</span>
+                    </div>
+                    <span className="case-status">In progress</span>
+                  </li>
+                  <li className="case-item">
+                    <div>
+                      <strong>Atlas Contract Review</strong>
+                      <span className="case-meta">Waiting on docs</span>
+                    </div>
+                    <span className="case-status muted">On hold</span>
+                  </li>
+                  <li className="case-item">
+                    <div>
+                      <strong>Meridian Audit Prep</strong>
+                      <span className="case-meta">Kickoff today</span>
+                    </div>
+                    <span className="case-status">Scheduled</span>
+                  </li>
+                </ul>
+              </div>
+            </aside>
+
+            <section className="workspace-center">
+              <div className="panel-card">
+                <div className="panel-card__header">
+                  <h2>Active Workspace</h2>
+                  <span className="pill">Case 01</span>
+                </div>
+                <div className="workspace-stream">
+                  <article>
+                    <h3>Current objective</h3>
+                    <p>
+                      Consolidate jurisdiction analysis and prepare a briefing memo for counsel
+                      review.
+                    </p>
+                  </article>
+                  <article>
+                    <h3>Recent activity</h3>
+                    <ul className="activity-list">
+                      <li>Drafted timeline summary from uploaded exhibits.</li>
+                      <li>Reviewed contract variance clauses for compliance risk.</li>
+                      <li>Queued agent sync with regional legal guidance.</li>
+                    </ul>
+                  </article>
+                  <article className="workspace-callout">
+                    <h3>Next recommended action</h3>
+                    <p>Schedule a 15-minute voice session with the AI agent to confirm scope.</p>
+                    <button type="button" className="button primary">Start voice session</button>
+                  </article>
+                </div>
+              </div>
+            </section>
+
+            <aside className="workspace-panel workspace-panel--right">
+              <div className="panel-card">
+                <div className="panel-card__header">
+                  <h2>AI Configuration</h2>
+                  <span className="pill">Draft mode</span>
+                </div>
+                <div className="config-list">
+                  <div>
+                    <h4>Primary agent</h4>
+                    <p>Compliance Counsel</p>
+                  </div>
+                  <div>
+                    <h4>Jurisdiction focus</h4>
+                    <p>EU + UK</p>
+                  </div>
+                  <div>
+                    <h4>Output</h4>
+                    <p>Briefing memo + checklist</p>
+                  </div>
+                  <div className="config-actions">
+                    <button type="button" className="button ghost full">Edit settings</button>
+                    <button type="button" className="button primary full">Run evaluation</button>
+                  </div>
+                </div>
+              </div>
+            </aside>
+          </div>
+        </section>
+      </div>
+    );
+  }
 
   return (
     <div className="page">

--- a/frontend/aijurisdictionfronend/src/styles/app.css
+++ b/frontend/aijurisdictionfronend/src/styles/app.css
@@ -167,6 +167,145 @@
   padding-top: 3rem;
 }
 
+.workspace-page {
+  padding-top: 2rem;
+}
+
+.workspace-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.workspace-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.workspace-meta {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.workspace-grid {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr) 280px;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.workspace-center,
+.workspace-panel {
+  min-width: 0;
+}
+
+.panel-card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+  border: 1px solid rgba(31, 27, 22, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.panel-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.button.small {
+  padding: 0.45rem 1rem;
+  font-size: 0.85rem;
+}
+
+.case-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.case-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem 1rem;
+  border-radius: 14px;
+  background: var(--surface-muted);
+  border: 1px solid transparent;
+}
+
+.case-item.active {
+  background: #fff;
+  border-color: var(--accent-soft);
+  box-shadow: 0 12px 24px rgba(31, 27, 22, 0.08);
+}
+
+.case-meta {
+  display: block;
+  color: var(--ink-muted);
+  font-size: 0.85rem;
+  margin-top: 0.3rem;
+}
+
+.case-status {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--accent);
+  background: var(--accent-soft);
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  height: fit-content;
+}
+
+.case-status.muted {
+  color: var(--ink-muted);
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+
+.workspace-stream {
+  display: grid;
+  gap: 1.4rem;
+}
+
+.activity-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.workspace-callout {
+  background: var(--surface-muted);
+  padding: 1.2rem;
+  border-radius: 16px;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.config-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.config-actions {
+  display: grid;
+  gap: 0.6rem;
+  margin-top: 0.4rem;
+}
+
 .page.center {
   align-items: center;
   text-align: center;
@@ -528,6 +667,22 @@ textarea {
   display: flex;
   flex-wrap: wrap;
   gap: 0.6rem;
+}
+
+@media (max-width: 1100px) {
+  .workspace-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .workspace-panel {
+    display: none;
+  }
+}
+
+@media (max-width: 700px) {
+  .workspace-header {
+    align-items: flex-start;
+  }
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary\n- add signed-in 3-column workspace layout on home\n- keep marketing homepage for signed-out users\n- add responsive collapse for side panels\n- document signed-in homepage behavior\n\n## Testing\n- not run (frontend-only layout change)