### PR TITLE
Add end-user chat panel to chat simulator UI

### DIFF
--- a/api/chat-simulator-app/README.md
+++ b/api/chat-simulator-app/README.md
@@ -16,6 +16,8 @@ The simulator now supports:
 - creating chat sessions with country/language/discussion type
 - submitting a case instruction and uploading text documents
 - starting `POST /v1/chat/sessions/{session_id}/stream` and viewing streamed events in real time
+- using the new right-side **End User Chat View** panel that renders core messages as user-facing chat bubbles
+- sending manual end-user answers from the bottom input box (stored via `POST /v1/chat/messages`)
 - fetching result payload and downloading exports as JSON or PDF
 
 ## Default simulator inputs

--- a/api/chat-simulator-app/static/index.html
+++ b/api/chat-simulator-app/static/index.html
@@ -8,88 +8,105 @@
   </head>
   <body>
     <main class="shell">
-      <h1>Chat Simulator</h1>
-      <p>Start a chat session, submit your case with documents, and watch streamed core messages in real-time.</p>
+      <div class="simulator-layout">
+        <div class="simulator-controls">
+          <h1>Chat Simulator</h1>
+          <p>Start a chat session, submit your case with documents, and watch streamed core messages in real-time.</p>
 
-      <section class="grid">
-        <div>
-          <label for="baseUrl">API base URL</label>
-          <input id="baseUrl" value="http://localhost:8080" placeholder="http://localhost:8080" />
+          <section class="grid">
+            <div>
+              <label for="baseUrl">API base URL</label>
+              <input id="baseUrl" value="http://localhost:8080" placeholder="http://localhost:8080" />
+            </div>
+            <div>
+              <label for="apiKey">x-api-key</label>
+              <input id="apiKey" value="aijuris" />
+            </div>
+          </section>
+
+          <section class="grid row">
+            <div>
+              <label for="country">Country</label>
+              <input id="country" value="SK" placeholder="SK" />
+            </div>
+            <div>
+              <label for="language">Language (optional)</label>
+              <input id="language" value="en-US" placeholder="en-US" />
+            </div>
+            <div>
+              <label for="discussionType">Discussion type</label>
+              <select id="discussionType">
+                <option value="advice">advice</option>
+                <option value="court">court</option>
+              </select>
+            </div>
+          </section>
+
+          <section class="row">
+            <button id="createSession">Create Session</button>
+            <button id="clearSession" class="secondary">Clear Session</button>
+            <pre id="sessionStatus">No session created yet.</pre>
+          </section>
+
+          <section class="row">
+            <label for="instruction">Case instruction</label>
+            <textarea id="instruction" placeholder="Describe your case and request legal support..."></textarea>
+          </section>
+
+          <section class="grid row">
+            <div>
+              <label for="questionTimeout">Question timeout (seconds)</label>
+              <input id="questionTimeout" type="number" min="1" value="300" />
+            </div>
+            <div>
+              <label for="maxDiscussion">Max discussion (minutes)</label>
+              <input id="maxDiscussion" type="number" min="0" step="1" value="15" />
+            </div>
+          </section>
+
+          <section class="row">
+            <label for="documents">Upload documents (text-based files)</label>
+            <input id="documents" type="file" multiple />
+            <small>Uploaded file contents are sent as API document payloads.</small>
+          </section>
+
+          <section class="row actions">
+            <button id="startStream">Start Stream</button>
+            <button id="refreshMessages" class="secondary">Refresh Messages</button>
+            <button id="getResult" class="secondary">Get Result</button>
+            <button id="downloadJson" class="secondary">Download JSON</button>
+            <button id="downloadPdf" class="secondary">Download PDF</button>
+          </section>
+
+          <section class="row">
+            <h2>Streamed events</h2>
+            <pre id="streamLog">No stream started yet.</pre>
+          </section>
+
+          <section class="row">
+            <h2>Session messages</h2>
+            <pre id="messages">[]</pre>
+          </section>
+
+          <section class="row">
+            <h2>Result</h2>
+            <pre id="result">No result fetched yet.</pre>
+          </section>
         </div>
