### PR TITLE
Add Slovakia rental chat simulation and richer validator scoring

### DIFF
--- a/data/case_prenajom/sk_public_najomna_zmluva_template.txt
+++ b/data/case_prenajom/sk_public_najomna_zmluva_template.txt
@@ -1,0 +1,24 @@
+NÁJOMNÁ ZMLUVA (vzor)
+
+Článok I. Zmluvné strany
+Prenajímateľ: [meno, adresa]
+Nájomca: [meno, adresa]
+
+Článok II. Predmet nájmu
+Prenajímateľ prenecháva nájomcovi byt na adrese [adresa bytu] do dočasného užívania.
+
+Článok III. Doba nájmu
+Nájom sa uzatvára na dobu určitú/neurčitú od [dátum].
+
+Článok IV. Nájomné a úhrady
+Mesačné nájomné je [suma] EUR, splatné do 5. dňa príslušného mesiaca.
+Kaucia je vo výške [suma] EUR.
+
+Článok V. Práva a povinnosti
+Nájomca užíva byt riadne a v súlade so zmluvou.
+
+Článok VI. Skončenie nájmu
+Výpovedná lehota je [počet] mesiac(e/ov). Výpoveď musí byť písomná.
+
+Článok VII. Záverečné ustanovenia
+Zmluva je vyhotovená v dvoch rovnopisoch a podpísaná oboma stranami.

--- a/data/case_prenajom/slovakia_rental_validation_report.json
+++ b/data/case_prenajom/slovakia_rental_validation_report.json
@@ -1,0 +1,40 @@
+{
+  "simulated_duration_minutes": 10.83,
+  "weighted_accuracy": 93.49,
+  "human_likeness": 96.0,
+  "contract_similarity": 67.27,
+  "summary": "Strongest axis: legal_accuracy (100.0). Needs improvement: contract_alignment (67.3).",
+  "score_breakdown": [
+    {
+      "name": "legal_accuracy",
+      "score": 100.0,
+      "rationale": "Computed from overlap between expected legal points and final answer."
+    },
+    {
+      "name": "coverage",
+      "score": 100.0,
+      "rationale": "Computed from overlap between expected legal points and transcript."
+    },
+    {
+      "name": "clarity",
+      "score": 90.0,
+      "rationale": "Shorter, well-bounded conclusions receive higher clarity."
+    },
+    {
+      "name": "risk_awareness",
+      "score": 100.0,
+      "rationale": "Checks whether caveats or next-step guidance is present."
+    },
+    {
+      "name": "human_likeness",
+      "score": 96.0,
+      "rationale": "Measures whether the conversation mirrors realistic lawyer-client intake behavior."
+    },
+    {
+      "name": "contract_alignment",
+      "score": 67.27,
+      "rationale": "Measures overlap between generated contract and reference Slovak rental templates."
+    }
+  ],
+  "final_contract": "Rozumiem. Tu je navrh najomnej zmluvy (byt):\n1) Zmluvne strany: Prenajimatel Jana Novotna, Najomca Tomas Hlavaty a manzelka.\n2) Predmet najmu: Byt na adrese Dunajska 12, Bratislava.\n3) Doba najmu: Na dobu urcitu 1 rok, od 01.04.2026.\n4) Najomne: 850 EUR mesacne, splatne do 5. dna v mesiaci.\n5) Platba vopred: 2 mesacne najomne vopred.\n6) Kaucia: 1 mesacne najomne, vratna po odovzdani bytu bez skod.\n7) Ukoncenie: Vypovedna lehota podla dohody, dorucenie pisomne aj emailom.\n8) Zaverecne ustanovenia: Datum podpisu, pocet vyhotoveni, podpisy oboch stran.\nChcete finalny vystup aj vo formate PDF?"
+}

--- a/docs/AI_AGENTS_VALIDATOR.md
+++ b/docs/AI_AGENTS_VALIDATOR.md
@@ -10,19 +10,25 @@
   - `question`
   - `expected_points` (legal anchors you expect the system to cover)
 - final result text from the core system
+- optional `final_contract` text
+- optional `reference_contracts` (public template excerpts for comparison)
 
 ## Scoring criteria
 
 Default weighted criteria:
 
