### PR TITLE
feat(simulator + api): end-to-end chat streaming with document upload and JSON/PDF exports

### DIFF
--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -62,6 +62,10 @@ When core (`/src`) code changes:
 1. Bump `__version__` in `src/aijurisdictionagents/__init__.py`.
 2. Bump `[project].version` in root `pyproject.toml`.
 
+When chat simulator code changes:
+1. Bump `version` in `api/chat-simulator-app/pyproject.toml`.
+2. Bump `version` in `api/chat-simulator-app/app/main.py`.
+
 ## Swagger and authentication
 
 - Swagger UI (local): `http://localhost:8080/docs`
@@ -169,3 +173,15 @@ New endpoints:
 - `POST /v1/chat/sessions`
 - `POST /v1/chat/messages`
 - `GET /v1/chat/sessions/{session_id}/messages`
+- `POST /v1/chat/sessions/{session_id}/stream` (SSE streaming from core orchestrator)
+- `GET /v1/chat/sessions/{session_id}/result`
+- `GET /v1/chat/sessions/{session_id}/export?format=json|pdf`
+
+
+## Minimal runnable example (streaming API + core)
+
+Start API first, then run:
+
+```bash
+python examples/api_streaming_demo.py
+```

--- a/api/aijuristiction-api/app/chat/api.py
+++ b/api/aijuristiction-api/app/chat/api.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
-from typing import List, Optional
+import json
+from collections import deque
+from queue import Queue
+from threading import Thread
+from typing import List, Literal, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import Response, StreamingResponse
+from pydantic import BaseModel, Field
 
-from app.chat.models import Message, MessageRole, Session
+from app.chat.core_runtime import core_message_role, run_orchestration
+from app.chat.models import Message, MessageRole, Session, SessionResult, SessionState
 from app.chat.repository import InMemoryChatRepository
 from app.security import require_api_key
+
+from aijurisdictionagents.schemas import Document as CoreDocument
+from aijurisdictionagents.schemas import Message as CoreMessage
 
 router = APIRouter(prefix="/v1/chat", tags=["chat"], dependencies=[Depends(require_api_key)])
 _repository = InMemoryChatRepository()
@@ -16,6 +25,9 @@ _repository = InMemoryChatRepository()
 
 class CreateSessionRequest(BaseModel):
     user_id: Optional[UUID] = None
+    country: str = "SK"
+    language: str | None = None
+    discussion_type: Literal["advice", "court"] = "advice"
 
 
 class CreateMessageRequest(BaseModel):
@@ -24,9 +36,28 @@ class CreateMessageRequest(BaseModel):
     content: str
 
 
+class InputDocument(BaseModel):
+    doc_id: str = Field(default="doc")
+    path: str
+    content: str
+
+
+class StartSessionStreamRequest(BaseModel):
+    instruction: str
+    documents: List[InputDocument] = Field(default_factory=list)
+    question_timeout_seconds: float = 300
+    max_discussion_minutes: float = 15
+    user_replies: List[str] = Field(default_factory=list)
+
+
 @router.post("/sessions", response_model=Session)
 def create_session(payload: CreateSessionRequest) -> Session:
-    session = Session(user_id=payload.user_id)
+    session = Session(
+        user_id=payload.user_id,
+        country=payload.country,
+        language=payload.language,
+        discussion_type=payload.discussion_type,
+    )
     return _repository.create_session(session)
 
 
@@ -45,3 +76,158 @@ def list_session_messages(session_id: UUID) -> List[Message]:
     if _repository.get_session(session_id) is None:
         raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
     return _repository.list_messages(session_id)
