### PR TITLE
feat(api): expose API and core versions for frontend

### DIFF
--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -38,6 +38,30 @@ docker compose up --build
 - `GET /health`
 - `GET /version`
 
+`GET /version` response includes:
+- `api_version`: API package version (`api/aijuristiction-api/pyproject.toml`).
+- `core_version`: core system version from installed `aijurisdictionagents` package or local `src/aijurisdictionagents/__init__.py` during monorepo development.
+
+Example:
+
+```json
+{
+  "service": "aijuristiction-api",
+  "version": "0.1.0",
+  "api_version": "0.1.0",
+  "core_version": "0.1.0"
+}
+```
+
+## Version bump workflow
+
+When API code changes:
+1. Bump `version` in `api/aijuristiction-api/pyproject.toml`.
+
+When core (`/src`) code changes:
+1. Bump `__version__` in `src/aijurisdictionagents/__init__.py`.
+2. Bump `[project].version` in root `pyproject.toml`.
+
 ## Swagger and authentication
 
 - Swagger UI (local): `http://localhost:8080/docs`

--- a/api/aijuristiction-api/app/main.py
+++ b/api/aijuristiction-api/app/main.py
@@ -9,10 +9,13 @@ from fastapi.responses import JSONResponse
 
 from app.chat.api import router as chat_router
 from app.telemetry import configure_telemetry
+from app.versioning import get_api_version, get_core_version
+
+API_VERSION = get_api_version()
 
 app = FastAPI(
     title="AI Juristiction API",
-    version="0.1.0",
+    version=API_VERSION,
     description=(
         "API for AI Juristiction services. "
         "Chat endpoints require `x-api-key` header."
@@ -52,4 +55,11 @@ def health() -> JSONResponse:
 
 @app.get("/version")
 def version() -> JSONResponse:
-    return JSONResponse({"service": "aijuristiction-api", "version": app.version})
+    return JSONResponse(
+        {
+            "service": "aijuristiction-api",
+            "version": app.version,
+            "api_version": app.version,
+            "core_version": get_core_version(),
+        }
+    )

--- a/api/aijuristiction-api/app/versioning.py
+++ b/api/aijuristiction-api/app/versioning.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import re
+from importlib.metadata import PackageNotFoundError, version as package_version
+from pathlib import Path
+
+API_PACKAGE_NAME = "aijuristiction-api"
+CORE_PACKAGE_NAME = "aijurisdictionagents"
+UNKNOWN_VERSION = "unknown"
+
+
+def get_api_version() -> str:
+    installed = _get_installed_package_version(API_PACKAGE_NAME)
+    if installed != UNKNOWN_VERSION:
+        return installed
+
+    source_version = _get_api_project_version()
+    if source_version is not None:
+        return source_version
+    return UNKNOWN_VERSION
+
+
+def get_core_version() -> str:
+    installed = _get_installed_package_version(CORE_PACKAGE_NAME)
+    if installed != UNKNOWN_VERSION:
+        return installed
+
+    source_version = _get_core_source_version()
+    if source_version is not None:
+        return source_version
+    return UNKNOWN_VERSION
+
+
+def _get_installed_package_version(package_name: str) -> str:
+    try:
+        return package_version(package_name)
+    except PackageNotFoundError:
+        return UNKNOWN_VERSION
+
+
+def _get_core_source_version() -> str | None:
+    init_file = (
+        Path(__file__).resolve().parents[3] / "src" / "aijurisdictionagents" / "__init__.py"
+    )
+    if not init_file.exists():
+        return None
+
+    content = init_file.read_text(encoding="utf-8")
+    match = re.search(r'__version__\s*=\s*"([^"]+)"', content)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def _get_api_project_version() -> str | None:
+    pyproject_file = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    if not pyproject_file.exists():
+        return None
+
+    content = pyproject_file.read_text(encoding="utf-8")
+    match = re.search(r'(?m)^version\s*=\s*"([^"]+)"\s*$', content)
+    if match is None:
+        return None
+    return match.group(1)

--- a/api/aijuristiction-api/tests/test_health.py
+++ b/api/aijuristiction-api/tests/test_health.py
@@ -15,7 +15,11 @@ def test_health_endpoint() -> None:
 def test_version_endpoint() -> None:
     response = client.get("/version")
     assert response.status_code == 200
-    assert response.json()["service"] == "aijuristiction-api"
+    payload = response.json()
+    assert payload["service"] == "aijuristiction-api"
+    assert payload["version"] == payload["api_version"]
+    assert payload["api_version"] != "unknown"
+    assert isinstance(payload["core_version"], str)
 
 
 def test_swagger_docs_available() -> None:

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -23,3 +23,5 @@ if __name__ == "__main__":
     version = get_json("http://localhost:8080/version")
     print("health:", health)
     print("version:", version)
+    print("api_version:", version.get("api_version"))
+    print("core_version:", version.get("core_version"))


### PR DESCRIPTION
## Summary
- add version resolver utility for API and core package versions
- extend GET /version to return pi_version and core_version (while keeping ersion for compatibility)
- update API tests, README docs, and minimal demo output

## Validation
- pytest could not be executed in this environment due to missing astapi dependency in active interpreter