-- `legal_accuracy` (45%)
-- `coverage` (30%)
-- `clarity` (15%)
+- `legal_accuracy` (30%)
+- `coverage` (20%)
+- `clarity` (10%)
 - `risk_awareness` (10%)
+- `human_likeness` (15%)
+- `contract_alignment` (15%)
 
 The output is a `ValidationReport` with:
 
 - `weighted_accuracy` (0-100)
+- `human_likeness` (0-100)
+- `contract_similarity` (0-100)
 - per-criterion scores and rationale
 - summary sentence
 
@@ -36,8 +42,9 @@ For deeper legal quality review, pass a production LLM client (OpenAI/Azure Foun
 - low temperature (0.0-0.2)
 - strict JSON schema parsing and fallback to heuristic scores
 
-## Minimal runnable example
+## Minimal runnable examples
 
 ```bash
 python examples/validator_demo.py
+python examples/slovakia_rental_10min_validation_demo.py
 ```

--- a/examples/slovakia_rental_10min_validation_demo.py
+++ b/examples/slovakia_rental_10min_validation_demo.py
@@ -1,0 +1,115 @@
+"""Simulate a 10+ minute Slovak rental-lawyer chat and validate it.
+
+Run:
+    python examples/slovakia_rental_10min_validation_demo.py
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+import json
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = REPO_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from aijurisdictionagents.agents import (  # noqa: E402
+    AIAgentsValidator,
+    AIUserSimulatorAgent,
+    ValidatorInputs,
+    create_lawyer_agent,
+)
+from aijurisdictionagents.llm.mock import MockLLMClient  # noqa: E402
+from aijurisdictionagents.schemas import Message  # noqa: E402
+
+
+def main() -> None:
+    llm = MockLLMClient()
+    lawyer = create_lawyer_agent(llm, "SK")
+    user = AIUserSimulatorAgent(llm=llm, language="sk")
+
+    conversation: list[Message] = []
+    qa_pairs: list[dict[str, str]] = []
+
+    kickoff = (
+        "Prosím priprav nájomnú zmluvu pre Slovensko. Prenajímateľ je fyzická osoba, "
+        "nájomca manželský pár. Byt je v Bratislave, prenájom na 1 rok, výpovedná lehota 1 mesiac, "
+        "nájomné 850 EUR, splatné do 5. dňa a dve mesačné nájomné vopred."
+    )
+    conversation.append(Message(role="user", agent_name="EndUser", content=kickoff))
+
+    step_seconds = 65
+    start_time = datetime(2026, 4, 1, 9, 0, 0)
+
+    for turn_index in range(10):
+        lawyer_text = lawyer.respond(conversation=conversation, documents=[], sources=[]).content
+        conversation.append(Message(role="assistant", agent_name=lawyer.name, content=lawyer_text))
+
+        user_text = user.prepare_random_answer(
+            question=lawyer_text,
+            conversation=conversation,
+            documents=[],
+        )
+        conversation.append(Message(role="user", agent_name="EndUser", content=user_text))
+
+        qa_pairs.append(
+            {
+                "minute": (start_time + timedelta(seconds=turn_index * step_seconds)).isoformat(),
+                "question": lawyer_text,
+                "answer": user_text,
+            }
+        )
+
+    conversation.append(Message(role="user", agent_name="EndUser", content="Prosím priprav teraz kompletný návrh nájomnej zmluvy."))
+    final_contract = lawyer.respond(conversation=conversation, documents=[], sources=[]).content
+
+    payload = {"qaPairs": qa_pairs}
+    reference_contract = (REPO_ROOT / "data" / "case_prenajom" / "sk_public_najomna_zmluva_template.txt").read_text(
+        encoding="utf-8"
+    )
+    validator = AIAgentsValidator()
+
+    report = validator.evaluate(
+        communication_payload=payload,
+        inputs=ValidatorInputs(
+            country="SK",
+            question="Ako pripraviť nájomnú zmluvu pre byt v Bratislave?",
+            expected_points=(
+                "zmluvne strany",
+                "predmet najmu",
+                "doba najmu",
+                "najomne splatne",
+                "platba vopred",
+                "kaucia",
+                "ukoncenie",
+                "vypovedna lehota",
+                "zaverecne ustanovenia",
+            ),
+        ),
+        final_result=final_contract,
+        final_contract=final_contract,
+        reference_contracts=(reference_contract,),
+    )
+
+    result = {
+        "simulated_duration_minutes": round((len(qa_pairs) * step_seconds) / 60, 2),
+        "weighted_accuracy": report.weighted_accuracy,
+        "human_likeness": report.human_likeness,
+        "contract_similarity": report.contract_similarity,
+        "summary": report.summary,
+        "score_breakdown": [s.__dict__ for s in report.scores],
+        "final_contract": final_contract,
+    }
+
+    output_path = REPO_ROOT / "data" / "case_prenajom" / "slovakia_rental_validation_report.json"
+    output_path.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    print(f"\nSaved report to: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aijurisdictionagents/agents/judge.py
+++ b/src/aijurisdictionagents/agents/judge.py
@@ -7,6 +7,6 @@ from ..llm import LLMClient
 def create_judge(llm: LLMClient) -> Agent:
     system_prompt = (
         "You are a judge evaluating the lawyer's arguments. "
-        "Ask clarifying questions, weigh the evidence, and issue a reasoned decision."
+        "Ask clarifying questions, weigh the evidence, issue a reasoned decision, and check whether the exchange feels realistic for human legal intake."
     )
     return Agent(name="Judge", system_prompt=system_prompt, llm=llm)

--- a/src/aijurisdictionagents/agents/lawyer.py
+++ b/src/aijurisdictionagents/agents/lawyer.py
@@ -14,6 +14,7 @@ LAWYER_BASE_PROMPT = textwrap.dedent(
 
     ROLE & TONE
     - Professional, concise, empathetic, but transactional.
+    - Keep question flow human-like: acknowledge user details before asking the next focused question.
     - Do not overpromise outcomes. Focus on fact-finding and next steps.
     - Do not provide definitive legal advice; provide a preliminary assessment
       and recommend consulting a licensed attorney for final decisions if needed.

--- a/src/aijurisdictionagents/agents/slovakia.py
+++ b/src/aijurisdictionagents/agents/slovakia.py
@@ -26,6 +26,7 @@ def create_lawyer_slovakia(llm: LLMClient) -> Agent:
 
         CONVERSATION STRUCTURE
         - Start with short acknowledgment + what you need next.
+        - Keep interaction realistic: ask one to two focused questions per turn and react to prior answers before moving on.
         - Ask 8–15 clarifying questions, grouped by theme:
           A) Parties & identification (FO/PO, IČO, address)
           B) Contract/relationship & obligations

--- a/src/aijurisdictionagents/agents/user_simulator.py
+++ b/src/aijurisdictionagents/agents/user_simulator.py
@@ -25,6 +25,7 @@ USER_SIMULATOR_PROMPT = textwrap.dedent(
     - If the question asks for unknown facts, provide a plausible placeholder and
       clearly indicate uncertainty.
     - Prefer one short paragraph.
+    - Keep style natural, as if written by a real client in chat (small imperfections are acceptable).
     """
 ).strip()
 

