### PR TITLE
Rebrand mobile app to AIJurisDictA and add new branding assets

### DIFF
--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -1,17 +1,18 @@
-# AI Jurisdiction Mobile (Flutter)
+# AIJurisDictA - AI Juris Digital Agent (Flutter)
 
-Flutter mobile client prepared for local testing of the AI Jurisdiction chat workflow.
+Flutter mobile client prepared for local testing of the AIJurisDictA (AI Juris Digital Agent) chat workflow.
 
 ## Features
 
 - Chat-bot style conversation UI.
-- Aijurisdicta login-themed background in the chat screen.
+- Rebranded mobile layout with login card at the top and blue legal-themed background from the footer artwork.
 - Add supporting documents using the device camera.
-- Switch responder mode before the input box:
+- Message area is centered between login header and selectors.
 - Initial localized Jurisdicta welcome message shown on app start.
-- Language selection in app bar (`SK` default, `EN`, `GE`, with `DE` accepted as alias for German).
+- Language/country selector is shown below the message area (`SK` default, `EN`, `GE`, with `DE` accepted as alias for German).
   - `AI User Simulator` (default for local tests)
-  - `Real Person`
+  - `Read User`
+- Local mode selector appears only when API base URL points to local hosts (`localhost`, `127.0.0.1`, `10.0.2.2`, `0.0.0.0`).
 - Select country/language before chatting (default: `Slovakia (SK)`).
 - Open generated summary/document PDF links directly from the mobile app once a session exists.
 - Uses the real API chat endpoints with API key auth:
@@ -20,7 +21,7 @@ Flutter mobile client prepared for local testing of the AI Jurisdiction chat wor
   - `POST /v1/chat/sessions/{session_id}/stream` (AI User Simulator mode)
   - Header: `x-api-key: aijuris`
 - Default local API base URL for Android emulator: `http://10.0.2.2:8080`.
-- Includes AI Jurisdicta branded top logo and background graphic.
+- Uses refreshed branding assets from provided logo/footer/icons set.
 - Communication/error logging:
   - non-web targets write JSON log entries to a timestamped file in a `logs` folder
   - file name pattern: `mobile_YYYYMMDD_HHMMSS.log`
@@ -126,4 +127,4 @@ shared Flutter sources are committed.
 
 Reference UI snapshot prepared for review of the mobile chat layout.
 
-![Mobile chat UI snapshot](docs/chat_ui_snapshot.svg)
+Open `docs/chat_ui_snapshot.html` in a browser for the updated rebrand layout preview.

--- a/mobile_app/assets/branding/ai-logo.svg
+++ b/mobile_app/assets/branding/ai-logo.svg
@@ -1,11 +1,18 @@
-<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect x="6" y="6" width="108" height="108" rx="24" stroke="#1B7F8E" stroke-width="3"/>
-  <path d="M60 26V74" stroke="#0B1220" stroke-width="4" stroke-linecap="round"/>
-  <path d="M34 44L60 34L86 44" stroke="#0B1220" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M34 44L22 64" stroke="#0B1220" stroke-width="3" stroke-linecap="round"/>
-  <path d="M86 44L98 64" stroke="#0B1220" stroke-width="3" stroke-linecap="round"/>
-  <circle cx="22" cy="64" r="6" fill="#D7A84F"/>
-  <circle cx="98" cy="64" r="6" fill="#D7A84F"/>
-  <circle cx="60" cy="34" r="6" fill="#1B7F8E"/>
-  <rect x="44" y="74" width="32" height="18" rx="6" fill="#0B1220"/>
+<svg width="480" height="120" viewBox="0 0 480 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="shield" x1="14" y1="6" x2="106" y2="108" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1B77D2"/>
+      <stop offset="1" stop-color="#0A2F6B"/>
+    </linearGradient>
+    <linearGradient id="text" x1="130" y1="20" x2="420" y2="98" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1E7BD8"/>
+      <stop offset="1" stop-color="#1A2D50"/>
+    </linearGradient>
+  </defs>
+  <path d="M60 8C43 16 28 18 14 20V62C14 89 33 104 60 112C87 104 106 89 106 62V20C92 18 77 16 60 8Z" fill="url(#shield)" stroke="#0A2F6B" stroke-width="3"/>
+  <path d="M60 16V108" stroke="#DDEBFF" stroke-width="3"/>
+  <path d="M38 76C44 78 52 76 56 70V42C50 40 43 42 38 47C35 51 35 58 38 62" fill="#EAF2FF"/>
+  <path d="M74 50H94M74 58H94M74 66H90" stroke="#EAF2FF" stroke-width="3" stroke-linecap="round"/>
+  <path d="M78 75C82 66 89 59 96 53" stroke="#EAF2FF" stroke-width="2.5"/>
+  <text x="124" y="78" font-family="Arial, sans-serif" font-size="58" font-weight="700" fill="url(#text)">AIJurisDictA</text>
 </svg>