+
+
+@router.post("/sessions/{session_id}/stream")
+def stream_session(session_id: UUID, payload: StartSessionStreamRequest) -> StreamingResponse:
+    session = _repository.get_session(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
+    if session.state == SessionState.COMPLETED:
+        raise HTTPException(status_code=409, detail="Session already completed")
+
+    event_queue: Queue[tuple[str, dict[str, object]] | None] = Queue()
+    replies = deque(payload.user_replies)
+
+    def user_response_provider(_question: str, _timeout: float) -> str | None:
+        if replies:
+            return replies.popleft()
+        return None
+
+    def message_callback(core_message: CoreMessage) -> None:
+        persisted = _repository.add_message(
+            Message(
+                session_id=session_id,
+                role=MessageRole(core_message_role(core_message.role)),
+                content=core_message.content,
+                agent_name=core_message.agent_name,
+            )
+        )
+        event_queue.put(
+            (
+                "message",
+                {
+                    "id": str(persisted.id),
+                    "session_id": str(session_id),
+                    "role": persisted.role.value,
+                    "agent_name": persisted.agent_name,
+                    "content": persisted.content,
+                    "created_at": persisted.created_at.isoformat(),
+                },
+            )
+        )
+
+    def worker() -> None:
+        try:
+            docs = [
+                CoreDocument(doc_id=d.doc_id, path=d.path, content=d.content)
+                for d in payload.documents
+            ]
+            result = run_orchestration(
+                session=session,
+                instruction=payload.instruction,
+                documents=docs,
+                question_timeout_seconds=payload.question_timeout_seconds,
+                max_discussion_minutes=payload.max_discussion_minutes,
+                user_response_provider=user_response_provider,
+                message_callback=message_callback,
+            )
+            session_result = SessionResult(
+                final_recommendation=result.final_recommendation,
+                judge_rationale=result.judge_rationale,
+                citations=[{"filename": c.filename, "snippet": c.snippet} for c in result.citations],
+                metadata={"message_count": len(result.messages)},
+            )
+            _repository.set_result(session_id, session_result)
+            event_queue.put(("result", session_result.model_dump(mode="json")))
+            event_queue.put(("done", {"session_id": str(session_id)}))
+        except Exception as exc:  # noqa: BLE001
+            _repository.mark_failed(session_id)
+            event_queue.put(("error", {"message": str(exc)}))
+        finally:
+            event_queue.put(None)
+
+    Thread(target=worker, daemon=True).start()
+
+    def stream() -> str:
+        while True:
+            item = event_queue.get()
+            if item is None:
+                break
+            event_name, body = item
+            yield f"event: {event_name}\ndata: {json.dumps(body)}\n\n"
+
+    return StreamingResponse(stream(), media_type="text/event-stream")
+
+
+@router.get("/sessions/{session_id}/result", response_model=SessionResult)
+def get_session_result(session_id: UUID) -> SessionResult:
+    result = _repository.get_result(session_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"Result for session {session_id} not found")
+    return result
+
+
+@router.get("/sessions/{session_id}/export")
+def export_session_result(session_id: UUID, format: Literal["json", "pdf"] = Query("json")) -> Response:
+    result = _repository.get_result(session_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"Result for session {session_id} not found")
+
+    if format == "json":
+        body = result.model_dump_json(indent=2)
+        return Response(
+            content=body,
+            media_type="application/json",
+            headers={"Content-Disposition": f'attachment; filename="session-{session_id}.json"'},
+        )
+
+    pdf_content = _build_simple_pdf(
+        title=f"Session {session_id}",
+        lines=[
+            "AI Jurisdiction Session Result",
+            "",
+            f"Final recommendation: {result.final_recommendation}",
+            f"Judge rationale: {result.judge_rationale}",
+        ],
+    )
+    return Response(
+        content=pdf_content,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="session-{session_id}.pdf"'},
+    )
+
+
+def _build_simple_pdf(title: str, lines: List[str]) -> bytes:
+    escaped_lines = [line.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)") for line in lines]
+    text_lines = [f"({title}) Tj", "T*", "(----------------) Tj", "T*"]
+    for line in escaped_lines:
+        text_lines.append(f"({line}) Tj")
+        text_lines.append("T*")
+    content_stream = "BT /F1 11 Tf 50 770 Td " + " ".join(text_lines) + " ET"
+    stream_bytes = content_stream.encode("latin-1", errors="replace")
+
+    objects = [
+        b"1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj\n",
+        b"2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj\n",
+        b"3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >> endobj\n",
+        f"4 0 obj << /Length {len(stream_bytes)} >> stream\n".encode("latin-1") + stream_bytes + b"\nendstream endobj\n",
+        b"5 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj\n",
+    ]
+
+    output = bytearray(b"%PDF-1.4\n")
+    offsets: list[int] = [0]
+    for obj in objects:
+        offsets.append(len(output))
+        output.extend(obj)
+    xref_pos = len(output)
+    output.extend(f"xref\n0 {len(objects)+1}\n".encode("latin-1"))
+    output.extend(b"0000000000 65535 f \n")
+    for off in offsets[1:]:
+        output.extend(f"{off:010d} 00000 n \n".encode("latin-1"))
+    output.extend(
+        f"trailer << /Root 1 0 R /Size {len(objects)+1} >>\nstartxref\n{xref_pos}\n%%EOF".encode(
+            "latin-1"
+        )
+    )
+    return bytes(output)

--- a/api/aijuristiction-api/app/chat/core_runtime.py
+++ b/api/aijuristiction-api/app/chat/core_runtime.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import logging
+import sys
+import tempfile
+from pathlib import Path
+from typing import Sequence
+
+from app.chat.models import Session
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from aijurisdictionagents.agents import create_judge, create_lawyer_agent
+from aijurisdictionagents.llm import get_llm_client
+from aijurisdictionagents.observability import TraceRecorder
+from aijurisdictionagents.orchestration import Orchestrator
+from aijurisdictionagents.schemas import Document, Message, OrchestrationResult
+
+
+def run_orchestration(
+    session: Session,
+    instruction: str,
+    documents: Sequence[Document],
+    question_timeout_seconds: float,
+    max_discussion_minutes: float,
+    user_response_provider,
+    message_callback,
+) -> OrchestrationResult:
+    llm = get_llm_client()
+    lawyer = create_lawyer_agent(llm, session.country)
+    judge = create_judge(llm) if session.discussion_type == "court" else None
+
+    logger = logging.getLogger("aijuristiction-api.core")
+    with tempfile.TemporaryDirectory(prefix="aijuris_api_run_") as temp_dir:
+        trace = TraceRecorder(Path(temp_dir))
+        try:
+            orchestrator = Orchestrator(lawyer=lawyer, judge=judge, trace=trace, logger=logger)
+            return orchestrator.run(
+                instruction,
+                documents,
+                country=session.country,
+                language=session.language,
+                question_timeout_seconds=question_timeout_seconds,
+                max_discussion_minutes=max_discussion_minutes,
+                discussion_type=session.discussion_type,
+                user_response_provider=user_response_provider,
+                message_callback=message_callback,
+            )
+        finally:
+            trace.close()
+
+
+def core_message_role(role: str) -> str:
+    role_lower = role.lower().strip()
+    if role_lower in {"user", "assistant", "system"}:
+        return role_lower
+    return "assistant"

--- a/api/aijuristiction-api/app/chat/models.py
+++ b/api/aijuristiction-api/app/chat/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from enum import Enum
-from typing import List, Optional
+from typing import Any, List, Optional
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
@@ -37,6 +37,7 @@ class Message(BaseModel):
     session_id: UUID
     role: MessageRole
     content: str
+    agent_name: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     attachments: List[Attachment] = Field(default_factory=list)
 
@@ -50,5 +51,16 @@ class GenerationJob(BaseModel):
 class Session(BaseModel):
     id: UUID = Field(default_factory=uuid4)
     user_id: Optional[UUID] = None
+    country: str = ""
+    language: str | None = None
+    discussion_type: str = "advice"
     state: SessionState = SessionState.ACTIVE
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class SessionResult(BaseModel):
+    final_recommendation: str
+    judge_rationale: str
+    citations: List[dict[str, str]] = Field(default_factory=list)
+    generated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/api/aijuristiction-api/app/chat/repository.py
+++ b/api/aijuristiction-api/app/chat/repository.py
@@ -4,13 +4,14 @@ from threading import Lock
 from typing import Dict, List
 from uuid import UUID
 
-from app.chat.models import Message, Session
+from app.chat.models import Message, Session, SessionResult, SessionState
 
 
 class InMemoryChatRepository:
     def __init__(self) -> None:
         self._sessions: Dict[UUID, Session] = {}
         self._messages_by_session: Dict[UUID, List[Message]] = {}
+        self._results: Dict[UUID, SessionResult] = {}
         self._lock = Lock()
 
     def create_session(self, session: Session) -> Session:
@@ -31,3 +32,18 @@ class InMemoryChatRepository:
 
     def list_messages(self, session_id: UUID) -> List[Message]:
         return list(self._messages_by_session.get(session_id, []))
+
+    def set_result(self, session_id: UUID, result: SessionResult) -> None:
+        with self._lock:
+            if session_id not in self._sessions:
+                raise KeyError(f"Session {session_id} not found")
+            self._results[session_id] = result
+            self._sessions[session_id].state = SessionState.COMPLETED
+
+    def get_result(self, session_id: UUID) -> SessionResult | None:
+        return self._results.get(session_id)
+
+    def mark_failed(self, session_id: UUID) -> None:
+        with self._lock:
+            if session_id in self._sessions:
+                self._sessions[session_id].state = SessionState.FAILED

--- a/api/aijuristiction-api/e2e-playwright/package-lock.json
+++ b/api/aijuristiction-api/e2e-playwright/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aijuristiction-api-e2e",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aijuristiction-api-e2e",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@playwright/test": "^1.58.2"
       }

