### PR TITLE
Disable polling/lifecycle workflows and set API deploy default

### DIFF
--- a/.github/workflows/api_build_deploy.yml
+++ b/.github/workflows/api_build_deploy.yml
@@ -15,7 +15,7 @@ on:
       deploy:
         description: "Deploy to Azure Container Apps"
         required: true
-        default: "false"
+        default: "true"
       github_environment:
         description: "GitHub Environment that contains Azure variables"
         required: true

--- a/.github/workflows/lifecycle_implementation_agent.yml
+++ b/.github/workflows/lifecycle_implementation_agent.yml
@@ -1,8 +1,6 @@
 name: lifecycle-implementation-agent
 
 on:
-  schedule:
-    - cron: "*/15 * * * *"
   workflow_dispatch:
     inputs:
       project_owner:
@@ -46,6 +44,7 @@ concurrency:
 
 jobs:
   implement-ready-task:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     env:
       PROJECT_OWNER: ${{ github.event.inputs.project_owner || 'mmaideveloper' }}

--- a/.github/workflows/project_polling.yml
+++ b/.github/workflows/project_polling.yml
@@ -1,8 +1,6 @@
 name: project-polling
 
 on:
-  schedule:
-    - cron: "*/15 * * * *"
   workflow_dispatch:
 
 permissions:
@@ -17,6 +15,7 @@ concurrency:
 
 jobs:
   poll:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}

--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -57,6 +57,9 @@ Required GitHub Environment variables:
 The workflow dispatch input `github_environment` selects which GitHub Environment
 supplies these variables.
 
+For Azure OIDC federation setup (GitHub -> Entra app federated credential for
+`AZURE_CLIENT_ID`), see `infra/README.md` section `GitHub workflow deployment setup (OIDC federation)`.
+
 ## E2E testing recommendation
 
 Because you are familiar with Playwright, use **Playwright API testing** (`APIRequestContext`) for API E2E:

--- a/infra/README.md
+++ b/infra/README.md
@@ -136,6 +136,73 @@ If your `.env` is at the repo root, no extra flag is needed. To use a different 
   -EnvFilePath ".env"
 ```
 
+## GitHub workflow deployment setup (OIDC federation)
+
+The API workflow `.github/workflows/api_build_deploy.yml` logs into Azure using OIDC
+(`azure/login@v2`) and expects `AZURE_CLIENT_ID` to be an Entra application that has
+a federated credential for GitHub.
+
+1. Create an Entra app and service principal:
+
+```powershell
+$SubscriptionId = "<SUBSCRIPTION_ID>"
+$ResourceGroupName = "<RESOURCE_GROUP_NAME>"
+$AcrName = "<ACR_NAME>"
+$RepoOwner = "<GITHUB_OWNER>"
+$RepoName = "<GITHUB_REPO>"
+$GithubEnvironment = "dev"   # must match workflow input github_environment
+
+az account set --subscription $SubscriptionId
+$TenantId = az account show --query tenantId -o tsv
+$ClientId = az ad app create --display-name "aijurisdiction-api-deploy" --query appId -o tsv
+az ad sp create --id $ClientId
+```
+
+2. Grant required Azure roles:
+
+```powershell
+az role assignment create `
+  --assignee $ClientId `
+  --role "Contributor" `
+  --scope "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName"
+
+az role assignment create `
+  --assignee $ClientId `
+  --role "AcrPush" `
+  --scope "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.ContainerRegistry/registries/$AcrName"
+```
+
+3. Create federated credential for GitHub Environment:
+
+```powershell
+$federatedCredential = @{
+  name        = "github-${RepoOwner}-${RepoName}-${GithubEnvironment}"
+  issuer      = "https://token.actions.githubusercontent.com"
+  subject     = "repo:${RepoOwner}/${RepoName}:environment:${GithubEnvironment}"
+  description = "OIDC federation for API deployment workflow"
+  audiences   = @("api://AzureADTokenExchange")
+} | ConvertTo-Json -Depth 5
+
+$tempFile = Join-Path $env:TEMP "github-federated-credential.json"
+$federatedCredential | Out-File -FilePath $tempFile -Encoding utf8
+az ad app federated-credential create --id $ClientId --parameters $tempFile
+```
+
+4. Configure GitHub Environment variables (Settings -> Environments -> `<environment>` -> Variables):
+
+- `AZURE_CLIENT_ID` = `$ClientId`
+- `AZURE_TENANT_ID` = `$TenantId`
+- `AZURE_SUBSCRIPTION_ID` = `<SUBSCRIPTION_ID>`
+- `AZURE_RESOURCE_GROUP` = `<RESOURCE_GROUP_NAME>`
+- `AZURE_CONTAINERAPPS_ENVIRONMENT` = `<CONTAINERAPPS_ENV_NAME>`
+- `AZURE_CONTAINER_APP_NAME` = `<CONTAINER_APP_NAME>`
+- `AZURE_CONTAINER_REGISTRY` = `<ACR_NAME>`
+
+5. Run the workflow:
+
+- Workflow: `API Build and Deploy`
+- Inputs: `deploy=true`, `github_environment=<environment>`
+
 ## Files
 
 - `infra/bicep/main.bicep`: Azure resources definition


### PR DESCRIPTION
## Summary
- disable `project_polling` workflow execution
- disable `lifecycle_implementation_agent` workflow execution
- set `api_build_deploy` workflow dispatch input `deploy` default to `true`
- add OIDC federation setup documentation for GitHub Environment -> Azure login in infra and API docs

## Notes
- Workflows remain in repo for later re-enable; execution is currently blocked via job-level conditions and schedule trigger removal for these two automation workflows.