--- a/mobile_app/assets/branding/hero-footer.svg
+++ b/mobile_app/assets/branding/hero-footer.svg
@@ -1,0 +1,14 @@
+<svg width="1200" height="260" viewBox="0 0 1200 260" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="130" x2="1200" y2="130" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#041B59"/>
+      <stop offset="0.5" stop-color="#1388E9"/>
+      <stop offset="1" stop-color="#041B59"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="260" fill="url(#bg)"/>
+  <path d="M0 184C158 136 306 235 448 181C628 111 744 221 902 181C1034 147 1116 170 1200 188V260H0V184Z" fill="#7FE0FF" fill-opacity="0.32"/>
+  <path d="M0 204C137 173 292 248 460 200C604 160 730 220 888 195C1024 174 1118 194 1200 210" stroke="#D2F7FF" stroke-width="2" stroke-opacity="0.8"/>
+  <circle cx="120" cy="80" r="38" fill="#4DB5FF" fill-opacity="0.38"/>
+  <circle cx="1060" cy="82" r="45" fill="#78CEFF" fill-opacity="0.3"/>
+</svg>

--- a/mobile_app/assets/branding/icon-ai-head.svg
+++ b/mobile_app/assets/branding/icon-ai-head.svg
@@ -1,0 +1,6 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="48" cy="48" r="46" fill="url(#g)" stroke="#0C3270" stroke-width="2"/>
+<defs><linearGradient id="g" x1="8" y1="8" x2="84" y2="88"><stop stop-color="#2E98F0"/><stop offset="1" stop-color="#0A2F6B"/></linearGradient></defs>
+<path d="M33 64C40 67 50 64 55 57V35C48 32 40 34 34 41C31 45 31 54 33 58" fill="#E8F1FF"/>
+<path d="M44 34L56 34M44 40L58 40M44 46L55 46" stroke="#BFE0FF" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/mobile_app/assets/branding/icon-court.svg
+++ b/mobile_app/assets/branding/icon-court.svg
@@ -1,0 +1,8 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 32L48 14L82 32H14Z" fill="#78BFFF" stroke="#0C3270" stroke-width="2"/>
+<rect x="18" y="32" width="60" height="8" fill="#1E7FDC"/>
+<rect x="22" y="40" width="8" height="28" fill="#D8EBFF" stroke="#0C3270" stroke-width="1.5"/>
+<rect x="40" y="40" width="8" height="28" fill="#D8EBFF" stroke="#0C3270" stroke-width="1.5"/>
+<rect x="58" y="40" width="8" height="28" fill="#D8EBFF" stroke="#0C3270" stroke-width="1.5"/>
+<rect x="14" y="68" width="68" height="10" fill="#1E7FDC" stroke="#0C3270" stroke-width="2"/>
+</svg>