--- a/api/aijuristiction-api/e2e-playwright/package.json
+++ b/api/aijuristiction-api/e2e-playwright/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aijuristiction-api-e2e",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "test": "playwright test"
   },

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "0.1.0"
+version = "0.1.1"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -8,7 +8,11 @@ AUTH_HEADERS = {"x-api-key": "aijuris"}
 
 
 def test_create_session_and_messages_roundtrip() -> None:
-    session_response = client.post("/v1/chat/sessions", json={}, headers=AUTH_HEADERS)
+    session_response = client.post(
+        "/v1/chat/sessions",
+        json={"country": "SK", "discussion_type": "advice"},
+        headers=AUTH_HEADERS,
+    )
     assert session_response.status_code == 200
     session_id = session_response.json()["id"]
 
@@ -29,6 +33,51 @@ def test_create_session_and_messages_roundtrip() -> None:
     messages = list_response.json()
     assert len(messages) == 1
     assert messages[0]["role"] == "user"
+
+
+def test_stream_core_orchestration_and_export_json_pdf() -> None:
+    session_response = client.post(
+        "/v1/chat/sessions",
+        json={"country": "SK", "discussion_type": "advice", "language": "en-US"},
+        headers=AUTH_HEADERS,
+    )
+    assert session_response.status_code == 200
+    session_id = session_response.json()["id"]
+
+    with client.stream(
+        "POST",
+        f"/v1/chat/sessions/{session_id}/stream",
+        headers=AUTH_HEADERS,
+        json={
+            "instruction": "Need legal advice about lease termination.",
+            "documents": [{"doc_id": "d1", "path": "lease.txt", "content": "Lease terms"}],
+            "question_timeout_seconds": 1,
+            "max_discussion_minutes": 1,
+        },
+    ) as response:
+        assert response.status_code == 200
+        events = "".join(response.iter_text())
+
+    assert "event: message" in events
+    assert "event: result" in events
+    assert "event: done" in events
+
+    result_response = client.get(f"/v1/chat/sessions/{session_id}/result", headers=AUTH_HEADERS)
+    assert result_response.status_code == 200
+    assert "final_recommendation" in result_response.json()
+
+    export_json = client.get(
+        f"/v1/chat/sessions/{session_id}/export?format=json", headers=AUTH_HEADERS
+    )
+    assert export_json.status_code == 200
+    assert export_json.headers["content-type"].startswith("application/json")
+
+    export_pdf = client.get(
+        f"/v1/chat/sessions/{session_id}/export?format=pdf", headers=AUTH_HEADERS
+    )
+    assert export_pdf.status_code == 200
+    assert export_pdf.headers["content-type"].startswith("application/pdf")
+    assert export_pdf.content.startswith(b"%PDF")
 
 
 def test_create_message_returns_404_for_unknown_session() -> None:

--- a/api/chat-simulator-app/README.md
+++ b/api/chat-simulator-app/README.md
@@ -12,10 +12,17 @@ uvicorn app.main:app --reload --port 8090
 
 Open `http://localhost:8090/chat-simulator` and set **API base URL** to your API service (default `http://localhost:8080`).
 
+The simulator now supports:
+- creating chat sessions with country/language/discussion type
+- submitting a case instruction and uploading text documents
+- starting `POST /v1/chat/sessions/{session_id}/stream` and viewing streamed events in real time
+- fetching result payload and downloading exports as JSON or PDF
+
 ## Endpoints
 
 - `GET /health`
 - `GET /chat-simulator`
+- `GET /version`
 - `GET /static/*` (simulator assets)
 
 ## Minimal runnable example
@@ -23,4 +30,11 @@ Open `http://localhost:8090/chat-simulator` and set **API base URL** to your API
 ```bash
 cd api/chat-simulator-app
 uvicorn app.main:app --port 8090
+```
+
+
+Version check:
+
+```bash
+curl http://localhost:8090/version
 ```

--- a/api/chat-simulator-app/app/main.py
+++ b/api/chat-simulator-app/app/main.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version as package_version
 from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
+SIMULATOR_PACKAGE = "chat-simulator-app"
+
+
 app = FastAPI(
     title="AI Juristiction Chat Simulator App",
-    version="0.1.0",
+    version="0.1.1",
     description="Standalone chat simulator application for validating core chat APIs.",
 )
 
@@ -22,7 +26,23 @@ def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
+@app.get("/version")
+def version() -> dict[str, str]:
+    return {
+        "service": "chat-simulator-app",
+        "version": app.version,
+        "simulator_version": _get_simulator_version(),
+    }
+
+
 @app.get("/", include_in_schema=False)
 @app.get("/chat-simulator", include_in_schema=False)
 def simulator_page() -> FileResponse:
     return FileResponse(_STATIC_DIR / "index.html")
+
+
+def _get_simulator_version() -> str:
+    try:
+        return package_version(SIMULATOR_PACKAGE)
+    except PackageNotFoundError:
+        return app.version

--- a/api/chat-simulator-app/pyproject.toml
+++ b/api/chat-simulator-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chat-simulator-app"
-version = "0.1.0"
+version = "0.1.1"
 description = "Standalone chat simulator UI for testing aijuristiction-api chat endpoints"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/chat-simulator-app/static/index.html
+++ b/api/chat-simulator-app/static/index.html
@@ -9,7 +9,7 @@
   <body>
     <main class="shell">
       <h1>Chat Simulator</h1>
-      <p>Standalone simulator app for validating chat API behavior before frontend deploy.</p>
+      <p>Start a chat session, submit your case with documents, and watch streamed core messages in real-time.</p>
 
       <section class="grid">
         <div>
@@ -22,31 +22,73 @@
         </div>
       </section>
 
+      <section class="grid row">
+        <div>
+          <label for="country">Country</label>
+          <input id="country" value="SK" placeholder="SK" />
+        </div>
+        <div>
+          <label for="language">Language (optional)</label>
+          <input id="language" value="en-US" placeholder="en-US" />
+        </div>
+        <div>
+          <label for="discussionType">Discussion type</label>
+          <select id="discussionType">
+            <option value="advice">advice</option>
+            <option value="court">court</option>
+          </select>
+        </div>
+      </section>
+
       <section class="row">
         <button id="createSession">Create Session</button>
         <button id="clearSession" class="secondary">Clear Session</button>
         <pre id="sessionStatus">No session created yet.</pre>
       </section>
 
-      <section class="row grid">
+      <section class="row">
+        <label for="instruction">Case instruction</label>
+        <textarea id="instruction" placeholder="Describe your case and request legal support..."></textarea>
+      </section>
+
+      <section class="grid row">
         <div>