-        <div>
-          <label for="apiKey">x-api-key</label>
-          <input id="apiKey" value="aijuris" />
-        </div>
-      </section>
 
-      <section class="grid row">
-        <div>
-          <label for="country">Country</label>
-          <input id="country" value="SK" placeholder="SK" />
-        </div>
-        <div>
-          <label for="language">Language (optional)</label>
-          <input id="language" value="en-US" placeholder="en-US" />
-        </div>
-        <div>
-          <label for="discussionType">Discussion type</label>
-          <select id="discussionType">
-            <option value="advice">advice</option>
-            <option value="court">court</option>
-          </select>
-        </div>
-      </section>
-
-      <section class="row">
-        <button id="createSession">Create Session</button>
-        <button id="clearSession" class="secondary">Clear Session</button>
-        <pre id="sessionStatus">No session created yet.</pre>
-      </section>
-
-      <section class="row">
-        <label for="instruction">Case instruction</label>
-        <textarea id="instruction" placeholder="Describe your case and request legal support..."></textarea>
-      </section>
-
-      <section class="grid row">
-        <div>
-          <label for="questionTimeout">Question timeout (seconds)</label>
-          <input id="questionTimeout" type="number" min="1" value="300" />
-        </div>
-        <div>
-          <label for="maxDiscussion">Max discussion (minutes)</label>
-          <input id="maxDiscussion" type="number" min="0" step="1" value="15" />
-        </div>
-      </section>
-
-      <section class="row">
-        <label for="documents">Upload documents (text-based files)</label>
-        <input id="documents" type="file" multiple />
-        <small>Uploaded file contents are sent as API document payloads.</small>
-      </section>
-
-      <section class="row actions">
-        <button id="startStream">Start Stream</button>
-        <button id="refreshMessages" class="secondary">Refresh Messages</button>
-        <button id="getResult" class="secondary">Get Result</button>
-        <button id="downloadJson" class="secondary">Download JSON</button>
-        <button id="downloadPdf" class="secondary">Download PDF</button>
-      </section>
-
-      <section class="row">
-        <h2>Streamed events</h2>
-        <pre id="streamLog">No stream started yet.</pre>
-      </section>
-
-      <section class="row">
-        <h2>Session messages</h2>
-        <pre id="messages">[]</pre>
-      </section>
-
-      <section class="row">
-        <h2>Result</h2>
-        <pre id="result">No result fetched yet.</pre>
-      </section>
+        <aside class="simulator-chat">
+          <h2>End User Chat View</h2>
+          <p>Core streamed messages are rendered as the end-user conversation.</p>
+          <div id="chatTranscript" class="chat-transcript">
+            <p class="chat-placeholder">No chat messages yet. Start a stream or refresh messages.</p>
+          </div>
+          <form id="chatReplyForm" class="chat-reply-form">
+            <label for="userReplyInput">End user answer</label>
+            <textarea id="userReplyInput" placeholder="Type end user response..." required></textarea>
+            <button id="sendUserReply" type="submit">Send answer</button>
+          </form>
+        </aside>
+      </div>
     </main>
     <script src="/static/simulator.js"></script>
   </body>

