### PR TITLE
Fix API lint and pytest resolution for CI (import order and pythonpath)

### DIFF
--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -110,6 +110,13 @@ Run it independently to test chat flows before frontend deployment.
 GitHub workflow: `.github/workflows/api_build_deploy.yml`
 
 - CI checks: install deps, lint (`ruff`), type-check (`mypy`), tests (`pytest`), and Docker build.
+- Local pre-flight command to mirror CI from this folder:
+
+```bash
+ruff check . && mypy app && pytest -q
+```
+
+The `pytest` command is configured with `pythonpath = ["."]` in `pyproject.toml`, so direct invocation works consistently in local runs and GitHub Actions.
 - Deploy path: on manual dispatch with `deploy=true`, push image to Azure Container Registry and deploy/update Azure Container App.
 
 Required GitHub Environment variables:

--- a/api/aijuristiction-api/app/chat/core_runtime.py
+++ b/api/aijuristiction-api/app/chat/core_runtime.py
@@ -4,20 +4,26 @@ import logging
 import sys
 import tempfile
 from pathlib import Path
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 from app.chat.models import Session
+
+if TYPE_CHECKING:
+    from aijurisdictionagents.schemas import Document, OrchestrationResult
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 SRC_ROOT = REPO_ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
-from aijurisdictionagents.agents import create_judge, create_lawyer_agent
-from aijurisdictionagents.llm import get_llm_client
-from aijurisdictionagents.observability import TraceRecorder
-from aijurisdictionagents.orchestration import Orchestrator
-from aijurisdictionagents.schemas import Document, Message, OrchestrationResult
+
+def _load_core_dependencies():
+    from aijurisdictionagents.agents import create_judge, create_lawyer_agent
+    from aijurisdictionagents.llm import get_llm_client
+    from aijurisdictionagents.observability import TraceRecorder
+    from aijurisdictionagents.orchestration import Orchestrator
+
+    return create_judge, create_lawyer_agent, get_llm_client, TraceRecorder, Orchestrator
 
 
 def run_orchestration(
@@ -29,15 +35,18 @@ def run_orchestration(
     user_response_provider,
     message_callback,
 ) -> OrchestrationResult:
+    create_judge, create_lawyer_agent, get_llm_client, trace_recorder, orchestrator_class = (
+        _load_core_dependencies()
+    )
     llm = get_llm_client()
     lawyer = create_lawyer_agent(llm, session.country)
     judge = create_judge(llm) if session.discussion_type == "court" else None
 
     logger = logging.getLogger("aijuristiction-api.core")
     with tempfile.TemporaryDirectory(prefix="aijuris_api_run_") as temp_dir:
-        trace = TraceRecorder(Path(temp_dir))
+        trace = trace_recorder(Path(temp_dir))
         try:
-            orchestrator = Orchestrator(lawyer=lawyer, judge=judge, trace=trace, logger=logger)
+            orchestrator = orchestrator_class(lawyer=lawyer, judge=judge, trace=trace, logger=logger)
             return orchestrator.run(
                 instruction,
                 documents,

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -31,6 +31,7 @@ line-length = 100
 [tool.pytest.ini_options]
 addopts = "-q"
 testpaths = ["tests"]
+pythonpath = ["."]
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION
### Motivation
- CI linting failed due to module-level imports that depend on a local `src/` bootstrap, and pytest failed to resolve the local `app` package when run directly from the API folder. 
- The change aims to satisfy `ruff` import-order (`E402`) rules while preserving runtime behavior and make local `pytest` invocation consistent with CI.

### Description
- Defer importing runtime-only core dependencies by adding a loader function `_load_core_dependencies()` and keep schema types under `TYPE_CHECKING` to avoid module-level imports at top-of-file. 
- Replace direct runtime imports in `app/chat/core_runtime.py` with calls to the loader and update usage to use the returned constructors/classes. 
- Remove the unused `Message` schema import from `core_runtime.py`. 
- Configure pytest resolution by adding `pythonpath = ["."]` to `api/aijuristiction-api/pyproject.toml` and add a CI-aligned local pre-flight command to `api/aijuristiction-api/README.md` (`ruff check . && mypy app && pytest -q`).

### Testing
- Ran `cd api/aijuristiction-api && ruff check .` and it succeeded (no lint errors). 
- Ran `cd api/aijuristiction-api && pytest -q` and tests completed successfully (test suite passed; an OpenTelemetry exporter warning appeared during shutdown but did not fail tests). 
- Executed `python examples/minimal_demo.py` which failed with `ConnectionRefusedError` as expected because no local API server was running in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ba3d05b08332a4f225848a9c36e7)