-          <label for="role">Role</label>
-          <select id="role">
-            <option value="user">user</option>
-            <option value="assistant">assistant</option>
-            <option value="system">system</option>
-          </select>
+          <label for="questionTimeout">Question timeout (seconds)</label>
+          <input id="questionTimeout" type="number" min="1" value="300" />
         </div>
-        <div class="stretch">
-          <label for="content">Message content</label>
-          <textarea id="content" placeholder="Type a message"></textarea>
+        <div>
+          <label for="maxDiscussion">Max discussion (minutes)</label>
+          <input id="maxDiscussion" type="number" min="0" step="1" value="15" />
         </div>
       </section>
 
-      <section class="row"><button id="sendMessage">Send Message</button></section>
       <section class="row">
-        <button id="refreshMessages">Refresh Messages</button>
+        <label for="documents">Upload documents (text-based files)</label>
+        <input id="documents" type="file" multiple />
+        <small>Uploaded file contents are sent as API document payloads.</small>
+      </section>
+
+      <section class="row actions">
+        <button id="startStream">Start Stream</button>
+        <button id="refreshMessages" class="secondary">Refresh Messages</button>
+        <button id="getResult" class="secondary">Get Result</button>
+        <button id="downloadJson" class="secondary">Download JSON</button>
+        <button id="downloadPdf" class="secondary">Download PDF</button>
+      </section>
+
+      <section class="row">
+        <h2>Streamed events</h2>
+        <pre id="streamLog">No stream started yet.</pre>
+      </section>
+
+      <section class="row">
+        <h2>Session messages</h2>
         <pre id="messages">[]</pre>
+      </section>
+
+      <section class="row">
+        <h2>Result</h2>
+        <pre id="result">No result fetched yet.</pre>
       </section>
     </main>
     <script src="/static/simulator.js"></script>

--- a/api/chat-simulator-app/static/simulator.css
+++ b/api/chat-simulator-app/static/simulator.css
@@ -11,14 +11,21 @@ body {
 }
 
 .shell {
-  max-width: 900px;
+  max-width: 980px;
   margin: 0 auto;
   background: #1e293b;
   border-radius: 16px;
   padding: 1.25rem;
 }
 