--- a/api/chat-simulator-app/static/simulator.css
+++ b/api/chat-simulator-app/static/simulator.css
@@ -11,11 +11,31 @@ body {
 }
 
 .shell {
-  max-width: 980px;
+  max-width: 1320px;
   margin: 0 auto;
   background: #1e293b;
   border-radius: 16px;
   padding: 1.25rem;
+}
+
+.simulator-layout {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: minmax(0, 1.8fr) minmax(320px, 1fr);
+}
+
+.simulator-controls {
+  min-width: 0;
+}
+
+.simulator-chat {
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  background: #0b1222;
 }
 
 h1, h2 {
@@ -62,6 +82,10 @@ textarea {
   min-height: 100px;
 }
 
+#userReplyInput {
+  min-height: 88px;
+}
+
 button {
   cursor: pointer;
   background: #3b82f6;
@@ -96,4 +120,60 @@ pre {
   display: grid;
   gap: 0.6rem;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.chat-transcript {
+  margin-top: 0.65rem;
+  border: 1px solid #1e293b;
+  border-radius: 12px;
+  background: #020617;
+  padding: 0.85rem;
+  min-height: 350px;
+  max-height: 620px;
+  overflow-y: auto;
+}
+
+.chat-message {
+  width: fit-content;
+  max-width: 92%;
+  border-radius: 12px;
+  padding: 0.65rem 0.75rem;
+  margin-bottom: 0.7rem;
+  line-height: 1.35;
+}
+
+.chat-message.core {
+  background: #2563eb;
+  margin-right: auto;
+}
+
+.chat-message.user {
+  background: #475569;
+  margin-left: auto;
+}
+
+.chat-meta {
+  display: block;
+  font-size: 0.75rem;
+  color: #d1d5db;
+  margin-bottom: 0.25rem;
+}
+
+.chat-placeholder {
+  margin: 0;
+  color: #94a3b8;
+}
+
+.chat-reply-form {
+  margin-top: 0.8rem;
+}
+
+@media (max-width: 1100px) {
+  .simulator-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .chat-transcript {
+    max-height: 320px;
+  }
 }

--- a/api/chat-simulator-app/static/simulator.js
+++ b/api/chat-simulator-app/static/simulator.js
@@ -11,12 +11,68 @@ const documentsInput = document.getElementById("documents");
 const streamLog = document.getElementById("streamLog");
 const messagesEl = document.getElementById("messages");
 const resultEl = document.getElementById("result");
+const chatTranscriptEl = document.getElementById("chatTranscript");
+const chatReplyForm = document.getElementById("chatReplyForm");
+const userReplyInput = document.getElementById("userReplyInput");
 const defaultsUrl = "/static/default-inputs.json";
 
 let sessionId = null;
 
 function getBaseUrl() {
   return baseUrlInput.value.trim();
+}
+
+function ensureChatPlaceholder() {
+  if (chatTranscriptEl.childElementCount > 0) return;
+  const placeholder = document.createElement("p");
+  placeholder.className = "chat-placeholder";
+  placeholder.textContent = "No chat messages yet. Start a stream or refresh messages.";
+  chatTranscriptEl.appendChild(placeholder);
+}
+
+function clearChatPlaceholder() {
+  const placeholder = chatTranscriptEl.querySelector(".chat-placeholder");
+  if (placeholder) placeholder.remove();
+}
+
+function messageSpeaker(message) {
+  if (message.role === "user") return "End user";
+  if (message.agent_name) return `Core (${message.agent_name})`;
+  return "Core system";
+}
+
+function isUserMessage(message) {
+  return message.role === "user";
+}
+
+function buildChatMessageNode(message) {
+  const article = document.createElement("article");
+  article.className = `chat-message ${isUserMessage(message) ? "user" : "core"}`;
+
+  const meta = document.createElement("span");
+  meta.className = "chat-meta";
+  meta.textContent = messageSpeaker(message);
+
+  const body = document.createElement("p");
+  body.textContent = message.content;
+
+  article.append(meta, body);
+  return article;
+}
+
+function appendChatMessage(message) {
+  clearChatPlaceholder();
+  chatTranscriptEl.appendChild(buildChatMessageNode(message));
+  chatTranscriptEl.scrollTop = chatTranscriptEl.scrollHeight;
+}
+
+function renderChatMessages(messages) {
+  chatTranscriptEl.innerHTML = "";
+  for (const message of messages) {
+    chatTranscriptEl.appendChild(buildChatMessageNode(message));
+  }
+  ensureChatPlaceholder();
+  chatTranscriptEl.scrollTop = chatTranscriptEl.scrollHeight;
 }
 
 async function applyDefaultInputs() {
@@ -152,16 +208,22 @@ async function startStream() {
 
     for (const block of split) {
       const events = parseSseChunk(`${block}\n\n`);
-      for (const e of events) {
-        appendStream(`${e.event}: ${JSON.stringify(e.data)}`);
+      for (const eventItem of events) {
+        appendStream(`${eventItem.event}: ${JSON.stringify(eventItem.data)}`);
+        if (eventItem.event === "message" && eventItem.data && typeof eventItem.data === "object") {
+          appendChatMessage(eventItem.data);
+        }
       }
     }
   }
 
   if (buffer.trim()) {
     const trailingEvents = parseSseChunk(buffer);
-    for (const e of trailingEvents) {
-      appendStream(`${e.event}: ${JSON.stringify(e.data)}`);
+    for (const eventItem of trailingEvents) {
+      appendStream(`${eventItem.event}: ${JSON.stringify(eventItem.data)}`);
+      if (eventItem.event === "message" && eventItem.data && typeof eventItem.data === "object") {
+        appendChatMessage(eventItem.data);
+      }
     }
   }
 
@@ -175,6 +237,29 @@ async function refreshMessages() {
   });
   const body = await parseResponse(response);
   messagesEl.textContent = JSON.stringify(body, null, 2);
+  renderChatMessages(body);
+}
+
+async function sendUserReply() {
+  requireSession();
+  const content = userReplyInput.value.trim();
+  if (!content) throw new Error("End user answer is required.");
+
+  const response = await fetch(`${getBaseUrl()}/v1/chat/messages`, {
+    method: "POST",
+    headers: requestHeaders(),
+    body: JSON.stringify({
+      session_id: sessionId,
+      role: "user",
+      content,
+    }),
+  });
+
+  const body = await parseResponse(response);
+  appendChatMessage(body);
+  userReplyInput.value = "";
+  appendStream(`user_reply: ${content}`);
+  await refreshMessages();
 }
 
 async function getResult() {
@@ -212,6 +297,9 @@ function clearSession() {
   streamLog.textContent = "No stream started yet.";
   messagesEl.textContent = "[]";
   resultEl.textContent = "No result fetched yet.";
+  chatTranscriptEl.innerHTML = "";
+  ensureChatPlaceholder();
+  userReplyInput.value = "";
 }
 
 function bind(id, fn) {
@@ -234,4 +322,16 @@ bind("downloadJson", async () => downloadResult("json"));
 bind("downloadPdf", async () => downloadResult("pdf"));
 bind("clearSession", async () => clearSession());
 
+chatReplyForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  try {
+    await sendUserReply();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    appendStream(`error: ${message}`);
+    sessionStatus.textContent = message;
+  }
+});
+
+ensureChatPlaceholder();
 applyDefaultInputs();


### PR DESCRIPTION
### Motivation
- Provide a right-side panel in the chat simulator so developers can simulate the end-user view of core streamed messages and test user replies in-context. 
- Render core `message` events as user-facing chat bubbles and allow manual end-user replies to be submitted to the core API for easier integration testing.

### Description
- Reworked `api/chat-simulator-app/static/index.html` into a two-column layout with existing simulator controls on the left and a new `aside.simulator-chat` right panel that holds `#chatTranscript` and a reply form (`#chatReplyForm`, `#userReplyInput`).
- Added layout and UI styling in `api/chat-simulator-app/static/simulator.css` for the split grid, chat transcript, role-based bubble styles, and responsive behavior.
- Extended client logic in `api/chat-simulator-app/static/simulator.js` to render streamed `message` events into the right-panel transcript, load persisted session messages into the transcript via `refreshMessages()`, submit manual replies via `POST /v1/chat/messages` in `sendUserReply()`, and reset chat state in `clearSession()`.
- Updated `api/chat-simulator-app/README.md` to document the new right-side **End User Chat View** panel and the manual end-user answer workflow.

### Testing
- Ran unit/integration tests for the simulator with `cd api/chat-simulator-app && PYTHONPATH=. pytest -q tests/test_app.py`, which completed successfully.
- Automated browser screenshot attempt via the Playwright tooling failed with `net::ERR_EMPTY_RESPONSE` when navigating to `http://localhost:8090/chat-simulator`, so no screenshot artifact was produced (server-side page rendering and the test suite were validated separately).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c04508000833290dd4fe87549954a)