--- a/src/aijurisdictionagents/agents/validator.py
+++ b/src/aijurisdictionagents/agents/validator.py
@@ -39,28 +39,40 @@ class ValidationReport:
     weighted_accuracy: float
     scores: Sequence[CriterionScore]
     summary: str
+    contract_similarity: float
+    human_likeness: float
 
 
 DEFAULT_CRITERIA: tuple[EvaluationCriterion, ...] = (
     EvaluationCriterion(
         name="legal_accuracy",
         description="Whether the final answer aligns with expected legal anchors.",
-        weight=0.45,
+        weight=0.30,
     ),
     EvaluationCriterion(
         name="coverage",
         description="Whether the conversation addresses all key expected points.",
-        weight=0.30,
+        weight=0.20,
     ),
     EvaluationCriterion(
         name="clarity",
         description="Whether the final answer is concise and understandable.",
-        weight=0.15,
+        weight=0.10,
     ),
     EvaluationCriterion(
         name="risk_awareness",
         description="Whether caveats/next steps are communicated.",
         weight=0.10,
+    ),
+    EvaluationCriterion(
+        name="human_likeness",
+        description="Whether the exchange resembles a human lawyer-client intake conversation.",
+        weight=0.15,
+    ),
+    EvaluationCriterion(
+        name="contract_alignment",
+        description="Whether the final contract follows public Slovak rental contract patterns.",
+        weight=0.15,
     ),
 )
 
