### PR TITLE
Add local-first API database/storage layer with Azure-ready config, docs, example, and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,16 @@ LLM_PROVIDER=mock
 # - tag only (example: latest)
 # - repository:tag (example: ai-api-juris-dev:latest)
 # AZURE_API_IMAGE_TAG=
+
+
+# API database/storage selection (local|azure)
+DB_OPTION=local
+STORAGE_OPTION=local
+
+# Local mode
+DB_LOCAL=./data/api.sqlite3
+STORE_LOCAL=./storage
+
+# Azure mode (set in GitHub environment secrets)
+# DB_CLOUD=postgresql://user:password@host:5432/dbname
+# STORE_CLOUD=DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...;EndpointSuffix=core.windows.net

--- a/README.md
+++ b/README.md
@@ -369,3 +369,7 @@ flutter run
 ```
 
 Technical design details: `docs/MOBILE_TECHNICAL_DESIGN.md`.
+
+## Examples
+
+- API database minimal demo: `python examples/api_database_minimal_demo.py`

--- a/docs/API_DATABASE_LAYER.md
+++ b/docs/API_DATABASE_LAYER.md
@@ -1,0 +1,78 @@
+# API database layer (local + container + Azure-ready)
+
+## Recommended approach
+
+For your feature set, use a **hybrid model**:
+
+1. **Relational SQL database** for metadata and relationships.
+2. **Object storage** for document/audio binaries.
+
+## Environment variables (local + cloud)
+
+Use these environment variables in local `.env`, Docker, and GitHub environment secrets.
+
+- `DB_OPTION`: `local` or `azure`
+- `STORAGE_OPTION`: `local` or `azure`
+- `DB_LOCAL`: local SQLite path (example: `./data/api.sqlite3`)
+- `DB_CLOUD`: cloud database connection string (PostgreSQL in Azure)
+- `STORE_LOCAL`: local storage root path (example: `./storage`)
+- `STORE_CLOUD`: Azure Storage connection string
+
+If you set:
+- `DB_OPTION=azure`, then `DB_CLOUD` is required.
+- `STORAGE_OPTION=azure`, then `STORE_CLOUD` is required.
+
+This aligns with your GitHub environment secrets plan:
+- `DB_OPTION=azure`
+- `STORAGE_OPTION=azure`
+- `DB_CLOUD=...`
+- `STORE_CLOUD=...`
+
+## Concrete technology choice
+
+### Phase 1 (now): local + Docker + basic cloud portability
+
+- **SQLite** for metadata (`api.sqlite3`) via `ApiDatabaseStore`.
+- Filesystem blob folder for stored assets.
+
+### Phase 2 (production): scalable and resilient
+
+- **Azure Database for PostgreSQL** for metadata.
+- **Azure Blob Storage** for documents/audio/generated files.
+
+
+## Case-scoped storage layout
+
+For both local and azure modes, all case artifacts are written under a `case_id` folder/prefix:
+
+- Documents: `<case_id>/<kind>/v<version>_<filename>`
+- Communications: `<case_id>/communications/<communication_id>.<ext>`
+
+This guarantees every case has an isolated storage namespace.
+
+## Supported domain entities
+
+- `users`: sign-up and login metadata.
+- `companies`: company profile.
+- `company_users`: user/company association and role.
+- `cases`: user/company legal cases.
+- `case_documents`: source/generated document metadata + versions.
+- `case_communications`: chat/audio transcript references and summaries.
+
+## Minimal demo
+
+```bash
+PYTHONPATH=src python examples/api_database_minimal_demo.py
+```
+
+## Docker notes
+
+Mount volumes for local mode:
+- `/app/data` for `DB_LOCAL`
+- `/app/blob` for `STORE_LOCAL`
+
+## Azure Container Apps notes
+
+- Use secrets for `DB_CLOUD` and `STORE_CLOUD`.
+- Keep `DB_OPTION=azure` and `STORAGE_OPTION=azure`.
+- This commit validates env contracts; production adapters can be plugged in next.

--- a/examples/api_database_minimal_demo.py
+++ b/examples/api_database_minimal_demo.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import tempfile
+
+from aijurisdictionagents.api_db import ApiDatabaseStore
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        store = ApiDatabaseStore(db_path=root / "api.sqlite3", blob_root=root / "blob")
+        store.initialize()
+
+        user = store.create_user(
+            email="mobile.user@example.com",
+            full_name="Mobile User",
+            password="change-me",
+        )
+        company = store.create_company(legal_name="Demo Company Ltd")
+        store.add_user_to_company(user_id=user.user_id, company_id=company.company_id, role="admin")
+
+        case = store.create_case(
+            user_id=user.user_id,
+            company_id=company.company_id,
+            title="Employment contract review",
+        )
+        store.add_case_document(
+            case_id=case.case_id,
+            kind="source",
+            version=1,
+            original_filename="contract.docx",
+            payload=b"sample-binary-content",
+            uploaded_by_user_id=user.user_id,
+        )
+        store.add_case_communication(
+            case_id=case.case_id,
+            channel="audio",
+            summary="Initial consultation recorded.",
+            transcript_payload=b"audio transcript content",
+            extension="txt",
+        )
+
+        print(f"Created user: {user.email}")
+        print(f"Created company: {company.legal_name}")
+        print(f"Created case: {case.case_id}")
+        print(f"SQLite file: {store.db_path}")
+        print(f"Blob root: {store.blob_root}")
+        print("Tip: configure DB_OPTION/STORAGE_OPTION + DB_CLOUD/STORE_CLOUD for Azure mode.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aijurisdictionagents/api_db/__init__.py
+++ b/src/aijurisdictionagents/api_db/__init__.py
@@ -1,0 +1,4 @@
+from .config import ApiDataConfig
+from .store import ApiDatabaseStore, Case, Company, User
+
+__all__ = ["ApiDataConfig", "ApiDatabaseStore", "Case", "Company", "User"]

--- a/src/aijurisdictionagents/api_db/config.py
+++ b/src/aijurisdictionagents/api_db/config.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ApiDataConfig:
+    db_option: str
+    storage_option: str
+    db_local: str
+    db_cloud: str
+    store_local: str
+    store_cloud: str
+
+    @classmethod
+    def from_env(cls) -> "ApiDataConfig":
+        return cls(
+            db_option=os.getenv("DB_OPTION", "local").strip().lower(),
+            storage_option=os.getenv("STORAGE_OPTION", "local").strip().lower(),
+            db_local=os.getenv("DB_LOCAL", "./data/api.sqlite3").strip(),
+            db_cloud=os.getenv("DB_CLOUD", "").strip(),
+            store_local=os.getenv("STORE_LOCAL", "./storage").strip(),
+            store_cloud=os.getenv("STORE_CLOUD", "").strip(),
+        )
+
+    def validate(self) -> None:
+        if self.db_option not in {"local", "azure"}:
+            raise ValueError("DB_OPTION must be one of: local, azure")
+        if self.storage_option not in {"local", "azure"}:
+            raise ValueError("STORAGE_OPTION must be one of: local, azure")
+        if self.db_option == "azure" and not self.db_cloud:
+            raise ValueError("DB_CLOUD must be set when DB_OPTION=azure")
+        if self.storage_option == "azure" and not self.store_cloud:
+            raise ValueError("STORE_CLOUD must be set when STORAGE_OPTION=azure")
+
+    @property
+    def db_path(self) -> Path:
+        if self.db_option == "local":
+            return Path(self.db_local)
+        # Cloud DB configured via connection string (for PostgreSQL adapter in prod).
+        # During local development/tests this still needs a local metadata path.
+        return Path(self.db_local)
+
+    @property
+    def blob_root(self) -> Path:
+        if self.storage_option == "local":
+            return Path(self.store_local)
+        # Cloud storage configured via connection string (for Azure Blob adapter in prod).
+        # During local development/tests this still needs a local cache/staging path.
+        return Path(self.store_local)

--- a/src/aijurisdictionagents/api_db/store.py
+++ b/src/aijurisdictionagents/api_db/store.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import hmac
+import os
+from pathlib import Path
+import sqlite3
+import uuid
+
+from .config import ApiDataConfig
+
+
+@dataclass(frozen=True)
+class User:
+    user_id: str
+    email: str
+    full_name: str
+
+
+@dataclass(frozen=True)
+class Company:
+    company_id: str
+    legal_name: str
+
+
+@dataclass(frozen=True)
+class Case:
+    case_id: str
+    user_id: str
+    company_id: str | None
+    title: str
+
+
+class ApiDatabaseStore:
+    """Local-first API metadata store using SQLite + external blob storage references.
+
+    Storage backend supports local path writes and Azure URI prefixes while keeping
+    a case-scoped folder layout (`<case_id>/...`) for every stored artifact.
+    """
+
+    def __init__(
+        self,
+        *,
+        db_path: Path,
+        blob_root: Path,
+        storage_option: str = "local",
+        store_cloud: str = "",
+    ) -> None:
+        self.db_path = db_path
+        self.blob_root = blob_root
+        self.storage_option = storage_option
+        self.store_cloud = store_cloud
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.blob_root.mkdir(parents=True, exist_ok=True)
+
+    @classmethod
+    def from_env(cls) -> "ApiDatabaseStore":
+        config = ApiDataConfig.from_env()
+        config.validate()
+        return cls(
+            db_path=config.db_path,
+            blob_root=config.blob_root,
+            storage_option=config.storage_option,
+            store_cloud=config.store_cloud,
+        )
+
+    def initialize(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                PRAGMA foreign_keys = ON;
+
+                CREATE TABLE IF NOT EXISTS users (
+                    user_id TEXT PRIMARY KEY,
+                    email TEXT UNIQUE NOT NULL,
+                    full_name TEXT NOT NULL,
+                    password_hash TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS companies (
+                    company_id TEXT PRIMARY KEY,
+                    legal_name TEXT NOT NULL,
+                    profile_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS company_users (
+                    company_id TEXT NOT NULL,
+                    user_id TEXT NOT NULL,
+                    role TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    PRIMARY KEY(company_id, user_id),
+                    FOREIGN KEY(company_id) REFERENCES companies(company_id) ON DELETE CASCADE,
+                    FOREIGN KEY(user_id) REFERENCES users(user_id) ON DELETE CASCADE
+                );
+
+                CREATE TABLE IF NOT EXISTS cases (
+                    case_id TEXT PRIMARY KEY,
+                    user_id TEXT NOT NULL,
+                    company_id TEXT,
+                    title TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    FOREIGN KEY(user_id) REFERENCES users(user_id),
+                    FOREIGN KEY(company_id) REFERENCES companies(company_id)
+                );
+
+                CREATE TABLE IF NOT EXISTS case_documents (
+                    doc_id TEXT PRIMARY KEY,
+                    case_id TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    version INTEGER NOT NULL,
+                    storage_uri TEXT NOT NULL,
+                    original_filename TEXT NOT NULL,
+                    uploaded_by_user_id TEXT,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY(case_id) REFERENCES cases(case_id) ON DELETE CASCADE,
+                    FOREIGN KEY(uploaded_by_user_id) REFERENCES users(user_id)
+                );
+
+                CREATE TABLE IF NOT EXISTS case_communications (
+                    communication_id TEXT PRIMARY KEY,
+                    case_id TEXT NOT NULL,
+                    channel TEXT NOT NULL,
+                    transcript_uri TEXT,
+                    summary TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY(case_id) REFERENCES cases(case_id) ON DELETE CASCADE
+                );
+                """
+            )
+
+    def create_user(self, *, email: str, full_name: str, password: str) -> User:
+        user_id = str(uuid.uuid4())
+        now = _now_iso()
+        password_hash = _hash_password(password)
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO users(user_id, email, full_name, password_hash, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (user_id, email.lower(), full_name, password_hash, now),
+            )
+        return User(user_id=user_id, email=email.lower(), full_name=full_name)
+
+    def authenticate_user(self, *, email: str, password: str) -> User | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT user_id, email, full_name, password_hash FROM users WHERE email = ?",
+                (email.lower(),),
+            ).fetchone()
+
+        if row is None:
+            return None
+        if not _verify_password(password, row[3]):
+            return None
+        return User(user_id=row[0], email=row[1], full_name=row[2])
+
+    def create_company(self, *, legal_name: str, profile_json: str = "{}") -> Company:
+        company_id = str(uuid.uuid4())
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO companies(company_id, legal_name, profile_json, created_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (company_id, legal_name, profile_json, _now_iso()),
+            )
+        return Company(company_id=company_id, legal_name=legal_name)
+
+    def add_user_to_company(self, *, user_id: str, company_id: str, role: str) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO company_users(company_id, user_id, role, created_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (company_id, user_id, role, _now_iso()),
+            )
+
+    def create_case(self, *, user_id: str, company_id: str | None, title: str) -> Case:
+        case_id = str(uuid.uuid4())
+        now = _now_iso()
+        self._ensure_case_root(case_id)
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO cases(case_id, user_id, company_id, title, status, created_at, updated_at)
+                VALUES (?, ?, ?, ?, 'open', ?, ?)
+                """,
+                (case_id, user_id, company_id, title, now, now),
+            )
+        return Case(case_id=case_id, user_id=user_id, company_id=company_id, title=title)
+
+    def add_case_document(
+        self,
+        *,
+        case_id: str,
+        kind: str,
+        version: int,
+        original_filename: str,
+        payload: bytes,
+        uploaded_by_user_id: str | None = None,
+    ) -> str:
+        doc_id = str(uuid.uuid4())
+        relative_uri = Path(case_id) / kind / f"v{version}_{original_filename}"
+        storage_uri = self._store_payload(relative_uri=relative_uri, payload=payload)
+
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO case_documents(
+                    doc_id, case_id, kind, version, storage_uri, original_filename, uploaded_by_user_id, created_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    doc_id,
+                    case_id,
+                    kind,
+                    version,
+                    storage_uri,
+                    original_filename,
+                    uploaded_by_user_id,
+                    _now_iso(),
+                ),
+            )
+            conn.execute(
+                "UPDATE cases SET updated_at = ? WHERE case_id = ?",
+                (_now_iso(), case_id),
+            )
+        return doc_id
+
+    def add_case_communication(
+        self,
+        *,
+        case_id: str,
+        channel: str,
+        summary: str,
+        transcript_payload: bytes | None = None,
+        extension: str = "txt",
+    ) -> str:
+        communication_id = str(uuid.uuid4())
+        transcript_uri: str | None = None
+        if transcript_payload is not None:
+            relative_uri = Path(case_id) / "communications" / f"{communication_id}.{extension}"
+            transcript_uri = self._store_payload(relative_uri=relative_uri, payload=transcript_payload)
+
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO case_communications(
+                    communication_id, case_id, channel, transcript_uri, summary, created_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (communication_id, case_id, channel, transcript_uri, summary, _now_iso()),
+            )
+            conn.execute(
+                "UPDATE cases SET updated_at = ? WHERE case_id = ?",
+                (_now_iso(), case_id),
+            )
+        return communication_id
+
+    def _ensure_case_root(self, case_id: str) -> None:
+        (self.blob_root / case_id).mkdir(parents=True, exist_ok=True)
+
+    def _store_payload(self, *, relative_uri: Path, payload: bytes) -> str:
+        case_id = relative_uri.parts[0]
+        self._ensure_case_root(case_id)
+
+        local_destination = self.blob_root / relative_uri
+        local_destination.parent.mkdir(parents=True, exist_ok=True)
+        local_destination.write_bytes(payload)
+
+        if self.storage_option == "azure":
+            if not self.store_cloud:
+                raise ValueError("STORE_CLOUD is required when storage_option=azure")
+            prefix = self.store_cloud.rstrip("/")
+            return f"{prefix}/{relative_uri.as_posix()}"
+
+        return relative_uri.as_posix()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("PRAGMA foreign_keys = ON;")
+        return conn
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _hash_password(password: str) -> str:
+    salt = os.urandom(16)
+    digest = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, 100_000)
+    return f"{salt.hex()}:{digest.hex()}"
+
+
+def _verify_password(password: str, encoded: str) -> bool:
+    salt_hex, digest_hex = encoded.split(":", maxsplit=1)
+    salt = bytes.fromhex(salt_hex)
+    expected = bytes.fromhex(digest_hex)
+    candidate = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, 100_000)
+    return hmac.compare_digest(candidate, expected)

--- a/tests/test_api_database_layer.py
+++ b/tests/test_api_database_layer.py
@@ -1,0 +1,111 @@
+from pathlib import Path
+import sqlite3
+
+from aijurisdictionagents.api_db import ApiDataConfig, ApiDatabaseStore
+
+
+def test_api_database_layer_end_to_end(tmp_path: Path) -> None:
+    store = ApiDatabaseStore(db_path=tmp_path / "api.sqlite3", blob_root=tmp_path / "blob")
+    store.initialize()
+
+    user = store.create_user(
+        email="founder@example.com",
+        full_name="Founder User",
+        password="secret-pass",
+    )
+    authenticated = store.authenticate_user(email="founder@example.com", password="secret-pass")
+    assert authenticated is not None
+    assert authenticated.user_id == user.user_id
+
+    company = store.create_company(legal_name="Acme Legal s.r.o.")
+    store.add_user_to_company(user_id=user.user_id, company_id=company.company_id, role="owner")
+
+    case = store.create_case(
+        user_id=user.user_id,
+        company_id=company.company_id,
+        title="Supplier payment dispute",
+    )
+
+    doc_id = store.add_case_document(
+        case_id=case.case_id,
+        kind="source",
+        version=1,
+        original_filename="invoice.pdf",
+        payload=b"file-content",
+        uploaded_by_user_id=user.user_id,
+    )
+    assert doc_id
+
+    communication_id = store.add_case_communication(
+        case_id=case.case_id,
+        channel="chat",
+        summary="Client provided additional context",
+        transcript_payload=b"chat transcript",
+        extension="txt",
+    )
+    assert communication_id
+
+    case_root = tmp_path / "blob" / case.case_id
+    assert case_root.exists()
+    assert (case_root / "source" / "v1_invoice.pdf").exists()
+
+
+def test_api_database_config_from_env_local(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("DB_OPTION", "local")
+    monkeypatch.setenv("STORAGE_OPTION", "local")
+    monkeypatch.setenv("DB_LOCAL", str(tmp_path / "api.sqlite3"))
+    monkeypatch.setenv("STORE_LOCAL", str(tmp_path / "blob"))
+
+    config = ApiDataConfig.from_env()
+    config.validate()
+
+    store = ApiDatabaseStore.from_env()
+    assert store.db_path == tmp_path / "api.sqlite3"
+    assert store.blob_root == tmp_path / "blob"
+
+
+def test_api_database_config_requires_cloud_values(monkeypatch) -> None:
+    monkeypatch.setenv("DB_OPTION", "azure")
+    monkeypatch.setenv("STORAGE_OPTION", "azure")
+    monkeypatch.delenv("DB_CLOUD", raising=False)
+    monkeypatch.delenv("STORE_CLOUD", raising=False)
+
+    config = ApiDataConfig.from_env()
+
+    try:
+        config.validate()
+    except ValueError as exc:
+        assert "DB_CLOUD" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError when cloud options are set without secrets")
+
+
+def test_azure_storage_uri_keeps_case_folder_prefix(tmp_path: Path) -> None:
+    store = ApiDatabaseStore(
+        db_path=tmp_path / "api.sqlite3",
+        blob_root=tmp_path / "blob",
+        storage_option="azure",
+        store_cloud="https://example.blob.core.windows.net/cases",
+    )
+    store.initialize()
+
+    user = store.create_user(email="azure@example.com", full_name="Azure User", password="secret")
+    case = store.create_case(user_id=user.user_id, company_id=None, title="Cloud case")
+
+    store.add_case_document(
+        case_id=case.case_id,
+        kind="generated",
+        version=2,
+        original_filename="memo.docx",
+        payload=b"memo",
+        uploaded_by_user_id=user.user_id,
+    )
+
+    with sqlite3.connect(store.db_path) as conn:
+        row = conn.execute("SELECT storage_uri FROM case_documents LIMIT 1").fetchone()
+
+    assert row is not None
+    uri = row[0]
+    assert uri.startswith("https://example.blob.core.windows.net/cases/")
+    assert f"/{case.case_id}/generated/" in uri
+    assert (tmp_path / "blob" / case.case_id / "generated" / "v2_memo.docx").exists()


### PR DESCRIPTION
### Motivation

- Provide a simple local-first metadata store and blob layout for cases that can be switched to Azure later. 
- Standardize environment variables and contracts for DB and storage selection to support local and cloud deployments. 

### Description

- Add a new API database package under `src/aijurisdictionagents/api_db` implementing `ApiDatabaseStore`, domain types (`User`, `Company`, `Case`), and `ApiDataConfig` for env-driven configuration. 
- Implement local SQLite schema, file-based blob storage, and an Azure URI option in `store.py` with password hashing and authentication helpers. 
- Add documentation `docs/API_DATABASE_LAYER.md`, an example script `examples/api_database_minimal_demo.py`, and register the package in `__init__.py`. 
- Update `.env.example` with `DB_OPTION`, `STORAGE_OPTION`, local/cloud placeholders and add a short `## Examples` pointer in `README.md`. 
- Add end-to-end unit tests in `tests/test_api_database_layer.py` covering initialization, user/company/case flows, document/communication storage, env config validation, and Azure URI behavior. 

### Testing

- Ran `pytest tests/test_api_database_layer.py` and the test suite passed successfully. 
- The tests exercise `ApiDatabaseStore.initialize`, `create_user`, `authenticate_user`, `create_company`, `create_case`, `add_case_document`, and `add_case_communication` and verified on-disk blobs and stored URIs. 
- `ApiDataConfig.from_env()` and `validate()` behavior was tested for both local and missing-cloud-secret error conditions and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa9f7001fc83328efa634d3416cff0)