-h1 { margin-top: 0; }
+h1, h2 {
+  margin-top: 0;
+}
+
+h2 {
+  margin-bottom: 0.5rem;
+  font-size: 1.05rem;
+}
 
 .grid {
   display: grid;
@@ -26,7 +33,17 @@ h1 { margin-top: 0; }
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-label { display: block; font-size: 0.875rem; margin-bottom: 0.35rem; }
+label {
+  display: block;
+  font-size: 0.875rem;
+  margin-bottom: 0.35rem;
+}
+
+small {
+  color: #cbd5e1;
+  display: block;
+  margin-top: 0.4rem;
+}
 
 input,
 textarea,
@@ -41,10 +58,42 @@ button {
   color: inherit;
 }
 
-textarea { min-height: 90px; }
-button { cursor: pointer; background: #3b82f6; border: 0; font-weight: 600; }
-button.secondary { margin-top: 0.5rem; background: #475569; }
-.row { margin-top: 1rem; }
-pre { background: #020617; border: 1px solid #1e293b; border-radius: 10px; padding: 0.75rem; overflow-x: auto; }
-#messages { max-height: 320px; overflow-y: auto; }
-.stretch { grid-column: 1 / -1; }
+textarea {
+  min-height: 100px;
+}
+
+button {
+  cursor: pointer;
+  background: #3b82f6;
+  border: 0;
+  font-weight: 600;
+}
+
+button.secondary {
+  background: #475569;
+}
+
+.row {
+  margin-top: 1rem;
+}
+
+pre {
+  background: #020617;
+  border: 1px solid #1e293b;
+  border-radius: 10px;
+  padding: 0.75rem;
+  overflow-x: auto;
+}
+
+#streamLog,
+#messages,
+#result {
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.actions {
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}

--- a/api/chat-simulator-app/static/simulator.js
+++ b/api/chat-simulator-app/static/simulator.js
@@ -1,9 +1,16 @@
 const baseUrlInput = document.getElementById("baseUrl");
 const apiKeyInput = document.getElementById("apiKey");
+const countryInput = document.getElementById("country");
+const languageInput = document.getElementById("language");
+const discussionTypeInput = document.getElementById("discussionType");
 const sessionStatus = document.getElementById("sessionStatus");
+const instructionInput = document.getElementById("instruction");
+const questionTimeoutInput = document.getElementById("questionTimeout");
+const maxDiscussionInput = document.getElementById("maxDiscussion");
+const documentsInput = document.getElementById("documents");
+const streamLog = document.getElementById("streamLog");
 const messagesEl = document.getElementById("messages");
-const roleEl = document.getElementById("role");
-const contentEl = document.getElementById("content");
+const resultEl = document.getElementById("result");
 
 let sessionId = null;
 
@@ -21,8 +28,13 @@ function requireSession() {
   if (!sessionId) throw new Error("Create a session first.");
 }
 
-function requireNonEmptyMessage() {
-  if (!contentEl.value.trim()) throw new Error("Message content cannot be empty.");
+function appendStream(text) {
+  if (streamLog.textContent === "No stream started yet.") {
+    streamLog.textContent = text;
+    return;
+  }
+  streamLog.textContent += `\n${text}`;
+  streamLog.scrollTop = streamLog.scrollHeight;
 }
 
 async function parseResponse(response) {
@@ -32,10 +44,15 @@ async function parseResponse(response) {
 }
 
 async function createSession() {
+  const payload = {
+    country: countryInput.value.trim() || "SK",
+    language: languageInput.value.trim() || null,
+    discussion_type: discussionTypeInput.value,
+  };
   const response = await fetch(`${getBaseUrl()}/v1/chat/sessions`, {
     method: "POST",
     headers: requestHeaders(),
-    body: JSON.stringify({}),
+    body: JSON.stringify(payload),
   });
   const body = await parseResponse(response);
   sessionId = body.id;
@@ -43,16 +60,92 @@ async function createSession() {
   await refreshMessages();
 }
 
-async function sendMessage() {
+async function readSelectedDocuments() {
+  const files = Array.from(documentsInput.files || []);
+  const docs = [];
+  for (const file of files) {
+    const content = await file.text();
+    docs.push({
+      doc_id: file.name,
+      path: file.name,
+      content,
+    });
+  }
+  return docs;
+}
+
+function parseSseChunk(rawChunk) {
+  const events = [];
+  const blocks = rawChunk.split("\n\n");
+  for (const block of blocks) {
+    const lines = block.split("\n").map((line) => line.trim()).filter(Boolean);
+    if (!lines.length) continue;
+    const eventLine = lines.find((line) => line.startsWith("event:"));
+    const dataLine = lines.find((line) => line.startsWith("data:"));
+    if (!eventLine || !dataLine) continue;
+    const event = eventLine.slice(6).trim();
+    const dataText = dataLine.slice(5).trim();
+    try {
+      events.push({ event, data: JSON.parse(dataText) });
+    } catch {
+      events.push({ event, data: dataText });
+    }
+  }
+  return events;
+}
+
+async function startStream() {
   requireSession();
-  requireNonEmptyMessage();
-  const response = await fetch(`${getBaseUrl()}/v1/chat/messages`, {
+  const instruction = instructionInput.value.trim();
+  if (!instruction) throw new Error("Case instruction is required.");
+
+  streamLog.textContent = "Starting stream...";
+  const payload = {
+    instruction,
+    documents: await readSelectedDocuments(),
+    question_timeout_seconds: Number(questionTimeoutInput.value || 300),
+    max_discussion_minutes: Number(maxDiscussionInput.value || 15),
+  };
+
+  const response = await fetch(`${getBaseUrl()}/v1/chat/sessions/${sessionId}/stream`, {
     method: "POST",
     headers: requestHeaders(),
-    body: JSON.stringify({ session_id: sessionId, role: roleEl.value, content: contentEl.value }),
+    body: JSON.stringify(payload),
   });
-  await parseResponse(response);
-  contentEl.value = "";
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(body || `Failed to stream, status=${response.status}`);
+  }
+  if (!response.body) {
+    throw new Error("Streaming body is not available in this browser.");
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await response.body.getReader().read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const split = buffer.split("\n\n");
+    buffer = split.pop() || "";
+
+    for (const block of split) {
+      const events = parseSseChunk(`${block}\n\n`);
+      for (const e of events) {
+        appendStream(`${e.event}: ${JSON.stringify(e.data)}`);
+      }
+    }
+  }
+
+  if (buffer.trim()) {
+    const trailingEvents = parseSseChunk(buffer);
+    for (const e of trailingEvents) {
+      appendStream(`${e.event}: ${JSON.stringify(e.data)}`);
+    }
+  }
+
   await refreshMessages();
 }
 
@@ -65,10 +158,41 @@ async function refreshMessages() {
   messagesEl.textContent = JSON.stringify(body, null, 2);
 }
 
+async function getResult() {
+  requireSession();
+  const response = await fetch(`${getBaseUrl()}/v1/chat/sessions/${sessionId}/result`, {
+    headers: requestHeaders(false),
+  });
+  const body = await parseResponse(response);
+  resultEl.textContent = JSON.stringify(body, null, 2);
+}
+
+async function downloadResult(format) {
+  requireSession();
+  const response = await fetch(`${getBaseUrl()}/v1/chat/sessions/${sessionId}/export?format=${format}`, {
+    headers: requestHeaders(false),
+  });
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+
+  const blob = await response.blob();
+  const href = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  anchor.download = `session-${sessionId}.${format}`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(href);
+}
+
 function clearSession() {
   sessionId = null;
   sessionStatus.textContent = "No session created yet.";
+  streamLog.textContent = "No stream started yet.";
   messagesEl.textContent = "[]";
+  resultEl.textContent = "No result fetched yet.";
 }
 
 function bind(id, fn) {
@@ -77,12 +201,16 @@ function bind(id, fn) {
       await fn();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      appendStream(`error: ${message}`);
       sessionStatus.textContent = message;
     }
   });
 }
 
 bind("createSession", createSession);
-bind("sendMessage", sendMessage);
+bind("startStream", startStream);
 bind("refreshMessages", refreshMessages);
+bind("getResult", getResult);
+bind("downloadJson", async () => downloadResult("json"));
+bind("downloadPdf", async () => downloadResult("pdf"));
 bind("clearSession", async () => clearSession());

--- a/api/chat-simulator-app/tests/test_app.py
+++ b/api/chat-simulator-app/tests/test_app.py
@@ -12,10 +12,22 @@ def test_health() -> None:
     assert response.json() == {'status': 'ok'}
 
 
+def test_version() -> None:
+    response = client.get('/version')
+    assert response.status_code == 200
+    assert response.json() == {
+        'service': 'chat-simulator-app',
+        'version': '0.1.1',
+        'simulator_version': '0.1.1',
+    }
+
+
 def test_simulator_page_and_assets() -> None:
     page = client.get('/chat-simulator')
     assert page.status_code == 200
     assert '/static/simulator.js' in page.text
+    assert 'Start Stream' in page.text
+    assert 'Upload documents' in page.text
 
     js = client.get('/static/simulator.js')
     css = client.get('/static/simulator.css')

--- a/examples/api_streaming_demo.py
+++ b/examples/api_streaming_demo.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from urllib import request
+
+API_BASE = "http://localhost:8080"
+HEADERS = {
+    "Content-Type": "application/json",
+    "x-api-key": "aijuris",
+}
+
+
+def _post(path: str, payload: dict) -> dict:
+    req = request.Request(
+        API_BASE + path,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=HEADERS,
+        method="POST",
+    )
+    with request.urlopen(req, timeout=30) as response:  # noqa: S310
+        return json.loads(response.read().decode("utf-8"))
+
+
+def main() -> None:
+    session = _post(
+        "/v1/chat/sessions",
+        {"country": "SK", "discussion_type": "advice", "language": "en-US"},
+    )
+    session_id = session["id"]
+    print(f"Created session: {session_id}")
+
+    req = request.Request(
+        API_BASE + f"/v1/chat/sessions/{session_id}/stream",
+        data=json.dumps(
+            {
+                "instruction": "I need advice about late rent payment dispute.",
+                "documents": [
+                    {"doc_id": "lease", "path": "lease.txt", "content": "Rent due by 5th each month."}
+                ],
+            }
+        ).encode("utf-8"),
+        headers=HEADERS,
+        method="POST",
+    )
+
+    with request.urlopen(req, timeout=120) as response:  # noqa: S310
+        for raw_line in response:
+            line = raw_line.decode("utf-8").strip()
+            if line:
+                print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aijurisdictionagents"
-version = "0.1.0"
+version = "0.1.1"
 description = "Multi-agent legal discussion scaffold."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/src/aijurisdictionagents/orchestration/orchestrator.py
+++ b/src/aijurisdictionagents/orchestration/orchestrator.py
@@ -11,6 +11,7 @@ from ..observability import TraceRecorder
 from ..schemas import Document, Message, OrchestrationResult, Source
 
 UserResponseProvider = Callable[[str, float], str | None]
+MessageCallback = Callable[[Message], None]
 
 
 class Orchestrator:
@@ -36,6 +37,7 @@ class Orchestrator:
         max_discussion_minutes: float = 15,
         discussion_type: str = "advice",
         user_response_provider: UserResponseProvider | None = None,
+        message_callback: MessageCallback | None = None,
     ) -> OrchestrationResult:
         if not country.strip():
             raise ValueError("country is required.")
@@ -68,8 +70,7 @@ class Orchestrator:
             content=user_instruction,
             sources=[],
         )
-        conversation.append(user_message)
-        self.trace.record_message(user_message)
+        self._record_message(conversation, user_message, message_callback)
         self.logger.info("User instruction: %s", user_instruction)
 
         citations = select_sources(documents, user_instruction)
@@ -115,8 +116,7 @@ class Orchestrator:
                 citations,
                 system_prompt_override=lawyer_prompt,
             )
-            conversation.append(lawyer_message)
-            self.trace.record_message(lawyer_message)
+            self._record_message(conversation, lawyer_message, message_callback)
             last_lawyer_message = lawyer_message
             self.logger.info("Lawyer response: %s", lawyer_message.content)
 
@@ -144,6 +144,7 @@ class Orchestrator:
                 remaining_seconds,
                 question_timeout_seconds,
                 language,
+                message_callback,
             )
             if asked:
                 asked_user_question = True
@@ -171,8 +172,7 @@ class Orchestrator:
                             citations,
                             system_prompt_override=judge_prompt,
                         )
-                        conversation.append(judge_message)
-                        self.trace.record_message(judge_message)
+                        self._record_message(conversation, judge_message, message_callback)
                         last_judge_message = judge_message
                         self.logger.info("Judge response: %s", judge_message.content)
 
@@ -212,8 +212,7 @@ class Orchestrator:
                     citations,
                     system_prompt_override=judge_prompt,
                 )
-                conversation.append(judge_message)
-                self.trace.record_message(judge_message)
+                self._record_message(conversation, judge_message, message_callback)
                 last_judge_message = judge_message
                 self.logger.info("Judge response: %s", judge_message.content)
 
@@ -233,6 +232,7 @@ class Orchestrator:
                     remaining_seconds,
                     question_timeout_seconds,
                     language,
+                    message_callback,
                 )
                 if asked:
                     asked_user_question = True
