### PR TITLE
Add start-api skill and default to Azure Foundry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-# LLM_PROVIDER options: mock | openai | azurefoundry
-LLM_PROVIDER=mock
+# LLM_PROVIDER options: azurefoundry | openai | mock
+LLM_PROVIDER=azurefoundry
 
 # OpenAI
 # OPENAI_KEY=your_key_here

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,3 +33,9 @@ If the user asks to close a task:
 - Add a comment to the issue with the review/merge outcome.
 - Delete the feature branch and comment that deletion on the issue.
 - Move the task to Done (closed).
+
+Custom project skills:
+
+- `start-api` at `skills/start-api/SKILL.md`
+  - Purpose: start and health-check local `aijuristiction-api`.
+  - Script: `.\skills\start-api\scripts\start_api.ps1`

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Trace artifacts are written to `runs/YYYYMMDD_HHMMSS/`:
 - `run.log`
 - `trace.jsonl`
 
-`run.log` includes the active LLM provider (mock/OpenAI) at startup.
+`run.log` includes the active LLM provider (azurefoundry/openai/mock) at startup.
 When using Azure Foundry, `run.log` also records the auth method, endpoint, deployment, API version, and temperature,
 and temperature at INFO level.
 `run.log` also includes masked token details at DEBUG level (never the full key).
@@ -300,6 +300,18 @@ Local API docs (when API runs on port `8080`):
 - Swagger UI: `http://localhost:8080/docs`
 - OpenAPI JSON: `http://localhost:8080/openapi.json`
 
+Project skill for local API startup:
+
+```powershell
+.\skills\start-api\scripts\start_api.ps1
+```
+
+Background mode:
+
+```powershell
+.\skills\start-api\scripts\start_api.ps1 -Background
+```
+
 For full details, see `infra/README.md`.
 
 ## Corporate website
@@ -336,7 +348,8 @@ Live URL: `https://www.aiagenticsolutions.eu/`
 
 ## Assumptions
 
-- The default LLM provider is a deterministic mock (`LLM_PROVIDER=mock`).
+- The default LLM provider is Azure Foundry (`LLM_PROVIDER=azurefoundry`).
+- For local deterministic smoke testing without cloud credentials, set `LLM_PROVIDER=mock`.
 - PDF ingestion is optional and requires installing `pypdf`.
 - The initial version keeps all conversation state in memory.
 

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -3,6 +3,10 @@
 Run API first:
     uvicorn app.main:app --reload --port 8080 --app-dir api/aijuristiction-api
 
