### PR TITLE
feat(frontend): communication mode switcher for workspace (#83)

### DIFF
--- a/docs/FRONTEND_DEMO.md
+++ b/docs/FRONTEND_DEMO.md
@@ -66,6 +66,8 @@ Case sidebar behavior:
 - On the authenticated home view, the layout is a full-height flex row: sidebar on the left, navbar + content on the right.
 - The center workspace starts with a welcome state prompting the user to start a new case or continue by selecting a case in the sidebar.
 - The AI configuration panel includes a role selector with intent hints and highlights the active perspective.
+- The AI configuration panel now includes a communication mode segmented control (`Chat`, `Voice`, `Video`).
+- Communication mode changes are stored per case and switch the center workspace view without dropping case context.
 
 ## Case state model
 
@@ -74,5 +76,6 @@ Each case includes:
 - `id`, `title`, `description`, `status`, `createdAt`
 - `interactionHistory` entries with timestamps, actors, and messages
 - `selectedRole` and `selectedMode` stored per case
+- `selectedCommunicationMode` (`Chat`/`Voice`/`Video`) stored per case
 
 The active case is available globally via the `CaseProvider` context.

--- a/frontend/aijurisdictionfronend/src/pages/Home.tsx
+++ b/frontend/aijurisdictionfronend/src/pages/Home.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { FiMessageSquare, FiMic, FiVideo } from "react-icons/fi";
 import { useAuth } from "../auth/mockAuth";
 import { useLanguage } from "../components/LanguageProvider";
 import WorkspaceWelcome from "../components/WorkspaceWelcome";
-import { CaseRole, useCases } from "../state/CaseProvider";
+import { CaseCommunicationMode, CaseRole, useCases } from "../state/CaseProvider";
 
 const Home: React.FC = () => {
   const { t } = useLanguage();
@@ -15,7 +16,8 @@ const Home: React.FC = () => {
     continueRequested,
     setContinueRequested,
     addInteraction,
-    setCaseRole
+    setCaseRole,
+    setCaseCommunicationMode
   } = useCases();
   const [draftMessage, setDraftMessage] = React.useState("");
   const roleOptions = React.useMemo(
@@ -34,6 +36,29 @@ const Home: React.FC = () => {
         role: "Opposing Counsel" as CaseRole,
         label: t("workspaceOpposingTitle"),
         intent: t("roleIntentOpposing")
+      }
+    ],
+    [t]
+  );
+  const communicationModeOptions = React.useMemo(
+    () => [
+      {
+        mode: "Chat" as CaseCommunicationMode,
+        label: t("commsChat"),
+        icon: <FiMessageSquare aria-hidden="true" />,
+        actionLabel: t("commsChatAction")
+      },
+      {
+        mode: "Voice" as CaseCommunicationMode,
+        label: t("commsVoice"),
+        icon: <FiMic aria-hidden="true" />,
+        actionLabel: t("commsVoiceAction")
+      },
+      {
+        mode: "Video" as CaseCommunicationMode,
+        label: t("commsVideo"),
+        icon: <FiVideo aria-hidden="true" />,
+        actionLabel: t("commsVideoAction")
       }
     ],
     [t]
@@ -91,40 +116,66 @@ const Home: React.FC = () => {
                       </div>
                     </div>
                     <div className="workspace-stream">
-                      <div className="workspace-chat">
-                        <div className="workspace-chat__history">
-                          {activeCase?.interactionHistory.map((item) => {
-                            const isUser = item.actor === "You";
-                            return (
-                              <article
-                                key={item.id}
-                                className={`chat-message${isUser ? " chat-message--user" : ""}`}
-                              >
-                                <div className="chat-message__meta">
-                                  <strong>{item.actor}</strong>
-                                  <span>{new Date(item.createdAt).toLocaleString()}</span>
-                                </div>
-                                <p>{item.message}</p>
-                              </article>
-                            );
-                          })}
+                      {activeCase?.selectedCommunicationMode === "Chat" ? (
+                        <div className="workspace-chat">
+                          <div className="workspace-chat__history">
+                            {activeCase?.interactionHistory.map((item) => {
+                              const isUser = item.actor === "You";
+                              return (
+                                <article
+                                  key={item.id}
+                                  className={`chat-message${isUser ? " chat-message--user" : ""}`}
+                                >
+                                  <div className="chat-message__meta">
+                                    <strong>{item.actor}</strong>
+                                    <span>{new Date(item.createdAt).toLocaleString()}</span>
+                                  </div>
+                                  <p>{item.message}</p>
+                                </article>
+                              );
+                            })}
+                          </div>
+                          <form className="workspace-chat__composer" onSubmit={handleSendMessage}>
+                            <input
+                              type="text"
+                              value={draftMessage}
+                              onChange={(event) => setDraftMessage(event.target.value)}
+                              placeholder="Type your message..."
+                            />
+                            <button type="submit" className="button primary">
+                              Send
+                            </button>
+                          </form>
                         </div>
-                        <form className="workspace-chat__composer" onSubmit={handleSendMessage}>
-                          <input
-                            type="text"
-                            value={draftMessage}
-                            onChange={(event) => setDraftMessage(event.target.value)}
-                            placeholder="Type your message..."
-                          />
-                          <button type="submit" className="button primary">
-                            Send
+                      ) : (
+                        <article className="workspace-mode-card">
+                          <h3>
+                            {activeCase?.selectedCommunicationMode === "Voice"
+                              ? t("commsVoice")
+                              : t("commsVideo")}
+                          </h3>
+                          <p>
+                            {activeCase?.selectedCommunicationMode === "Voice"
+                              ? t("commsVoiceBody")
+                              : t("commsVideoBody")}
+                          </p>
+                          <button type="button" className="button primary">
+                            {activeCase?.selectedCommunicationMode === "Voice"
+                              ? t("commsVoiceAction")
+                              : t("commsVideoAction")}
                           </button>
-                        </form>
-                      </div>
+                        </article>
+                      )}
                       <article className="workspace-callout">
                         <h3>Next recommended action</h3>
                         <p>{activeCase?.workspace.nextAction}</p>
-                        <button type="button" className="button primary">Start voice session</button>
+                        <button type="button" className="button primary">
+                          {
+                            communicationModeOptions.find(
+                              (option) => option.mode === activeCase?.selectedCommunicationMode
+                            )?.actionLabel
+                          }
+                        </button>
                       </article>
                     </div>
                   </>
@@ -138,6 +189,32 @@ const Home: React.FC = () => {
                   <h2>Configurations</h2>
                 </div>
                 <div className="config-list">
+                  <fieldset className="role-selector" disabled={!activeCase}>
+                    <legend>{t("commsTitle")}</legend>
+                    <p className="hint">{t("commsSubtitle")}</p>
+                    <div className="segment-control" role="radiogroup">
+                      {communicationModeOptions.map((option) => {
+                        const isActive = activeCase?.selectedCommunicationMode === option.mode;
+                        return (
+                          <button
+                            key={option.mode}
+                            type="button"
+                            className={`segment-control__option${isActive ? " is-active" : ""}`}
+                            aria-pressed={isActive}
+                            aria-label={option.label}
+                            title={option.label}
+                            onClick={() => {
+                              if (activeCase) {
+                                setCaseCommunicationMode(activeCase.id, option.mode);
+                              }
+                            }}
+                          >
+                            <span className="segment-control__icon">{option.icon}</span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </fieldset>
                   <fieldset className="role-selector" disabled={!activeCase}>
                     <legend>{t("roleSelectorTitle")}</legend>
                     <p className="hint">{t("roleSelectorHint")}</p>

--- a/frontend/aijurisdictionfronend/src/state/CaseProvider.tsx
+++ b/frontend/aijurisdictionfronend/src/state/CaseProvider.tsx
@@ -3,6 +3,7 @@ import React from "react";
 export type CaseStatus = "In progress" | "On hold" | "Scheduled" | "Completed";
 export type CaseMode = "Draft" | "Review" | "Live" | "Archive";
 export type CaseRole = "AI Lawyer" | "AI Judge" | "Opposing Counsel";
+export type CaseCommunicationMode = "Chat" | "Voice" | "Video";
 
 export type CaseInteraction = {
   id: string;
@@ -28,6 +29,7 @@ export type CaseRecord = {
   interactionHistory: CaseInteraction[];
   selectedRole: CaseRole;
   selectedMode: CaseMode;
+  selectedCommunicationMode: CaseCommunicationMode;
   workspace: CaseWorkspace;
 };
 
@@ -45,6 +47,7 @@ type CaseContextValue = {
   updateCase: (caseId: string, update: Partial<CaseRecord>) => void;
   setCaseRole: (caseId: string, role: CaseRole) => void;
   setCaseMode: (caseId: string, mode: CaseMode) => void;
+  setCaseCommunicationMode: (caseId: string, mode: CaseCommunicationMode) => void;
 };
 
 const CaseContext = React.createContext<CaseContextValue | undefined>(undefined);
@@ -78,6 +81,7 @@ const initialCases: CaseRecord[] = [
     ],
     selectedRole: "AI Lawyer",
     selectedMode: "Draft",
+    selectedCommunicationMode: "Chat",
     workspace: {
       meta: "Due in 2 days",
       objective: "Consolidate jurisdiction analysis and prepare a briefing memo for counsel review.",
@@ -114,6 +118,7 @@ const initialCases: CaseRecord[] = [
     ],
     selectedRole: "AI Judge",
     selectedMode: "Review",
+    selectedCommunicationMode: "Voice",
     workspace: {
       meta: "Waiting on docs",
       objective: "Gather missing vendor exhibits and align on scope with procurement leadership.",
@@ -150,6 +155,7 @@ const initialCases: CaseRecord[] = [
     ],
     selectedRole: "Opposing Counsel",
     selectedMode: "Live",
+    selectedCommunicationMode: "Video",
     workspace: {
       meta: "Kickoff today",
       objective: "Align audit prep checklist and confirm timeline with internal teams.",
@@ -186,6 +192,7 @@ const initialCases: CaseRecord[] = [
     ],
     selectedRole: "AI Lawyer",
     selectedMode: "Archive",
+    selectedCommunicationMode: "Chat",
     workspace: {
       meta: "Closed last week",
       objective: "Finalize arbitration summary and archive case documentation.",
@@ -221,6 +228,7 @@ const buildNewCase = (index: number): CaseRecord => {
     ],
     selectedRole: "AI Lawyer",
     selectedMode: "Draft",
+    selectedCommunicationMode: "Chat",
     workspace: {
       meta: "Just created",
       objective: "Define scope, assign roles, and request initial documents.",
@@ -294,6 +302,13 @@ export const CaseProvider: React.FC<{ children: React.ReactNode }> = ({ children
     updateCase(caseId, { selectedMode: mode });
   }, [updateCase]);
 
+  const setCaseCommunicationMode = React.useCallback(
+    (caseId: string, mode: CaseCommunicationMode) => {
+      updateCase(caseId, { selectedCommunicationMode: mode });
+    },
+    [updateCase]
+  );
+
   const value = React.useMemo(
     () => ({
       cases,
@@ -308,7 +323,8 @@ export const CaseProvider: React.FC<{ children: React.ReactNode }> = ({ children
       addInteraction,
       updateCase,
       setCaseRole,
-      setCaseMode
+      setCaseMode,
+      setCaseCommunicationMode
     }),
     [
       cases,
@@ -323,7 +339,8 @@ export const CaseProvider: React.FC<{ children: React.ReactNode }> = ({ children
       addInteraction,
       updateCase,
       setCaseRole,
-      setCaseMode
+      setCaseMode,
+      setCaseCommunicationMode
     ]
   );
 

--- a/frontend/aijurisdictionfronend/src/styles/app.css
+++ b/frontend/aijurisdictionfronend/src/styles/app.css
@@ -481,6 +481,44 @@
   gap: 1rem;
 }
 
+.segment-control {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.4rem;
+  padding: 0.3rem;
+  border-radius: 12px;
+  background: var(--surface-muted);
+}
+
+.segment-control__option {
+  border: 1px solid transparent;
+  border-radius: 10px;
+  padding: 0.55rem 0.4rem;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.segment-control__option:hover {
+  border-color: rgba(31, 27, 22, 0.14);
+}
+
+.segment-control__option.is-active {
+  background: var(--surface);
+  border-color: rgba(31, 27, 22, 0.12);
+  box-shadow: 0 8px 18px rgba(31, 27, 22, 0.12);
+}
+
+.segment-control__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+}
+
 .role-selector {
   border: 1px solid var(--border);
   border-radius: 16px;
@@ -1093,6 +1131,14 @@ textarea {
 .workspace-chat {
   display: grid;
   gap: 1.2rem;
+}
+
+.workspace-mode-card {
+  background: var(--surface-muted);
+  border-radius: 16px;
+  padding: 1.2rem;
+  display: grid;
+  gap: 0.9rem;
 }
 
 .workspace-chat__history {


### PR DESCRIPTION
## Summary\n- add per-case communication mode state (Chat/Voice/Video)\n- add segmented selector in workspace configuration panel\n- render center workspace conditionally by selected communication mode\n- keep case context intact while switching modes\n- update frontend demo documentation\n\n## Validation\n- npm run build\n- npm run test\n- npm run lint (fails due existing repo-wide browser-global eslint config issues)\n\nCloses #83