### PR TITLE
Improve mobile app startup and camera error handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,6 @@ Custom project skills:
 - `start-api` at `skills/start-api/SKILL.md`
   - Purpose: start and health-check local `aijuristiction-api`.
   - Script: `.\skills\start-api\scripts\start_api.ps1`
+- `start-mobile-app` at `skills/start-mobile-app/SKILL.md`
+  - Purpose: start and verify the local Flutter mobile app.
+  - Script: `.\skills\start-mobile-app\scripts\start_mobile_app.ps1`

--- a/README.md
+++ b/README.md
@@ -341,6 +341,18 @@ npm run dev
 
 Then open `http://localhost:5173` in a browser. For details, see `docs/FRONTEND_DEMO.md`.
 
+## Mobile app
+
+Project skill for local mobile app startup:
+
+```powershell
+.\skills\start-mobile-app\scripts\start_mobile_app.ps1 -Background
+```
+
+This launcher now asks for `localApi` or `publicDevApi`.
+If you choose `localApi`, it starts the API in a visible console window so live API logs are shown there.
+Use `-ConsoleWindow` if you also want live Flutter logs in a separate terminal window.
+
 ### Deployment
 
 The corporate site is deployed via GitHub Actions (`corporate_web` workflow) using FTP per environment.

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -131,11 +131,20 @@ Future<void> main() async {
       'log_file': logger.logFilePath,
     },
   );
-  final cameras = await availableCameras();
-  await logger.info(
-    'Camera discovery completed',
-    <String, Object?>{'camera_count': cameras.length},
-  );
+  List<CameraDescription> cameras = <CameraDescription>[];
+  try {
+    cameras = await availableCameras();
+    await logger.info(
+      'Camera discovery completed',
+      <String, Object?>{'camera_count': cameras.length},
+    );
+  } catch (error, stackTrace) {
+    await logger.error(
+      'Camera discovery failed',
+      error,
+      stackTrace,
+    );
+  }
   runApp(AIJurisdictionMobileApp(
       cameras: cameras, logger: logger, apiBaseUrl: apiBaseUrl));
 }
@@ -1834,7 +1843,10 @@ class _ChatHomePageState extends State<ChatHomePage> {
 
     final path = await Navigator.of(context).push<String>(
       MaterialPageRoute<String>(
-        builder: (_) => CameraCapturePage(camera: widget.cameras.first),
+        builder: (_) => CameraCapturePage(
+          camera: widget.cameras.first,
+          logger: widget.logger,
+        ),
       ),
     );
     if (!mounted) {
@@ -2505,9 +2517,14 @@ class _BrandIcon extends StatelessWidget {
 }
 
 class CameraCapturePage extends StatefulWidget {
-  const CameraCapturePage({super.key, required this.camera});
+  const CameraCapturePage({
+    super.key,
+    required this.camera,
+    required this.logger,
+  });
 
   final CameraDescription camera;
+  final AppLogger logger;
 
   @override
   State<CameraCapturePage> createState() => _CameraCapturePageState();
@@ -2516,12 +2533,61 @@ class CameraCapturePage extends StatefulWidget {
 class _CameraCapturePageState extends State<CameraCapturePage> {
   CameraController? _controller;
   Future<void>? _initializeControllerFuture;
+  String? _cameraErrorMessage;
 
   @override
   void initState() {
     super.initState();
     _controller = CameraController(widget.camera, ResolutionPreset.medium);
-    _initializeControllerFuture = _controller!.initialize();
+    _initializeControllerFuture = _initializeCamera();
+  }
+
+  Future<void> _initializeCamera() async {
+    final controller = _controller;
+    if (controller == null) {
+      return;
+    }
+
+    try {
+      await controller.initialize();
+    } on CameraException catch (error, stackTrace) {
+      await widget.logger.error(
+        'Camera initialization failed',
+        error,
+        stackTrace,
+        <String, Object?>{'camera_error_code': error.code},
+      );
+      final message = _cameraErrorMessageFor(error);
+      if (mounted) {
+        setState(() {
+          _cameraErrorMessage = message;
+        });
+      }
+    } catch (error, stackTrace) {
+      await widget.logger.error(
+        'Unexpected camera initialization failure',
+        error,
+        stackTrace,
+      );
+      if (mounted) {
+        setState(() {
+          _cameraErrorMessage =
+              'Could not initialize camera. Try again or use another device.';
+        });
+      }
+    }
+  }
+
+  String _cameraErrorMessageFor(CameraException error) {
+    switch (error.code) {
+      case 'cameraNotReadable':
+        return 'Camera is busy or unavailable. Close other apps using the camera and try again.';
+      case 'CameraAccessDenied':
+      case 'cameraAccessDenied':
+        return 'Camera access was denied. Allow camera permission in the browser and try again.';
+      default:
+        return 'Could not initialize camera. ${error.description ?? error.code}';
+    }
   }
 
   @override
@@ -2536,10 +2602,42 @@ class _CameraCapturePageState extends State<CameraCapturePage> {
       return;
     }
 
-    await _initializeControllerFuture;
-    final image = await controller.takePicture();
-    if (mounted) {
-      Navigator.of(context).pop(image.path);
+    try {
+      await _initializeControllerFuture;
+      if (_cameraErrorMessage != null) {
+        return;
+      }
+      final image = await controller.takePicture();
+      if (mounted) {
+        Navigator.of(context).pop(image.path);
+      }
+    } on CameraException catch (error, stackTrace) {
+      await widget.logger.error(
+        'Camera capture failed',
+        error,
+        stackTrace,
+        <String, Object?>{'camera_error_code': error.code},
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(_cameraErrorMessageFor(error))),
+        );
+      }
+    } catch (error, stackTrace) {
+      await widget.logger.error(
+        'Unexpected camera capture failure',
+        error,
+        stackTrace,
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Could not capture the image. Try again or use another device.',
+            ),
+          ),
+        );
+      }
     }
   }
 