+By default, API uses LLM_PROVIDER=azurefoundry.
+For local smoke testing without Azure credentials:
+    LLM_PROVIDER=mock uvicorn app.main:app --reload --port 8080 --app-dir api/aijuristiction-api
+
 Then:
     python examples/minimal_demo.py
 """

--- a/skills/start-api/SKILL.md
+++ b/skills/start-api/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: start-api
+description: Start and verify the local `aijuristiction-api` service in this monorepo. Use when asked to "start api", "run backend locally", "bring up fastapi", "launch local server", or "health-check the API". Prefer this workflow for reliable local startup with the project `.conda` interpreter, default `LLM_PROVIDER=azurefoundry`, optional mock mode, and explicit health verification.
+---
+
+# Start API
+
+## Workflow
+
+1. Run the bundled startup script from repository root:
+   `.\skills\start-api\scripts\start_api.ps1`
+2. Keep default provider (`azurefoundry`) unless deterministic offline testing is needed.
+3. Verify `GET /health` is reachable at `http://127.0.0.1:8080/health`.
+4. Run the minimal example:
+   `python examples/minimal_demo.py`
+
+## Commands
+
+- Foreground start (default):
+  `.\skills\start-api\scripts\start_api.ps1`
+- Background start:
+  `.\skills\start-api\scripts\start_api.ps1 -Background`
+- Background start with mock provider:
+  `.\skills\start-api\scripts\start_api.ps1 -Background -LlmProvider mock`
+- Custom port:
+  `.\skills\start-api\scripts\start_api.ps1 -Port 8081`
+
+## Stop API
+
+If started with `-Background`, stop via:
+
+`Stop-Process -Id (Get-Content .\runs\api-local.pid) -Force`
+
+## Environment Notes
+
+- Default provider is `azurefoundry`.
+- For Azure Foundry requests, set:
+  `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT`, and either `AZURE_OPENAI_API_KEY` or `AZURE_OPENAI_AD_TOKEN`.
+- Use `-LlmProvider mock` for local smoke checks without cloud credentials.

--- a/skills/start-api/agents/openai.yaml
+++ b/skills/start-api/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Start API"
+  short_description: "Start and health-check local API service"
+  default_prompt: "Start the local aijuristiction API on port 8080 and verify /health."

--- a/skills/start-api/scripts/start_api.ps1
+++ b/skills/start-api/scripts/start_api.ps1
@@ -1,0 +1,122 @@
+param(
+    [ValidateSet("azurefoundry", "openai", "mock")]
+    [string]$LlmProvider = "azurefoundry",
+    [string]$BindHost = "127.0.0.1",
+    [int]$Port = 8080,
+    [switch]$Background,
+    [switch]$Reload,
+    [switch]$Install
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-PythonPath {
+    param([string]$RepoRoot)
+
+    $condaPython = Join-Path $RepoRoot ".conda\\python.exe"
+    if (Test-Path $condaPython) {
+        return $condaPython
+    }
+
+    $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+    if ($pythonCmd) {
+        return $pythonCmd.Source
+    }
+
+    throw "Python interpreter not found. Create .conda env or add python to PATH."
+}
+
+function Test-ApiHealth {
+    param(
+        [string]$TargetHost,
+        [int]$TargetPort
+    )
+
+    $url = "http://$TargetHost`:$TargetPort/health"
+    try {
+        $response = Invoke-WebRequest -UseBasicParsing -Uri $url -TimeoutSec 3
+        if ($response.StatusCode -eq 200) {
+            return $true
+        }
+    } catch {
+        return $false
+    }
+    return $false
+}
+
+$skillScriptsDir = $PSScriptRoot
+$repoRoot = Resolve-Path (Join-Path $skillScriptsDir "..\\..\\..")
+$apiDir = Join-Path $repoRoot "api\\aijuristiction-api"
+
+if (-not (Test-Path $apiDir)) {
+    throw "API project folder not found: $apiDir"
+}
+
+$python = Resolve-PythonPath -RepoRoot $repoRoot
+$env:LLM_PROVIDER = $LlmProvider
+
+if ($Install) {
+    Push-Location $apiDir
+    try {
+        & $python -m pip install -e ".[dev]"
+    } finally {
+        Pop-Location
+    }
+}
+
+$uvicornArgs = @("-m", "uvicorn", "app.main:app", "--host", $BindHost, "--port", "$Port")
+if ($Reload) {
+    $uvicornArgs += "--reload"
+}
+
+if ($Background) {
+    $runsDir = Join-Path $repoRoot "runs"
+    if (-not (Test-Path $runsDir)) {
+        New-Item -Path $runsDir -ItemType Directory | Out-Null
+    }
+
+    $stdoutLog = Join-Path $runsDir "api-local.log"
+    $stderrLog = Join-Path $runsDir "api-local.err.log"
+    $pidFile = Join-Path $runsDir "api-local.pid"
+
+    if (Test-Path $stdoutLog) { Remove-Item $stdoutLog -Force }
+    if (Test-Path $stderrLog) { Remove-Item $stderrLog -Force }
+
+    $process = Start-Process `
+        -FilePath $python `
+        -ArgumentList $uvicornArgs `
+        -WorkingDirectory $apiDir `
+        -RedirectStandardOutput $stdoutLog `
+        -RedirectStandardError $stderrLog `
+        -PassThru
+
+    Start-Sleep -Seconds 3
+
+    if (-not (Get-Process -Id $process.Id -ErrorAction SilentlyContinue)) {
+        throw "API process exited immediately. Check $stderrLog"
+    }
+
+    $process.Id | Out-File -FilePath $pidFile -Encoding ascii -NoNewline
+
+    $isHealthy = Test-ApiHealth -TargetHost $BindHost -TargetPort $Port
+    if ($isHealthy) {
+        Write-Output "API started in background. PID: $($process.Id)"
+        Write-Output "Health: http://$BindHost`:$Port/health"
+        Write-Output "Docs: http://$BindHost`:$Port/docs"
+        Write-Output "Stop: Stop-Process -Id (Get-Content `"$pidFile`") -Force"
+    } else {
+        Write-Warning "API started (PID $($process.Id)) but health endpoint is not ready yet."
+        Write-Output "Check logs:"
+        Write-Output "  $stdoutLog"
+        Write-Output "  $stderrLog"
+    }
+    exit 0
+}
+
+Write-Output "Starting API in foreground on http://$BindHost`:$Port (LLM_PROVIDER=$LlmProvider)"
+Push-Location $apiDir
+try {
+    & $python @uvicornArgs
+} finally {
+    Pop-Location
+}

--- a/src/aijurisdictionagents/cli.py
+++ b/src/aijurisdictionagents/cli.py
@@ -214,7 +214,7 @@ def main() -> int:
         args.language or "user_input_language",
     )
 
-    provider = os.getenv("LLM_PROVIDER", "mock").lower()
+    provider = os.getenv("LLM_PROVIDER", "azurefoundry").lower()
     logger.info("LLM provider requested: %s", provider)
     _log_token_info(logger, provider)
     llm = get_llm_client()

--- a/src/aijurisdictionagents/llm/__init__.py
+++ b/src/aijurisdictionagents/llm/__init__.py
@@ -22,7 +22,7 @@ except ImportError:  # pragma: no cover - only triggers when OpenAI deps are mis
 
 
 def get_llm_client() -> LLMClient:
-    provider = os.getenv("LLM_PROVIDER", "mock").lower()
+    provider = os.getenv("LLM_PROVIDER", "azurefoundry").lower()
     if provider == "mock":
         return MockLLMClient()
     if provider == "openai":


### PR DESCRIPTION
## Summary
- add a project-local start-api skill with a PowerShell launcher and OpenAI skill metadata
- make Azure Foundry the default LLM provider fallback across CLI/runtime/env docs
- document the new API startup workflow in the repo docs

## Validation
- python -m compileall src/aijurisdictionagents/llm/__init__.py src/aijurisdictionagents/cli.py examples/minimal_demo.py
- quick_validate.py skills/start-api
- runtime probe confirming fallback resolves to AzureFoundryClient when LLM_PROVIDER is unset