@@ -273,6 +273,7 @@ class Orchestrator:
                 remaining_seconds,
                 question_timeout_seconds,
                 language,
+                message_callback,
             )
             if not should_continue:
                 self.logger.info("User ended discussion or no follow-up provided.")
@@ -333,6 +334,17 @@ class Orchestrator:
         self.logger.info("Orchestration complete")
         return result
 
+    def _record_message(
+        self,
+        conversation: List[Message],
+        message: Message,
+        message_callback: MessageCallback | None,
+    ) -> None:
+        conversation.append(message)
+        self.trace.record_message(message)
+        if message_callback is not None:
+            message_callback(message)
+
     def _generate_final_summary(
         self,
         conversation: Sequence[Message],
@@ -352,6 +364,7 @@ class Orchestrator:
         remaining_seconds: float | None,
         question_timeout_seconds: float,
         language: str | None,
+        message_callback: MessageCallback | None,
     ) -> tuple[bool, bool, bool]:
         question = _extract_question(message.content)
         if not question:
@@ -385,8 +398,7 @@ class Orchestrator:
             content=content,
             sources=[],
         )
-        conversation.append(user_message)
-        self.trace.record_message(user_message)
+        self._record_message(conversation, user_message, message_callback)
         if answered and _is_finish_response(content):
             self.trace.record_event("discussion_finished", {"reason": "user_finished"})
             return True, True, True