@@ -86,18 +98,45 @@ class AIAgentsValidator:
         communication_path: str | Path,
         inputs: ValidatorInputs,
         final_result: str,
+        final_contract: str | None = None,
+        reference_contracts: Sequence[str] = (),
     ) -> ValidationReport:
         payload = json.loads(Path(communication_path).read_text(encoding="utf-8"))
-        return self.evaluate(payload, inputs, final_result)
+        return self.evaluate(
+            payload,
+            inputs,
+            final_result,
+            final_contract=final_contract,
+            reference_contracts=reference_contracts,
+        )
 
     def evaluate(
         self,
         communication_payload: dict[str, Any],
         inputs: ValidatorInputs,
         final_result: str,
+        final_contract: str | None = None,
+        reference_contracts: Sequence[str] = (),
     ) -> ValidationReport:
         transcript = _extract_transcript(communication_payload)
         heuristic_scores = self._heuristic_scores(transcript, inputs, final_result)
+        contract_similarity = _contract_similarity(final_contract or final_result, reference_contracts)
+        human_likeness = _human_likeness(transcript)
+
+        heuristic_scores.extend(
+            [
+                CriterionScore(
+                    name="human_likeness",
+                    score=human_likeness,
+                    rationale="Measures whether the conversation mirrors realistic lawyer-client intake behavior.",
+                ),
+                CriterionScore(
+                    name="contract_alignment",
+                    score=contract_similarity,
+                    rationale="Measures overlap between generated contract and reference Slovak rental templates.",
+                ),
+            ]
+        )
 
         if self.llm is None:
             scores = heuristic_scores
@@ -111,6 +150,8 @@ class AIAgentsValidator:
             weighted_accuracy=weighted_accuracy,
             scores=scores,
             summary=summary,
+            contract_similarity=contract_similarity,
+            human_likeness=human_likeness,
         )
 
     def _heuristic_scores(
@@ -127,9 +168,16 @@ class AIAgentsValidator:
         coverage_overlap = _safe_ratio(len(expected_tokens & transcript_tokens), max(1, len(expected_tokens)))
 
         sentence_count = max(1, len([s for s in re.split(r"[.!?]+", final_result) if s.strip()]))
-        clarity = min(1.0, 1 / sentence_count + 0.4)
+        has_structured_clauses = bool(re.search(r"\b\d+\)", final_result))
+        if has_structured_clauses:
+            clarity = 0.9
+        else:
+            clarity = min(1.0, 1 / sentence_count + 0.4)
 
-        risk_markers = {"risk", "uncertain", "depends", "recommend", "consult", "limitation", "deadline"}
+        risk_markers = {
+            "risk", "uncertain", "depends", "recommend", "consult", "limitation", "deadline",
+            "riziko", "odporucat", "odporucam", "lehota", "vypoved", "pisomne", "upozornenie",
+        }
         risk_awareness = 1.0 if (risk_markers & final_tokens) else 0.45
 
         return [
@@ -245,7 +293,7 @@ def _extract_transcript(payload: dict[str, Any]) -> str:
 
 
 def _tokens(text: str) -> set[str]:
-    return {token.lower() for token in re.findall(r"[a-zA-Z]{3,}", text)}
+    return {token.lower() for token in re.findall(r"[^\W\d_]{3,}", text, flags=re.UNICODE)}
 
 
 def _safe_ratio(numerator: int, denominator: int) -> float:
@@ -275,3 +323,56 @@ def _build_summary(scores: Sequence[CriterionScore]) -> str:
         f"Strongest axis: {best.name} ({best.score:.1f}). "
         f"Needs improvement: {weakest.name} ({weakest.score:.1f})."
     )
+
+
+def _contract_similarity(final_contract: str, reference_contracts: Sequence[str]) -> float:
+    final_tokens = _tokens(final_contract)
+    if not final_tokens:
+        return 0.0
+
+    required_sections = {
+        "zmluvne", "strany", "predmet", "najmu", "doba", "najomne", "kaucia", "ukoncenie", "vypovedna", "pisomne"
+    }
+    section_coverage = _safe_ratio(len(final_tokens & required_sections), len(required_sections))
+
+    references = list(reference_contracts)
+    if not references:
+        references = [
+            "zmluvne strany predmet najmu doba najmu najomne splatnost kaucia vypovedna lehota podpis",
+        ]
+
+    best_f1 = 0.0
+    for sample in references:
+        sample_tokens = _tokens(sample)
+        if not sample_tokens:
+            continue
+        overlap = len(final_tokens & sample_tokens)
+        precision = _safe_ratio(overlap, len(final_tokens))
+        recall = _safe_ratio(overlap, len(sample_tokens))
+        f1 = 0.0 if (precision + recall) == 0 else (2 * precision * recall) / (precision + recall)
+        best_f1 = max(best_f1, f1)
+
+    combined = 0.6 * section_coverage + 0.4 * best_f1
+    return round(combined * 100, 2)
+
+
+def _human_likeness(transcript: str) -> float:
+    lowered = transcript.lower()
+    if not lowered.strip():
+        return 0.0
+
+    question_mark_count = transcript.count("?")
+    qa_markers = sum(1 for marker in ("q:", "a:", "user:", "assistant:") if marker in lowered)
+    empathy_markers = sum(
+        1
+        for marker in ("rozumiem", "ďakujem", "dakujem", "prosím", "prosim", "i understand", "thank you")
+        if marker in lowered
+    )
+    legal_markers = sum(
+        1
+        for marker in ("zmluva", "nájom", "najom", "výpoveď", "vypoved", "lehota", "jurisdikcia", "dôkaz")
+        if marker in lowered
+    )
+
+    score = min(1.0, 0.2 + question_mark_count * 0.03 + qa_markers * 0.08 + empathy_markers * 0.05 + legal_markers * 0.05)
+    return round(score * 100, 2)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -33,6 +33,8 @@ def test_validator_evaluates_payload() -> None:
     assert 0 <= report.weighted_accuracy <= 100
     assert report.scores
     assert "Strongest axis" in report.summary
+    assert 0 <= report.human_likeness <= 100
+    assert 0 <= report.contract_similarity <= 100
 
 
 def test_validator_reads_payload_from_file(tmp_path: Path) -> None:
@@ -51,3 +53,4 @@ def test_validator_reads_payload_from_file(tmp_path: Path) -> None:
     )
 
     assert report.weighted_accuracy >= 0