@@ -2550,6 +2648,18 @@ class _CameraCapturePageState extends State<CameraCapturePage> {
       body: FutureBuilder<void>(
         future: _initializeControllerFuture,
         builder: (context, snapshot) {
+          if (_cameraErrorMessage != null) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  _cameraErrorMessage!,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+
           if (snapshot.connectionState == ConnectionState.done &&
               _controller != null) {
             return Stack(
@@ -2573,7 +2683,13 @@ class _CameraCapturePageState extends State<CameraCapturePage> {
 
           if (snapshot.hasError) {
             return Center(
-              child: Text('Could not initialize camera: ${snapshot.error}'),
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  'Could not initialize camera. ${snapshot.error}',
+                  textAlign: TextAlign.center,
+                ),
+              ),
             );
           }
 

--- a/mobile_app/pubspec.lock
+++ b/mobile_app/pubspec.lock
@@ -268,10 +268,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -561,10 +561,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/skills/start-api/SKILL.md
+++ b/skills/start-api/SKILL.md
@@ -20,6 +20,8 @@ description: Start and verify the local `aijuristiction-api` service in this mon
   `.\skills\start-api\scripts\start_api.ps1`
 - Background start:
   `.\skills\start-api\scripts\start_api.ps1 -Background`
+- Visible console window with live logs:
+  `.\skills\start-api\scripts\start_api.ps1 -ConsoleWindow`
 - Background start with mock provider:
   `.\skills\start-api\scripts\start_api.ps1 -Background -LlmProvider mock`
 - Custom port:

--- a/skills/start-api/scripts/start_api.ps1
+++ b/skills/start-api/scripts/start_api.ps1
@@ -4,6 +4,7 @@ param(
     [string]$BindHost = "127.0.0.1",
     [int]$Port = 8080,
     [switch]$Background,
+    [switch]$ConsoleWindow,
     [switch]$Reload,
     [switch]$Install
 )
@@ -47,6 +48,7 @@ function Test-ApiHealth {
 $skillScriptsDir = $PSScriptRoot
 $repoRoot = Resolve-Path (Join-Path $skillScriptsDir "..\\..\\..")
 $apiDir = Join-Path $repoRoot "api\\aijuristiction-api"
+$pwsh = (Get-Command pwsh -ErrorAction SilentlyContinue).Source
 
 if (-not (Test-Path $apiDir)) {
     throw "API project folder not found: $apiDir"
@@ -67,6 +69,31 @@ if ($Install) {
 $uvicornArgs = @("-m", "uvicorn", "app.main:app", "--host", $BindHost, "--port", "$Port")
 if ($Reload) {
     $uvicornArgs += "--reload"
+}
+
+if ($ConsoleWindow) {
+    if (-not $pwsh) {
+        throw "PowerShell 7 (pwsh) was not found on PATH."
+    }
+
+    $scriptPath = Join-Path $repoRoot "skills\start-api\scripts\start_api.ps1"
+    $consoleArgs = @(
+        "-NoExit",
+        "-Command",
+        "& '$scriptPath' -LlmProvider $LlmProvider -BindHost $BindHost -Port $Port"
+    )
+    if ($Reload) {
+        $consoleArgs[-1] += " -Reload"
+    }
+    if ($Install) {
+        $consoleArgs[-1] += " -Install"
+    }
+
+    Start-Process -FilePath $pwsh -ArgumentList $consoleArgs -WorkingDirectory $repoRoot | Out-Null
+    Write-Output "API console window started."
+    Write-Output "Health: http://$BindHost`:$Port/health"
+    Write-Output "Docs: http://$BindHost`:$Port/docs"
+    exit 0
 }
 
 if ($Background) {

--- a/skills/start-mobile-app/SKILL.md
+++ b/skills/start-mobile-app/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: start-mobile-app
+description: Start and verify the local Flutter mobile app in this monorepo. Use when asked to "start mobile app", "run flutter app locally", "launch mobile web target", "open the mobile client in Chrome", or "bring up the Flutter frontend against the local API or public dev API". Prefer this workflow for reliable local startup with the installed Flutter SDK, default Chrome target, an explicit API mode choice (`localApi` or `publicDevApi`), and web readiness verification.
+---
+
+# Start Mobile App
+
+## Workflow
+
+1. Ask which API mode to use: `localApi` or `publicDevApi`.
+2. Run the bundled launcher from repository root:
+   `.\skills\start-mobile-app\scripts\start_mobile_app.ps1`
+3. If `localApi` is selected and the API is not already up, start the local API in a visible console window so live logs stay on screen.
+4. Verify the Flutter web target responds at `http://127.0.0.1:7357`.
+
+## Commands
+
+- Foreground start on Chrome:
+  `.\skills\start-mobile-app\scripts\start_mobile_app.ps1`
+- Visible console window with Flutter logs:
+  `.\skills\start-mobile-app\scripts\start_mobile_app.ps1 -ConsoleWindow`
+- Background start on Chrome:
+  `.\skills\start-mobile-app\scripts\start_mobile_app.ps1 -Background`
+- Background start without opening a browser tab:
+  `.\skills\start-mobile-app\scripts\start_mobile_app.ps1 -Background -NoOpen`
+- Explicit local API mode:
+  `.\skills\start-mobile-app\scripts\start_mobile_app.ps1 -Background -ApiMode localApi`
+- Explicit public dev API mode:
+  `.\skills\start-mobile-app\scripts\start_mobile_app.ps1 -Background -ApiMode publicDevApi -PublicDevApiBaseUrl https://your-dev-api.example.com`
+- Use a different Flutter device:
+  `.\skills\start-mobile-app\scripts\start_mobile_app.ps1 -Device windows`
+- Override API base URL:
+  `.\skills\start-mobile-app\scripts\start_mobile_app.ps1 -ApiBaseUrl http://10.0.2.2:8080`
+
+## Stop Mobile App
+
+If started with `-Background`, stop via:
+
+`Stop-Process -Id (Get-Content .\runs\mobile-app.pid) -Force`
+
+## Environment Notes
+
+- Default Flutter device is `chrome`.
+- Default web URL is `http://127.0.0.1:7357`.
+- By default, the launcher opens the app URL in the browser after the web target becomes ready.
+- Use `-ConsoleWindow` when you want live Flutter logs in a separate terminal window instead of background log files.
+- For `localApi`, default API URL is `http://127.0.0.1:8080`.
+- For `publicDevApi`, the launcher uses `-PublicDevApiBaseUrl`, `PUBLIC_DEV_API_BASE_URL`, or `AIJ_PUBLIC_DEV_API_URL`. If none are set, it prompts for the URL.
+- The local API path uses `start-api -ConsoleWindow`, so request logs stay visible in the API console window.
+- Default API key is `aijuris`.
+- The launcher prefers Flutter from `%USERPROFILE%\develop\flutter\bin\flutter.bat`, then falls back to `flutter` on `PATH`.

--- a/skills/start-mobile-app/agents/openai.yaml
+++ b/skills/start-mobile-app/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Start Mobile App"
+  short_description: "Start local Flutter mobile app target"
+  default_prompt: "Start the local Flutter mobile app against the local API and verify the app URL."

--- a/skills/start-mobile-app/scripts/start_mobile_app.ps1
+++ b/skills/start-mobile-app/scripts/start_mobile_app.ps1
@@ -1,0 +1,246 @@
+param(
+    [string]$Device = "chrome",
+    [string]$BindHost = "127.0.0.1",
+    [int]$Port = 7357,
+    [ValidateSet("localApi", "publicDevApi")]
+    [string]$ApiMode = "",
+    [string]$ApiBaseUrl = "",
+    [string]$PublicDevApiBaseUrl = "",
+    [string]$ApiKey = "aijuris",
+    [switch]$Background,
+    [switch]$ConsoleWindow,
+    [switch]$PubGet,
+    [switch]$NoOpen
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-FlutterPath {
+    $userFlutter = Join-Path $env:USERPROFILE "develop\flutter\bin\flutter.bat"
+    if (Test-Path $userFlutter) {
+        return $userFlutter
+    }
+
+    $flutterCmd = Get-Command flutter -ErrorAction SilentlyContinue
+    if ($flutterCmd) {
+        return $flutterCmd.Source
+    }
+
+    throw "Flutter SDK not found. Install Flutter or add flutter to PATH."
+}
+
+function Test-WebReady {
+    param(
+        [string]$TargetHost,
+        [int]$TargetPort
+    )
+
+    $url = "http://$TargetHost`:$TargetPort"
+    try {
+        $response = Invoke-WebRequest -UseBasicParsing -Uri $url -TimeoutSec 3
+        return $response.StatusCode -eq 200
+    } catch {
+        return $false
+    }
+}
+
+function Open-AppUrl {
+    param([string]$Url)
+
+    if ($NoOpen) {
+        return
+    }
+
+    Start-Process $Url | Out-Null
+}
+
+function Test-ApiReady {
+    param([string]$Url)
+
+    $healthUrl = $Url.TrimEnd("/") + "/health"
+    try {
+        $response = Invoke-WebRequest -UseBasicParsing -Uri $healthUrl -TimeoutSec 3
+        return $response.StatusCode -eq 200
+    } catch {
+        return $false
+    }
+}
+
+function Resolve-ApiMode {
+    param([string]$RequestedMode)
+
+    if ($RequestedMode) {
+        return $RequestedMode
+    }
+
+    while ($true) {
+        $answer = (Read-Host "Choose API mode [localApi/publicDevApi]").Trim()
+        if ($answer -in @("localApi", "publicDevApi")) {
+            return $answer
+        }
+        Write-Warning "Please answer with 'localApi' or 'publicDevApi'."
+    }
+}
+
+function Resolve-ApiBaseUrl {
+    param(
+        [string]$Mode,
+        [string]$RequestedApiBaseUrl,
+        [string]$RequestedPublicDevApiBaseUrl
+    )
+
+    if ($RequestedApiBaseUrl) {
+        return $RequestedApiBaseUrl
+    }
+
+    if ($Mode -eq "localApi") {
+        return "http://127.0.0.1:8080"
+    }
+
+    if ($RequestedPublicDevApiBaseUrl) {
+        return $RequestedPublicDevApiBaseUrl
+    }
+
+    foreach ($name in @("PUBLIC_DEV_API_BASE_URL", "AIJ_PUBLIC_DEV_API_URL")) {
+        $value = [Environment]::GetEnvironmentVariable($name)
+        if ($value) {
+            return $value
+        }
+    }
+
+    while ($true) {
+        $answer = (Read-Host "Enter public dev API base URL").Trim()
+        if ($answer) {
+            return $answer
+        }
+        Write-Warning "Public dev API base URL cannot be empty."
+    }
+}
+
+$skillScriptsDir = $PSScriptRoot
+$repoRoot = Resolve-Path (Join-Path $skillScriptsDir "..\..\..")
+$appDir = Join-Path $repoRoot "mobile_app"
+$runsDir = Join-Path $repoRoot "runs"
+$pwsh = (Get-Command pwsh -ErrorAction SilentlyContinue).Source
+
+if (-not (Test-Path $appDir)) {
+    throw "Mobile app folder not found: $appDir"
+}
+
+$flutter = Resolve-FlutterPath
+$ApiMode = Resolve-ApiMode -RequestedMode $ApiMode
+$ApiBaseUrl = Resolve-ApiBaseUrl -Mode $ApiMode -RequestedApiBaseUrl $ApiBaseUrl -RequestedPublicDevApiBaseUrl $PublicDevApiBaseUrl
+
+if ($ApiMode -eq "localApi") {
+    if (-not (Test-ApiReady -Url $ApiBaseUrl)) {
+        & (Join-Path $repoRoot "skills\start-api\scripts\start_api.ps1") -ConsoleWindow | Out-Null
+        Start-Sleep -Seconds 4
+    }
+} elseif (-not (Test-ApiReady -Url $ApiBaseUrl)) {
+    Write-Warning "Public dev API is not reachable at $ApiBaseUrl."
+}
+
+if ($ConsoleWindow) {
+    if (-not $pwsh) {
+        throw "PowerShell 7 (pwsh) was not found on PATH."
+    }
+
+    $scriptPath = Join-Path $repoRoot "skills\start-mobile-app\scripts\start_mobile_app.ps1"
+    $command = "& '$scriptPath' -Device $Device -BindHost $BindHost -Port $Port -ApiMode $ApiMode -ApiBaseUrl $ApiBaseUrl -ApiKey $ApiKey"
+    if ($PublicDevApiBaseUrl) {
+        $command += " -PublicDevApiBaseUrl $PublicDevApiBaseUrl"
+    }
+    if ($PubGet) {
+        $command += " -PubGet"
+    }
+    if ($NoOpen) {
+        $command += " -NoOpen"
+    }
+
+    Start-Process -FilePath $pwsh -ArgumentList @("-NoExit", "-Command", $command) -WorkingDirectory $repoRoot | Out-Null
+    Write-Output "Mobile app console window started."
+    if ($Device -eq "chrome" -or $Device -eq "edge") {
+        Write-Output "App URL: http://$BindHost`:$Port"
+    }
+    Write-Output "API URL: $ApiBaseUrl"
+    exit 0
+}
+
+Push-Location $appDir
+try {
+    if ($PubGet) {
+        & $flutter pub get
+    }
+
+    $flutterArgs = @(
+        "run",
+        "-d", $Device,
+        "--dart-define=AIJ_API_BASE_URL=$ApiBaseUrl",
+        "--dart-define=AIJ_API_KEY=$ApiKey"
+    )
+
+    if ($Device -eq "chrome" -or $Device -eq "edge") {
+        $flutterArgs += @("--web-hostname", $BindHost, "--web-port", "$Port")
+    }
+
+    if ($Background) {
+        if (-not (Test-Path $runsDir)) {
+            New-Item -Path $runsDir -ItemType Directory | Out-Null
+        }
+
+        $stdoutLog = Join-Path $runsDir "mobile-app-$Port.log"
+        $stderrLog = Join-Path $runsDir "mobile-app-$Port.err.log"
+        $pidFile = Join-Path $runsDir "mobile-app.pid"
+
+        if (Test-Path $stdoutLog) { Remove-Item $stdoutLog -Force }
+        if (Test-Path $stderrLog) { Remove-Item $stderrLog -Force }
+
+        $process = Start-Process `
+            -FilePath $flutter `
+            -ArgumentList $flutterArgs `
+            -WorkingDirectory $appDir `
+            -RedirectStandardOutput $stdoutLog `
+            -RedirectStandardError $stderrLog `
+            -PassThru
+
+        Start-Sleep -Seconds 25
+
+        if (-not (Get-Process -Id $process.Id -ErrorAction SilentlyContinue)) {
+            throw "Mobile app process exited immediately. Check $stderrLog"
+        }
+
+        $process.Id | Out-File -FilePath $pidFile -Encoding ascii -NoNewline
+
+        if ($Device -eq "chrome" -or $Device -eq "edge") {
+            $isReady = Test-WebReady -TargetHost $BindHost -TargetPort $Port
+            if ($isReady) {
+                Open-AppUrl -Url "http://$BindHost`:$Port"
+                Write-Output "Mobile app started in background. PID: $($process.Id)"
+                Write-Output "App URL: http://$BindHost`:$Port"
+                Write-Output "API URL: $ApiBaseUrl"
+                Write-Output "Logs: $stdoutLog"
+                Write-Output "Errors: $stderrLog"
+                Write-Output "Stop: Stop-Process -Id (Get-Content `"$pidFile`") -Force"
+            } else {
+                Write-Warning "Mobile app process started (PID $($process.Id)) but web target is not ready yet."
+                Write-Output "Check logs:"
+                Write-Output "  $stdoutLog"
+                Write-Output "  $stderrLog"
+            }
+        } else {
+            Write-Output "Mobile app started in background. PID: $($process.Id)"
+            Write-Output "Device: $Device"
+            Write-Output "API URL: $ApiBaseUrl"
+            Write-Output "Stop: Stop-Process -Id (Get-Content `"$pidFile`") -Force"
+        }
+        exit 0
+    }
+
+    Write-Output "Starting mobile app on device '$Device' (API=$ApiBaseUrl)"
+    if ($Device -eq "chrome" -or $Device -eq "edge") {
+        Write-Output "App URL: http://$BindHost`:$Port"
+    }
+    & $flutter @flutterArgs
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- add a start-mobile-app project skill with API mode selection and console-window launch options
- add console-window support to start-api so local API logs stay visible
- harden Flutter mobile camera startup and capture paths so web camera failures are handled in-app instead of surfacing as uncaught Dart errors
- update docs for the new mobile and API startup workflows

## Validation
- flutter analyze
- quick_validate.py skills/start-mobile-app
- smoke-tested mobile launcher on web ports 7357/7359/7360
- verified app responds on the local web target and API console window launch works