--- a/mobile_app/assets/branding/icon-doc-check.svg
+++ b/mobile_app/assets/branding/icon-doc-check.svg
@@ -1,0 +1,8 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M20 14H56L74 32V82H20V14Z" fill="url(#g)" stroke="#0C3270" stroke-width="2"/>
+<path d="M56 14V32H74" stroke="#0C3270" stroke-width="2"/>
+<path d="M30 42H64M30 50H64M30 58H52" stroke="#DCEEFF" stroke-width="3" stroke-linecap="round"/>
+<circle cx="63" cy="69" r="14" fill="#1C7DDD" stroke="#0C3270" stroke-width="2"/>
+<path d="M56 69L61 74L70 64" stroke="#EAF5FF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<defs><linearGradient id="g" x1="20" y1="14" x2="74" y2="82"><stop stop-color="#2F99F0"/><stop offset="1" stop-color="#0A2F6B"/></linearGradient></defs>
+</svg>

--- a/mobile_app/assets/branding/icon-scale.svg
+++ b/mobile_app/assets/branding/icon-scale.svg
@@ -1,0 +1,7 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M48 18V72" stroke="#0C3270" stroke-width="4" stroke-linecap="round"/>
+<path d="M24 34L48 26L72 34" stroke="#0C3270" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M24 34L16 50H32L24 34Z" fill="#2A95ED"/>
+<path d="M72 34L64 50H80L72 34Z" fill="#2A95ED"/>
+<rect x="37" y="72" width="22" height="8" rx="4" fill="#0C3270"/>
+</svg>

--- a/mobile_app/docs/chat_ui_snapshot.html
+++ b/mobile_app/docs/chat_ui_snapshot.html
@@ -3,37 +3,43 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Mobile Chat Snapshot</title>
+<title>AIJurisDictA - Mobile Chat Snapshot</title>
 <style>
-body{margin:0;background:#eef1f7;font-family:Inter,Arial,sans-serif;display:flex;justify-content:center;padding:24px}
-.phone{width:390px;height:844px;background:white;border-radius:36px;box-shadow:0 12px 40px rgba(0,0,0,.18);overflow:hidden;border:10px solid #111}
-.top{background:#e7e9ff;padding:16px;font-weight:700;display:flex;justify-content:space-between}
-.mode{font-size:12px;background:white;border-radius:16px;padding:6px 10px}
-.banner{margin:12px;background:#f2f4ff;border-radius:10px;padding:10px;font-size:12px;color:#4a4d75}
-.chat{padding:12px;height:620px;display:flex;flex-direction:column;gap:10px}
+body{margin:0;background:#e6ecf8;font-family:Inter,Arial,sans-serif;display:flex;justify-content:center;padding:24px}
+.phone{width:390px;height:844px;background:linear-gradient(180deg,#041b59,#1388e9,#041b59);border-radius:36px;box-shadow:0 12px 40px rgba(0,0,0,.22);overflow:hidden;border:10px solid #111;padding:10px;box-sizing:border-box;color:#0a2f6b}
+.card{background:rgba(255,255,255,.92);border-radius:14px;padding:10px}
+.top{display:flex;align-items:center;gap:10px}
+.logo{width:42px;height:42px;background:#1e7bd8;border-radius:10px}
+.login{margin-left:auto;background:#e0ebff;border-radius:10px;padding:8px 12px;font-weight:700}
+.icons{display:flex;gap:10px;justify-content:space-between;margin:8px 0}
+.ico{width:50px;height:50px;border-radius:12px;background:rgba(255,255,255,.92);display:flex;align-items:center;justify-content:center;font-size:22px}
+.chat{margin-top:8px;height:360px;display:flex;flex-direction:column;gap:10px;padding:8px}
 .msg{max-width:78%;padding:10px 12px;border-radius:14px;font-size:14px;line-height:1.35}
-.assist{align-self:flex-start;background:#eceef4}
-.user{align-self:flex-end;background:#d9e7ff}
-.input{display:flex;gap:8px;padding:12px;border-top:1px solid #e6e8f2}
+.assist{align-self:flex-start;background:#e7effd}
+.user{align-self:flex-end;background:#d2e4ff}
+.selector{margin-top:8px}
+.row{display:flex;gap:8px;align-items:center;font-size:12px;margin:6px 0}
+.select{flex:1;background:white;border-radius:8px;padding:9px;color:#5e6d85}
+.input{display:flex;gap:8px;padding:8px;margin-top:8px}
 .btn{width:38px;height:38px;border-radius:10px;background:#e8edff;display:flex;align-items:center;justify-content:center}
-.text{flex:1;border:1px solid #ccd3e0;border-radius:10px;padding:10px;color:#788293;font-size:13px}
-.send{width:38px;height:38px;border-radius:10px;background:#4c67ff;color:#fff;display:flex;align-items:center;justify-content:center}
+.text{flex:1;border:1px solid #ccd3e0;background:white;border-radius:10px;padding:10px;color:#788293;font-size:13px}
+.send{width:38px;height:38px;border-radius:10px;background:#1f75d1;color:#fff;display:flex;align-items:center;justify-content:center}
 </style>
 </head>
 <body>
 <div class="phone">
-  <div class="top">AI Jurisdiction Assistant <span class="mode">AI User Simulator</span></div>
-  <div class="banner">📎 Attached document: /storage/emulated/0/DCIM/tenant_contract.jpg</div>
-  <div class="chat">
-    <div class="msg assist">Welcome! Upload a document photo and ask your legal question.</div>
+  <div class="card top"><div class="logo"></div><strong>AIJurisDictA</strong><span class="login">Sign in</span></div>
+  <div class="icons"><div class="ico">🤖</div><div class="ico">⚖️</div><div class="ico">📄</div><div class="ico">🏛️</div></div>
+  <div class="card chat">
+    <div class="msg assist">Hello, I am Jurisdicta. Describe your case and upload documents.</div>
     <div class="msg user">Can I terminate this rental agreement early without penalty?</div>
-    <div class="msg assist">Based on the uploaded clause, termination depends on notice period and breach conditions. Share your jurisdiction for precise guidance.</div>
+    <div class="msg assist">Based on uploaded clauses, this depends on notice period and local statute.</div>
   </div>
-  <div class="input">
-    <div class="btn">📷</div>
-    <div class="text">Ask your legal question...</div>
-    <div class="send">➤</div>
+  <div class="card selector">
+    <div class="row"><strong>Language & Country:</strong><div class="select">Slovakia (SK)</div></div>
+    <div class="row"><strong>Local mode:</strong><div class="select">AI User Simulator Agent</div></div>
   </div>
+  <div class="input"><div class="btn">📎</div><div class="text">Ask your legal question...</div><div class="send">➤</div></div>
 </div>
 </body>
 </html>

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -126,7 +126,7 @@ class AIJurisdictionMobileApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      title: 'AI Jurisdiction Mobile',
+      title: 'AIJurisDictA - AI Juris Digital Agent',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
         useMaterial3: true,
@@ -548,6 +548,14 @@ class _ChatHomePageState extends State<ChatHomePage> {
   String? _documentPath;
   bool _isSending = false;
 
+  bool get _showLocalResponderSwitch {
+    final host = Uri.parse(widget.apiBaseUrl).host.toLowerCase();
+    return host == 'localhost' ||
+        host == '127.0.0.1' ||
+        host == '10.0.2.2' ||
+        host == '0.0.0.0';
+  }
+
   @override
   void initState() {
     super.initState();
@@ -773,54 +781,6 @@ class _ChatHomePageState extends State<ChatHomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Row(
-          children: [
-            SvgPicture.asset(
-              'assets/branding/ai-logo.svg',
-              width: 26,
-              height: 26,
-            ),
-            const SizedBox(width: 8),
-            const Text('AI Jurisdicta Assistant'),
-          ],
-        ),
-        actions: [
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12),
-            child: DropdownButtonHideUnderline(
-              child: DropdownButton<ResponderMode>(
-                value: _responderMode,
-                onChanged: (mode) {
-                  if (mode == null) {
-                    return;
-                  }
-                  setState(() {
-                    _responderMode = mode;
-                  });
-                  unawaited(
-                    widget.logger.info(
-                      'Responder mode changed',
-                      <String, Object?>{'responder_mode': mode.name},
-                    ),
-                  );
-                  _apiClient.resetSession();
-                },
-                items: const [
-                  DropdownMenuItem(
-                    value: ResponderMode.aiUserSimulator,
-                    child: Text('AI User Simulator (default)'),
-                  ),
-                  DropdownMenuItem(
-                    value: ResponderMode.realPerson,
-                    child: Text('Real Person'),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ],
-      ),
       body: Stack(
         children: [
           Positioned.fill(
@@ -830,8 +790,9 @@ class _ChatHomePageState extends State<ChatHomePage> {
                   begin: Alignment.topCenter,
                   end: Alignment.bottomCenter,
                   colors: <Color>[
-                    Theme.of(context).colorScheme.surface,
-                    Theme.of(context).colorScheme.surfaceContainerLowest,
+                    const Color(0xFF041B59),
+                    const Color(0xFF1388E9),
+                    const Color(0xFF041B59),
                   ],
                 ),
               ),
@@ -841,13 +802,61 @@ class _ChatHomePageState extends State<ChatHomePage> {
             child: Opacity(
               opacity: 0.08,
               child: SvgPicture.asset(
-                'assets/branding/hero-graph.svg',
+                'assets/branding/hero-footer.svg',
                 fit: BoxFit.cover,
               ),
             ),
           ),
-          Column(
-            children: [
+          SafeArea(
+            child: Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+                  child: Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(0.94),
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                    child: Row(
+                      children: [
+                        SvgPicture.asset(
+                          'assets/branding/ai-logo.svg',
+                          width: 48,
+                          height: 48,
+                        ),
+                        const SizedBox(width: 10),
+                        const Expanded(
+                          child: Text(
+                            'Login',
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.w700,
+                              color: Color(0xFF0A2F6B),
+                            ),
+                          ),
+                        ),
+                        FilledButton.tonal(
+                          onPressed: () => _showSnackbar('Login UI placeholder'),
+                          child: const Text('Sign in'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: const [
+                      _BrandIcon(path: 'assets/branding/icon-ai-head.svg'),
+                      _BrandIcon(path: 'assets/branding/icon-scale.svg'),
+                      _BrandIcon(path: 'assets/branding/icon-doc-check.svg'),
+                      _BrandIcon(path: 'assets/branding/icon-court.svg'),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 8),
               if (_documentPath != null)
                 MaterialBanner(
                   content: Text('Attached document: $_documentPath'),
@@ -866,48 +875,6 @@ class _ChatHomePageState extends State<ChatHomePage> {
                     ),
                   ],
                 ),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
-                child: Row(
-                  children: [
-                    const Text('Locale:'),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: DropdownButton<LocaleOption>(
-                        isExpanded: true,
-                        value: _selectedLocale,
-                        onChanged: (locale) {
-                          if (locale == null) {
-                            return;
-                          }
-                          setState(() {
-                            _selectedLocale = locale;
-                            _updateWelcomeMessageForLocale();
-                          });
-                          unawaited(
-                            widget.logger.info(
-                              'Locale changed',
-                              <String, Object?>{
-                                'country': locale.countryCode,
-                                'language': locale.languageCode,
-                              },
-                            ),
-                          );
-                          _apiClient.resetSession();
-                        },
-                        items: _localeOptions
-                            .map(
-                              (locale) => DropdownMenuItem<LocaleOption>(
-                                value: locale,
-                                child: Text(locale.label),
-                              ),
-                            )
-                            .toList(),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
               Expanded(
                 child: ListView.builder(
                   reverse: true,
@@ -960,16 +927,107 @@ class _ChatHomePageState extends State<ChatHomePage> {
                   },
                 ),
               ),
-              SafeArea(
-                top: false,
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(12, 6, 12, 12),
-                  child: Row(
+              Padding(
+                padding: const EdgeInsets.fromLTRB(12, 6, 12, 4),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 10),
+                  decoration: BoxDecoration(
+                    color: Colors.white.withOpacity(0.9),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Column(
                     children: [
+                      Row(
+                        children: [
+                          const Text('Language & Country:'),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: DropdownButton<LocaleOption>(
+                              isExpanded: true,
+                              value: _selectedLocale,
+                              onChanged: (locale) {
+                                if (locale == null) {
+                                  return;
+                                }
+                                setState(() {
+                                  _selectedLocale = locale;
+                                  _updateWelcomeMessageForLocale();
+                                });
+                                unawaited(
+                                  widget.logger.info(
+                                    'Locale changed',
+                                    <String, Object?>{
+                                      'country': locale.countryCode,
+                                      'language': locale.languageCode,
+                                    },
+                                  ),
+                                );
+                                _apiClient.resetSession();
+                              },
+                              items: _localeOptions
+                                  .map(
+                                    (locale) => DropdownMenuItem<LocaleOption>(
+                                      value: locale,
+                                      child: Text(locale.label),
+                                    ),
+                                  )
+                                  .toList(),
+                            ),
+                          ),
+                        ],
+                      ),
+                      if (_showLocalResponderSwitch)
+                        Row(
+                          children: [
+                            const Text('Local mode:'),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: DropdownButton<ResponderMode>(
+                                isExpanded: true,
+                                value: _responderMode,
+                                onChanged: (mode) {
+                                  if (mode == null) {
+                                    return;
+                                  }
+                                  setState(() {
+                                    _responderMode = mode;
+                                  });
+                                  unawaited(
+                                    widget.logger.info(
+                                      'Responder mode changed',
+                                      <String, Object?>{
+                                        'responder_mode': mode.name,
+                                      },
+                                    ),
+                                  );
+                                  _apiClient.resetSession();
+                                },
+                                items: const [
+                                  DropdownMenuItem(
+                                    value: ResponderMode.aiUserSimulator,
+                                    child: Text('AI User Simulator Agent'),
+                                  ),
+                                  DropdownMenuItem(
+                                    value: ResponderMode.realPerson,
+                                    child: Text('Read User'),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(12, 2, 12, 12),
+                child: Row(
+                  children: [
                       IconButton(
                         onPressed: _captureDocument,
                         icon: const Icon(Icons.document_scanner),
-                        tooltip: 'Capture document',
+                        tooltip: 'Upload documents',
                       ),
                       const SizedBox(width: 8),
                       Expanded(
@@ -984,6 +1042,8 @@ class _ChatHomePageState extends State<ChatHomePage> {
                                 _responderMode == ResponderMode.aiUserSimulator
                                     ? 'Describe the case to start discussion...'
                                     : 'Ask your legal question...',
+                            filled: true,
+                            fillColor: Colors.white,
                             border: const OutlineInputBorder(),
                           ),
                         ),
@@ -1007,10 +1067,31 @@ class _ChatHomePageState extends State<ChatHomePage> {
                   ),
                 ),
               ),
-            ],
+              ],
+            ),
           ),
         ],
       ),
+    );
+  }
+}
+
+class _BrandIcon extends StatelessWidget {
+  const _BrandIcon({required this.path});
+
+  final String path;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 52,
+      height: 52,
+      padding: const EdgeInsets.all(6),
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(0.9),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: SvgPicture.asset(path),
     );
   }
 }

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -23,4 +23,8 @@ flutter:
   uses-material-design: true
   assets:
     - assets/branding/ai-logo.svg
-    - assets/branding/hero-graph.svg
+    - assets/branding/hero-footer.svg
+    - assets/branding/icon-ai-head.svg
+    - assets/branding/icon-scale.svg
+    - assets/branding/icon-doc-check.svg
+    - assets/branding/icon-court.svg


### PR DESCRIPTION
### Motivation
- Rebrand the Flutter mobile client from "AI Jurisdiction" to "AIJurisDictA / AI Juris Digital Agent" and refresh the chat UI to match new visual identity. 
- Surface a focused login card and legal-themed artwork while keeping the core chat/workflow intact for local API testing. 

### Description
- Updated app title and onboarding/welcome text and replaced the old logo and hero graphics with new SVG assets (`ai-logo.svg`, `hero-footer.svg`, and four icon SVGs) and wired them into the UI and `pubspec.yaml` assets list. 
- Restyled the chat snapshot preview (`docs/chat_ui_snapshot.html`) and README (`mobile_app/README.md`) to reflect the new branding, layout, copy and local-mode behavior. 
- Reworked `lib/main.dart` UI: added a login card and brand icon row, switched the background to the new gradient and `hero-footer.svg`, introduced `_BrandIcon` widget, adjusted text/input styles, and tweaked message hints and tooltips to match the rebrand. 
- Added conditional responder-mode selector visibility via `_showLocalResponderSwitch` which only shows the local-mode dropdown when `apiBaseUrl` points to local hosts (`localhost`, `127.0.0.1`, `10.0.2.2`, `0.0.0.0`) and renamed responder menu labels. 

### Testing
- Ran `flutter pub get` to refresh dependencies and update asset registration which completed successfully. 
- Performed a local smoke test with a debug run (`flutter run` on emulator) to verify assets render, the login/card UI appears, and the local responder switch logic behaves for `AIJ_API_BASE_URL` values; the smoke test succeeded. 
- Executed `flutter analyze` to catch obvious static issues and no analyzer errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8462961b08332923b765e185b6848)