+    assert report.human_likeness >= 0


### PR DESCRIPTION
### Motivation
- Provide an end-to-end way to simulate a realistic Slovak landlord/tenant intake conversation, produce a draft nájomná zmluva and automatically validate its quality against expected legal anchors and public templates. 
- Improve the validator so it can measure how human-like conversations are and how closely generated contracts align with public Slovak rental templates to support iterative agent tuning.

### Description
- Extend `AIAgentsValidator` to accept optional `final_contract` and `reference_contracts`, add `human_likeness` and `contract_similarity` into `ValidationReport`, and include two new scoring axes (`human_likeness` and `contract_alignment`) with adjusted default weights. (see `src/aijurisdictionagents/agents/validator.py`)
- Implement heuristic helpers `_contract_similarity` and `_human_likeness`, improve tokenization and clarity/risk heuristics to better handle Slovak text, and include these scores in the weighted accuracy computation. (see `src/aijurisdictionagents/agents/validator.py`)
- Add a runnable simulation example `examples/slovakia_rental_10min_validation_demo.py` that runs a 10+ minute simulated chat between `AIUserSimulatorAgent` and the Slovak lawyer agent and writes a validation report, and add a public-style Slovak rental template reference at `data/case_prenajom/sk_public_najomna_zmluva_template.txt`.
- Update agent prompts to improve human-like interaction (`user_simulator`, Slovak lawyer flow, base lawyer tone and judge prompt) and update docs `docs/AI_AGENTS_VALIDATOR.md` and tests `tests/test_validator.py` to reflect the new fields and behavior.

### Testing
- Ran `python -m pytest tests/test_validator.py` and it passed (2 passed). 
- Ran `python -m pytest tests/test_agents.py tests/test_validator.py tests/test_orchestrator.py` and the selected suite passed (14 passed).
- Updated unit tests to assert the new `human_likeness` and `contract_similarity` fields and they passed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1b598a66c83328ba4698a6dc9fd46)