### PR TITLE
fix(core): robust Azure auth env handling for CLI run

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Or using `environment.yml`:
 ```bash
 conda env create -f environment.yml
 conda activate aijurisdictionagents
+pip install -e ".[dev]"
 ```
 
 ## Run the demo
@@ -120,7 +121,17 @@ For a complete execution matrix (all CLI options and both discussion types), see
 Put documents in `data/` and run (country required):
 
 ```bash
-python -m aijurisdictionagents --country SK --data-dir data --instruction "We believe the contract was breached due to late delivery."
+python -m aijurisdictionagents --country SK --data-dir "data/case_prenajom" --instruction "Priprav mi zmluvu na prenajom bytu." --discussion-type advice
+```
+
+Windows note: if `python` is not available in PATH, use one of:
+
+```powershell
+py -m aijurisdictionagents --country SK --data-dir "data/case_prenajom" --instruction "Priprav mi zmluvu na prenajom bytu." --discussion-type advice
+```
+
+```powershell
+.\.conda\python.exe -m aijurisdictionagents --country SK --data-dir "data/case_prenajom" --instruction "Priprav mi zmluvu na prenajom bytu." --discussion-type advice
 ```
 
 To run without documents, omit `--data-dir` (it defaults to none).

--- a/src/aijurisdictionagents/llm/azure_foundry_client.py
+++ b/src/aijurisdictionagents/llm/azure_foundry_client.py
@@ -76,7 +76,7 @@ def load_azure_foundry_config_from_env() -> AzureFoundryConfig:
     )
     temperature = float(os.getenv("OPENAI_TEMPERATURE", "0.2"))
     api_key = os.getenv("AZURE_OPENAI_API_KEY", "").strip() or None
-    azure_ad_token = os.getenv("AZURE_OPENAI_AD_TOKEN", "").strip() or None
+    azure_ad_token = _optional_env("AZURE_OPENAI_AD_TOKEN")
 
     if not endpoint:
         raise ValueError("AZURE_OPENAI_ENDPOINT is required for LLM_PROVIDER=azurefoundry.")
@@ -105,6 +105,19 @@ def load_azure_foundry_config_from_env() -> AzureFoundryConfig:
         api_key=api_key,
         azure_ad_token=azure_ad_token,
     )
+
+
+def _optional_env(name: str) -> str | None:
+    value = os.getenv(name)
+    if value is None:
+        return None
+
+    normalized = value.strip()
+    if not normalized:
+        # Remove empty values so downstream SDK env fallbacks do not treat them as credentials.
+        os.environ.pop(name, None)
+        return None
+    return normalized
 
 
 def _render_documents(documents: Iterable[Document], max_chars: int = 4000) -> str:

--- a/tests/test_azure_foundry_client.py
+++ b/tests/test_azure_foundry_client.py
@@ -1,0 +1,16 @@
+import os
+
+from aijurisdictionagents.llm.azure_foundry_client import load_azure_foundry_config_from_env
+
+
+def test_load_azure_foundry_config_ignores_blank_ad_token(monkeypatch) -> None:
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com/")
+    monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4o-mini")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("AZURE_OPENAI_AD_TOKEN", "   ")
+
+    config = load_azure_foundry_config_from_env()
+
+    assert config.api_key == "test-key"
+    assert config.azure_ad_token is None
+    assert os.getenv("AZURE_OPENAI_AD_TOKEN") is None


### PR DESCRIPTION
## Summary
- sanitize optional AZURE_OPENAI_AD_TOKEN from environment when it is blank
- prevent SDK fallback from using an empty bearer token while API-key auth is configured
- add regression test for blank AD token handling
- update README setup/run docs for editable install and Windows interpreter usage

## Validation
- ./.conda/python.exe -m pytest tests/test_azure_foundry_client.py -q