### PR TITLE
Add note: automation workflows removed due to API key/account requirements

### DIFF
--- a/LIFECYCLE_AUTOMATION.md
+++ b/LIFECYCLE_AUTOMATION.md
@@ -3,6 +3,10 @@
 GitHub Actions lifecycle workflow automation is removed from this repository.
 Use local scripts and project automation helpers for lifecycle operations.
 
+Reason:
+- Codex automation requires `OPENAI_KEY`.
+- It also requires a separate paid OpenAI API account (a ChatGPT-only paid account is not sufficient).
+
 ## Local flow
 
 1. Select task in `Ready`.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ python examples/project_poll_demo.py
 
 For details, see `docs/AUTOMATION_POLLING.md`.
 
+Note:
+- Automatic project polling/pooling and lifecycle GitHub workflows were removed.
+- Reason: Codex automation requires `OPENAI_KEY` and a separate paid OpenAI API account (ChatGPT subscription alone is not sufficient).
+
 Lifecycle automation demo (issue #69 MVP):
 
 ```bash

--- a/docs/AUTOMATION_POLLING.md
+++ b/docs/AUTOMATION_POLLING.md
@@ -2,6 +2,9 @@
 
 This repository uses local polling scripts to drive Project V2 automation.
 
+Automatic polling/pooling GitHub workflow execution is disabled/removed.
+Reason: Codex-based automation requires `OPENAI_KEY` and a separate paid OpenAI API account.
+
 ## Local automation
 
 - Purpose: fetch Project V2 items and write snapshot JSON files, then move Ready tasks with PRs to In review.


### PR DESCRIPTION
## Summary
- add explicit notice that automatic polling/pooling and lifecycle GitHub workflows were removed
- document the reason: Codex automation requires `OPENAI_KEY` and a separate paid OpenAI API account
- clarify ChatGPT-only paid account is not sufficient