@@ -399,6 +411,7 @@ class Orchestrator:
         remaining_seconds: float | None,
         question_timeout_seconds: float,
         language: str | None,
+        message_callback: MessageCallback | None,
     ) -> bool:
         if user_response_provider is None:
             return False
@@ -425,8 +438,7 @@ class Orchestrator:
             content=content,
             sources=[],
         )
-        conversation.append(user_message)
-        self.trace.record_message(user_message)
+        self._record_message(conversation, user_message, message_callback)
         if _is_finish_response(content):
             self.trace.record_event("discussion_finished", {"reason": "user_finished"})
             return False
@@ -439,6 +451,7 @@ class Orchestrator:
         remaining_seconds: float | None,
         question_timeout_seconds: float,
         language: str | None,
+        message_callback: MessageCallback | None,
     ) -> bool:
         if user_response_provider is None:
             return False
@@ -465,8 +478,7 @@ class Orchestrator:
             content=content,
             sources=[],
         )
-        conversation.append(user_message)
-        self.trace.record_message(user_message)
+        self._record_message(conversation, user_message, message_callback)
         return _wants_judge_review(content)
 
 


### PR DESCRIPTION
### Motivation
- Provide a practical end-to-end simulator UI so QA can start a chat session, submit a case with documents, and observe core agent messages streamed back in real time. 
- Surface core orchestrator progress to clients via SSE so frontends receive each agent message as it is produced instead of waiting for orchestration to finish. 
- Persist session results and enable downloadable exports (JSON/PDF) for downstream review and testing.

### Description
- Added simulator UI and client logic to support session creation with `country`/`language`/`discussion_type`, instruction submission, text file uploads, SSE streaming display, message refresh, result fetch, and JSON/PDF download (`api/chat-simulator-app/static/*`, updated `tests/test_app.py`, updated README). 
- Implemented API streaming endpoint and exports: `POST /v1/chat/sessions/{session_id}/stream` streams SSE events, `GET /v1/chat/sessions/{session_id}/result` returns persisted `SessionResult`, and `GET /v1/chat/sessions/{session_id}/export?format=json|pdf` returns JSON or a simple PDF. 
- Introduced runtime bridge `app.chat.core_runtime.run_orchestration` to call the local core orchestrator, and extended `Orchestrator.run` with an optional `message_callback` that records and emits core messages via `_record_message`. 
- Extended chat domain models and in-memory repository to track session metadata and final results, added a minimal streaming demo `examples/api_streaming_demo.py`, and bumped package/app versions where appropriate.

### Testing
- Ran simulator unit tests with `cd api/chat-simulator-app && python -m pytest tests/test_app.py`, and the suite passed (`3 passed`).
- Started the API and simulator with `uvicorn` and validated `python examples/minimal_demo.py` printed healthy `health`/`version` responses as expected. 
- Attempted an automated browser screenshot of the simulator UI via Playwright but the browser container could not connect to the local simulator (`ERR_EMPTY_RESPONSE`); this is an environment connectivity issue and not a functional failure of the app itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b495c94048332b7b8e4c4f4562768)