### PR TITLE
Add speech-to-text option for mobile question/answer input

### DIFF
--- a/examples/mobile_app_minimal_demo.md
+++ b/examples/mobile_app_minimal_demo.md
@@ -6,6 +6,8 @@ flutter pub get
 flutter run --dart-define=AIJ_API_BASE_URL=http://10.0.2.2:8080 --dart-define=AIJ_API_KEY=aijuris
 ```
 
+After launch, use the microphone icon in the chat input row to dictate a question or answer and then press send.
+
 Optional local API smoke request:
 
 ```bash

--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -7,6 +7,7 @@ Flutter mobile client prepared for local testing of the AIJurisDictA (AI Juris D
 - Chat-bot style conversation UI.
 - Rebranded mobile layout with login card at the top and blue legal-themed background from the footer artwork.
 - Add supporting documents using the device camera.
+- Add questions/answers by speech using the microphone button next to the chat input.
 - Message area is centered between login header and selectors.
 - Initial localized Jurisdicta welcome message shown on app start.
 - Language/country selector is shown below the message area (`SK` default, `EN`, `GE`, with `DE` accepted as alias for German).
@@ -40,6 +41,11 @@ For iOS simulator/local device, override `AIJ_API_BASE_URL` with your host IP, f
 ```bash
 flutter run --dart-define=AIJ_API_BASE_URL=http://127.0.0.1:8080 --dart-define=AIJ_API_KEY=aijuris
 ```
+
+
+### Speech input
+
+Use the microphone icon in the chat composer to dictate a message. Tap again to stop recording, then send the recognized text as a normal chat message.
 
 ## Local API contract
 

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -6,6 +6,9 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:http/http.dart' as http;
+import 'package:speech_to_text/speech_recognition_error.dart';
+import 'package:speech_to_text/speech_recognition_result.dart';
+import 'package:speech_to_text/speech_to_text.dart';
 
 import 'logging/app_logger.dart';
 
@@ -540,6 +543,7 @@ class _ChatHomePageState extends State<ChatHomePage> {
   static const double _communicationMinutes = 3;
 
   final TextEditingController _inputController = TextEditingController();
+  final SpeechToText _speechToText = SpeechToText();
 
   late final ApiClient _apiClient;
   late final List<ChatMessage> _messages;
@@ -547,6 +551,8 @@ class _ChatHomePageState extends State<ChatHomePage> {
   late LocaleOption _selectedLocale;
   String? _documentPath;
   bool _isSending = false;
+  bool _speechEnabled = false;
+  bool _isListening = false;
 
   bool get _showLocalResponderSwitch {
     final host = Uri.parse(widget.apiBaseUrl).host.toLowerCase();
@@ -595,6 +601,102 @@ class _ChatHomePageState extends State<ChatHomePage> {
         },
       ),
     );
+    unawaited(_initializeSpeechRecognition());
+  }
+
+  String _localeIdForSpeech(LocaleOption locale) {
+    switch (locale.languageCode.toUpperCase()) {
+      case 'SK':
+        return 'sk_SK';
+      case 'CS':
+        return 'cs_CZ';
+      case 'DE':
+      case 'GE':
+        return 'de_DE';
+      case 'EN':
+      default:
+        return 'en_US';
+    }
+  }
+
+  Future<void> _initializeSpeechRecognition() async {
+    final enabled = await _speechToText.initialize(
+      onError: _onSpeechError,
+      onStatus: _onSpeechStatus,
+    );
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _speechEnabled = enabled;
+    });
+    await widget.logger.info(
+      'Speech recognition initialized',
+      <String, Object?>{'enabled': enabled},
+    );
+  }
+
+  void _onSpeechResult(SpeechRecognitionResult result) {
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _inputController.text = result.recognizedWords;
+      _inputController.selection = TextSelection.fromPosition(
+        TextPosition(offset: _inputController.text.length),
+      );
+    });
+  }
+
+  void _onSpeechStatus(String status) {
+    if (!mounted) {
+      return;
+    }
+    final isListening = status == 'listening';
+    setState(() {
+      _isListening = isListening;
+    });
+    unawaited(
+      widget.logger.info(
+        'Speech status changed',
+        <String, Object?>{'status': status},
+      ),
+    );
+  }
+
+  void _onSpeechError(SpeechRecognitionError error) {
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _isListening = false;
+    });
+    _showSnackbar('Speech recognition error: ${error.errorMsg}');
+    unawaited(
+      widget.logger.error(
+        'Speech recognition error',
+        Exception(error.errorMsg),
+        StackTrace.current,
+        <String, Object?>{'permanent': error.permanent},
+      ),
+    );
+  }
+
+  Future<void> _toggleSpeechInput() async {
+    if (!_speechEnabled) {
+      _showSnackbar('Speech recognition is unavailable on this device.');
+      return;
+    }
+    if (_isListening) {
+      await _speechToText.stop();
+      return;
+    }
+    await _speechToText.listen(
+      onResult: _onSpeechResult,
+      partialResults: true,
+      localeId: _localeIdForSpeech(_selectedLocale),
+      listenMode: ListenMode.dictation,
+    );
   }
 
   void _updateWelcomeMessageForLocale() {
@@ -619,6 +721,7 @@ class _ChatHomePageState extends State<ChatHomePage> {
 
   @override
   void dispose() {
+    _speechToText.stop();
     _inputController.dispose();
     super.dispose();
   }
@@ -953,6 +1056,9 @@ class _ChatHomePageState extends State<ChatHomePage> {
                                   _selectedLocale = locale;
                                   _updateWelcomeMessageForLocale();
                                 });
+                                if (_isListening) {
+                                  unawaited(_speechToText.stop());
+                                }
                                 unawaited(
                                   widget.logger.info(
                                     'Locale changed',
@@ -1047,6 +1153,19 @@ class _ChatHomePageState extends State<ChatHomePage> {
                             border: const OutlineInputBorder(),
                           ),
                         ),
+                      ),
+                      const SizedBox(width: 8),
+                      IconButton(
+                        onPressed: _toggleSpeechInput,
+                        icon: Icon(
+                          _isListening ? Icons.mic : Icons.mic_none,
+                          color: _isListening
+                              ? Theme.of(context).colorScheme.primary
+                              : null,
+                        ),
+                        tooltip: _isListening
+                            ? 'Stop speech input'
+                            : 'Add question/answer by speech',
                       ),
                       const SizedBox(width: 8),
                       IconButton(

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   http: ^1.2.2
   path_provider: ^2.1.5
   flutter_svg: ^2.1.0
+  speech_to_text: ^6.6.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Motivation
- Provide mic-based speech input so mobile users can dictate questions and answers into the chat composer. 
- Respect selected locale when recognizing speech so recognized text matches the chosen language. 
- Ensure the speech lifecycle is cleanly managed (init, stop on locale change, stop on dispose) and documented for developers.

### Description
- Integrate `speech_to_text` and add imports in `mobile_app/lib/main.dart` and the `speech_to_text` dependency in `mobile_app/pubspec.yaml`.
- Add a `SpeechToText` instance, initialization (`_initializeSpeechRecognition`), locale mapping (`_localeIdForSpeech`), result/status/error handlers (`_onSpeechResult`, `_onSpeechStatus`, `_onSpeechError`) and a toggle action (`_toggleSpeechInput`) in `mobile_app/lib/main.dart`.
- Add a microphone `IconButton` next to the chat input that toggles listening and updates the input `TextField` with recognized words, and stop active listening on locale changes and during `dispose()`.
- Update documentation to explain speech input usage in `mobile_app/README.md` and `examples/mobile_app_minimal_demo.md`.

### Testing
- Ran `python examples/minimal_demo.py` which attempted a local API health check and failed because the local API at `localhost:8080` was not running (expected failure in this environment).
- Attempted `cd mobile_app && flutter --version` which failed because the Flutter SDK is not installed in the current environment (no Flutter build/test executed).
- Playwright/browser screenshot attempt against a local server failed with network errors because no app server was available (no end-to-end UI test executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a94446704883329e9620d5406f46db)