### PR TITLE
docs: add mobile app retest report and validation results

### DIFF
--- a/docs/MOBILE_RETEST_REPORT.md
+++ b/docs/MOBILE_RETEST_REPORT.md
@@ -1,0 +1,59 @@
+# Mobile App Retest Report
+
+## Scope
+Retest requested areas:
+- AIUserSimulator automatic ask/answer flow.
+- PDF document creation and download from mobile app.
+- Language and country selection behavior.
+- AIAgentsValidator final accuracy score.
+- Law citation presence and click-through redirect behavior.
+
+## Test Execution Summary
+
+### 1) AIUserSimulator ask/answer flow
+**Result:** ✅ PASS (backend agent logic)
+
+Executed unit tests for agent behavior and orchestrated flow:
+- `tests/test_agents.py`
+- `tests/test_orchestrator.py`
+
+These verify simulator agent creation/use and orchestrated message progression, including citations in orchestrator output.
+
+### 2) PDF creation/download from mobile app
+**Result:** ❌ FAIL (feature not present in current mobile UI code)
+
+Retest found no mobile UI actions or API calls wired for:
+- `GET /v1/chat/sessions/{session_id}/export?format=pdf&kind=summary`
+- `GET /v1/chat/sessions/{session_id}/export?format=pdf&kind=document`
+
+The current Flutter app code includes chat/session/reply/stream and document-path attachment, but no explicit PDF export/download button or handler.
+
+### 3) Language and country selection
+**Result:** ✅ PASS (implemented in mobile UI)
+
+Retest confirms a `Language & Country` dropdown exists with locale options and session reset on change.
+
+### 4) AIAgentsValidator final accuracy score
+**Result:** ✅ PASS
+
+`python examples/validator_demo.py` output:
+- **Weighted accuracy: 66.97**
+
+### 5) Citation from law + clickable redirect
+**Result:** ❌ FAIL (not implemented in current mobile UI)
+
+Retest confirms:
+- Backend/orchestrator tests validate citation objects exist.
+- Current mobile chat bubble rendering displays message text only and does not render citation links or click handlers for source redirect.
+
+## Environment Notes
+- Flutter CLI is not installed in this environment (`flutter: command not found`), so widget/integration tests could not be executed here.
+- Python backend test coverage used as primary executable validation.
+
+## Recommendation
+To fully satisfy mobile citation and PDF requirements:
+1. Add API client methods for export endpoints.
+2. Add UI controls for summary/document PDF download/open.
+3. Extend message model to include source citations with URL/path metadata.
+4. Render citations as tappable links and open source documents via a URL launcher / in-app webview.
+5. Add Flutter widget/integration tests for locale selection, export buttons, and citation link taps.


### PR DESCRIPTION
### Motivation
- Document the outcomes of a focused retest of mobile and backend behaviors (AIUserSimulator ask/answer flow, PDF export/download, language/country selection, AIAgentsValidator scoring, and citation click-through) and record environment limitations and recommendations.

### Description
- Add `docs/MOBILE_RETEST_REPORT.md` which summarizes pass/fail status for each area, includes the validator weighted accuracy, notes missing mobile PDF and citation UI wiring, and provides concrete recommendations for implementing export endpoints and tappable citations.

### Testing
- Ran `pytest tests/test_agents.py tests/test_documents.py tests/test_validator.py tests/test_orchestrator.py -q` (all tests passed), executed `python examples/validator_demo.py` (produced `Weighted accuracy: 66.97`), attempted `cd mobile_app && flutter test` (failed due to missing `flutter` CLI), and ran `python examples/minimal_demo.py` (failed due to no local API at `localhost:8080`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a933ecd35883328ab2e3cc307e0d7e)