### PR TITLE
Add case memory: API, DB store and mobile case management

### DIFF
--- a/api/aijuristiction-api/app/cases_api.py
+++ b/api/aijuristiction-api/app/cases_api.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from app.security import require_api_key
+
+from aijurisdictionagents.api_db import ApiDatabaseStore, Case
+
+router = APIRouter(prefix='/v1/cases', tags=['cases'], dependencies=[Depends(require_api_key)])
+_MAX_ACTIVE_CASES = 5
+
+
+class CaseResponse(BaseModel):
+    case_id: str
+    user_id: str
+    company_id: str | None = None
+    title: str
+    status: str
+    created_at: str
+    updated_at: str
+
+
+class CreateCaseRequest(BaseModel):
+    user_id: str = Field(min_length=1)
+    title: str = Field(min_length=1)
+
+
+class UpdateCaseRequest(BaseModel):
+    user_id: str = Field(min_length=1)
+    title: str = Field(min_length=1)
+
+
+def get_store() -> ApiDatabaseStore:
+    store = ApiDatabaseStore.from_env()
+    store.initialize()
+    return store
+
+
+@router.get('', response_model=list[CaseResponse])
+def list_cases(user_id: str, store: ApiDatabaseStore = Depends(get_store)) -> list[CaseResponse]:
+    return [_to_case_response(item) for item in store.list_cases(user_id=user_id)]
+
+
+@router.post('', response_model=CaseResponse, status_code=status.HTTP_201_CREATED)
+def create_case(payload: CreateCaseRequest, store: ApiDatabaseStore = Depends(get_store)) -> CaseResponse:
+    active = store.count_active_cases(user_id=payload.user_id)
+    if active >= _MAX_ACTIVE_CASES:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f'Maximum number of cases reached ({_MAX_ACTIVE_CASES})',
+        )
+    case = store.create_case(user_id=payload.user_id, company_id=None, title=payload.title.strip())
+    return _to_case_response(case)
+
+
+@router.patch('/{case_id}', response_model=CaseResponse)
+def rename_case(case_id: str, payload: UpdateCaseRequest, store: ApiDatabaseStore = Depends(get_store)) -> CaseResponse:
+    try:
+        case = store.update_case_title(case_id=case_id, user_id=payload.user_id, title=payload.title.strip())
+    except KeyError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return _to_case_response(case)
+
+
+@router.delete('/{case_id}', status_code=status.HTTP_204_NO_CONTENT)
+def delete_case(case_id: str, user_id: str, store: ApiDatabaseStore = Depends(get_store)) -> None:
+    try:
+        store.soft_delete_case(case_id=case_id, user_id=user_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+
+def _to_case_response(case: Case) -> CaseResponse:
+    return CaseResponse(
+        case_id=case.case_id,
+        user_id=case.user_id,
+        company_id=case.company_id,
+        title=case.title,
+        status=case.status,
+        created_at=case.created_at,
+        updated_at=case.updated_at,
+    )

--- a/api/aijuristiction-api/app/chat/api.py
+++ b/api/aijuristiction-api/app/chat/api.py
@@ -28,6 +28,7 @@ from app.chat.repository import InMemoryChatRepository
 from app.security import require_api_key
 from app.versioning import get_api_version, get_core_version
 
+from aijurisdictionagents.api_db import ApiDatabaseStore
 from aijurisdictionagents.schemas import Document as CoreDocument
 from aijurisdictionagents.schemas import Message as CoreMessage
 
@@ -46,6 +47,7 @@ _REGISTERED_PDF_FONT_FAMILIES: set[str] = set()
 
 class CreateSessionRequest(BaseModel):
     user_id: Optional[UUID] = None
+    case_id: str | None = None
     country: str = "SK"
     language: str | None = None
     discussion_type: Literal["advice", "court"] = "advice"
@@ -67,6 +69,41 @@ class InputDocument(BaseModel):
     content: str
 
 
+
+
+def _get_store() -> ApiDatabaseStore:
+    store = ApiDatabaseStore.from_env()
+    store.initialize()
+    return store
+
+
+def _persist_case_message_if_needed(*, session: Session, role: str, content: str, agent_name: str | None = None) -> None:
+    case_id = session.case_id
+    if case_id is None or not case_id.strip():
+        return
+    store = _get_store()
+    store.add_case_message(case_id=case_id, role=role, content=content, agent_name=agent_name)
+
+
+def _persist_case_document_marker_if_needed(*, session: Session, content: str) -> None:
+    case_id = session.case_id
+    if case_id is None or not case_id.strip():
+        return
+    match = re.search(r"\[Attached local document path:\s*([^\]]+)\]", content, flags=re.IGNORECASE)
+    if not match:
+        return
+    path_value = match.group(1).strip()
+    if not path_value:
+        return
+    store = _get_store()
+    store.add_case_text_document(
+        case_id=case_id,
+        original_filename=Path(path_value).name or "attachment.txt",
+        content=f"Local path reference: {path_value}",
+        uploaded_by_user_id=str(session.user_id) if session.user_id else None,
+    )
+
+
 class StartSessionStreamRequest(BaseModel):
     instruction: str
     documents: List[InputDocument] = Field(default_factory=list)
@@ -81,6 +118,7 @@ class StartSessionStreamRequest(BaseModel):
 def create_session(payload: CreateSessionRequest) -> Session:
     session = Session(
         user_id=payload.user_id,
+        case_id=payload.case_id,
         country=payload.country,
         language=payload.language,
         discussion_type=payload.discussion_type,
@@ -116,6 +154,8 @@ def reply_to_session(session_id: UUID, payload: ReplyRequest) -> Message:
             agent_name="User",
         )
     )
+    _persist_case_message_if_needed(session=session, role="user", content=content, agent_name="User")
+    _persist_case_document_marker_if_needed(session=session, content=content)
 
     from aijurisdictionagents.agents import create_lawyer_agent
     from aijurisdictionagents.llm import get_llm_client
@@ -150,6 +190,12 @@ def reply_to_session(session_id: UUID, payload: ReplyRequest) -> Message:
             content=lawyer_message.content,
             agent_name=lawyer_message.agent_name,
         )
+    )
+    _persist_case_message_if_needed(
+        session=session,
+        role="assistant",
+        content=lawyer_message.content,
+        agent_name=lawyer_message.agent_name,
     )
 
     return persisted_lawyer
@@ -290,6 +336,12 @@ def stream_session(session_id: UUID, payload: StartSessionStreamRequest) -> Stre
                 content=core_message.content,
                 agent_name=core_message.agent_name,
             )
+        )
+        _persist_case_message_if_needed(
+            session=session,
+            role=core_message_role(core_message.role),
+            content=core_message.content,
+            agent_name=core_message.agent_name,
         )
         event_queue.put(
             (

--- a/api/aijuristiction-api/app/chat/models.py
+++ b/api/aijuristiction-api/app/chat/models.py
@@ -51,6 +51,7 @@ class GenerationJob(BaseModel):
 class Session(BaseModel):
     id: UUID = Field(default_factory=uuid4)
     user_id: Optional[UUID] = None
+    case_id: str | None = None
     country: str = ""
     language: str | None = None
     discussion_type: str = "advice"

--- a/api/aijuristiction-api/app/main.py
+++ b/api/aijuristiction-api/app/main.py
@@ -13,6 +13,7 @@ from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
+from app.cases_api import router as cases_router
 from app.chat.api import router as chat_router
 from app.logging_config import configure_logging
 from app.telemetry import configure_telemetry
@@ -62,6 +63,7 @@ app.add_middleware(
 )
 app.include_router(chat_router)
 app.include_router(users_router)
+app.include_router(cases_router)
 configure_telemetry(app, service_name="aijuristiction-api", service_version=app.version)
 
 

--- a/api/aijuristiction-api/tests/test_cases.py
+++ b/api/aijuristiction-api/tests/test_cases.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def _headers() -> dict[str, str]:
+    return {"x-api-key": "aijuris"}
+
+
+def _create_user(client: TestClient, idx: int = 1) -> str:
+    response = client.post(
+        "/v1/users/sign-up",
+        headers=_headers(),
+        json={
+            "phone_number": f"+42190000000{idx}",
+            "email": f"case-user-{idx}@example.com",
+            "password": "secret",
+        },
+    )
+    assert response.status_code == 201
+    return response.json()["user_id"]
+
+
+def test_case_lifecycle_and_limit(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("DB_OPTION", "local")
+    monkeypatch.setenv("STORAGE_OPTION", "local")
+    monkeypatch.setenv("DB_LOCAL", str(tmp_path / "api.sqlite3"))
+    monkeypatch.setenv("STORE_LOCAL", str(tmp_path / "storage"))
+
+    client = TestClient(app)
+    user_id = _create_user(client)
+
+    created_ids: list[str] = []
+    for index in range(5):
+        response = client.post(
+            "/v1/cases",
+            headers=_headers(),
+            json={"user_id": user_id, "title": f"Case {index}"},
+        )
+        assert response.status_code == 201
+        created_ids.append(response.json()["case_id"])
+
+    sixth = client.post(
+        "/v1/cases",
+        headers=_headers(),
+        json={"user_id": user_id, "title": "Case 6"},
+    )
+    assert sixth.status_code == 409
+
+    rename = client.patch(
+        f"/v1/cases/{created_ids[0]}",
+        headers=_headers(),
+        json={"user_id": user_id, "title": "Renamed"},
+    )
+    assert rename.status_code == 200
+    assert rename.json()["title"] == "Renamed"
+
+    delete = client.delete(
+        f"/v1/cases/{created_ids[1]}?user_id={user_id}",
+        headers=_headers(),
+    )
+    assert delete.status_code == 204
+
+    listing = client.get(f"/v1/cases?user_id={user_id}", headers=_headers())
+    assert listing.status_code == 200
+    assert len(listing.json()) == 4

--- a/docs/MOBILE_TECHNICAL_DESIGN.md
+++ b/docs/MOBILE_TECHNICAL_DESIGN.md
@@ -68,3 +68,17 @@ This provides quick distribution for testers and a deployable web preview while 
 ## Review snapshot
 
 A visual snapshot of the proposed chat interface is maintained at `mobile_app/docs/chat_ui_snapshot.svg` and the source layout at `mobile_app/docs/chat_ui_snapshot.html`.
+
+## Case memory and mobile case management (latest)
+
+- Added case lifecycle over API for mobile: list, create, rename, soft delete.
+- Enforced max 5 active cases per user (`/v1/cases` create returns `409` after limit).
+- Chat session creation now carries `user_id` and `case_id` so replies/stream messages can be persisted in DB case communications.
+- Mobile app now requires selecting/creating a case before sending messages and shows case selector + create/rename/delete actions.
+- Existing and future chat messages are persisted for case-linked sessions; document path attachments are persisted as text document records.
+
+Minimal runnable example:
+
+```bash
+python examples/minimal_demo.py
+```

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -215,6 +215,26 @@ String _stripCaseUpdateJson(String content) {
   return visible.isEmpty ? content.trimRight() : visible;
 }
 
+class CaseSummary {
+  const CaseSummary({
+    required this.caseId,
+    required this.title,
+    required this.status,
+  });
+
+  final String caseId;
+  final String title;
+  final String status;
+
+  static CaseSummary fromJson(Map<String, dynamic> json) {
+    return CaseSummary(
+      caseId: json['case_id'] as String? ?? '',
+      title: json['title'] as String? ?? '',
+      status: json['status'] as String? ?? 'open',
+    );
+  }
+}
+
 class StreamEvent {
   const StreamEvent({required this.event, required this.data});
 
@@ -301,8 +321,20 @@ class ApiClient {
   final String apiKey;
   final AppLogger logger;
   String? _sessionId;
+  String? _caseId;
+  String? _userId;
 
   String? get sessionId => _sessionId;
+  String? get caseId => _caseId;
+
+  void setSignedInUser(String userId) {
+    _userId = userId;
+  }
+
+  void setActiveCase(String? caseId) {
+    _caseId = caseId;
+    _sessionId = null;
+  }
 
   Map<String, String> get _headers => <String, String>{
         'Content-Type': 'application/json',
@@ -399,6 +431,61 @@ class ApiClient {
     }
   }
 
+  Future<List<CaseSummary>> listCases({required String userId}) async {
+    final response = await _get(
+      path: '/v1/cases?user_id=$userId',
+      action: 'list_cases',
+    );
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw Exception('Case list failed with status ${response.statusCode}.');
+    }
+    final decoded = jsonDecode(response.body) as List<dynamic>;
+    return decoded
+        .whereType<Map>()
+        .map((value) => CaseSummary.fromJson(Map<String, dynamic>.from(value)))
+        .toList();
+  }
+
+  Future<CaseSummary> createCase({required String userId, required String title}) async {
+    final response = await _postJson(
+      path: '/v1/cases',
+      action: 'create_case',
+      payload: <String, Object?>{'user_id': userId, 'title': title},
+    );
+    if (response.statusCode == 409) {
+      throw Exception('Maximum number of cases reached (5).');
+    }
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw Exception('Case creation failed with status ${response.statusCode}.');
+    }
+    return CaseSummary.fromJson(_decodeResponseBody(response, action: 'create_case'));
+  }
+
+  Future<CaseSummary> renameCase({required String caseId, required String userId, required String title}) async {
+    final uri = baseUri.resolve('/v1/cases/$caseId');
+    final response = await http.patch(
+      uri,
+      headers: _headers,
+      body: jsonEncode(<String, Object?>{'user_id': userId, 'title': title}),
+    );
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw Exception('Case rename failed with status ${response.statusCode}.');
+    }
+    return CaseSummary.fromJson(_decodeResponseBody(response, action: 'rename_case'));
+  }
+
+  Future<void> deleteCase({required String caseId, required String userId}) async {
+    final uri = baseUri.resolve('/v1/cases/$caseId?user_id=$userId');
+    final response = await http.delete(uri, headers: <String, String>{'x-api-key': apiKey});
+    if (response.statusCode != 204) {
+      throw Exception('Case delete failed with status ${response.statusCode}.');
+    }
+    if (_caseId == caseId) {
+      _caseId = null;
+      _sessionId = null;
+    }
+  }
+
   Future<String> _createSession({
     required ResponderMode responderMode,
     required LocaleOption locale,
@@ -409,6 +496,8 @@ class ApiClient {
       'discussion_type': discussionType,
       'country': locale.countryCode,
       'language': locale.languageCode,
+      'user_id': _userId,
+      'case_id': _caseId,
     };
     final sessionResponse = await _postJson(
       path: '/v1/chat/sessions',
@@ -1528,6 +1617,9 @@ class _ChatHomePageState extends State<ChatHomePage> {
   bool _speechEnabled = false;
   bool _isListening = false;
   late LocalAuthUser _signedInUser;
+  List<CaseSummary> _cases = <CaseSummary>[];
+  CaseSummary? _selectedCase;
+  bool _isLoadingCases = false;
 
   bool get _showLocalResponderSwitch {
     final host = Uri.parse(widget.apiBaseUrl).host.toLowerCase();
@@ -1553,6 +1645,7 @@ class _ChatHomePageState extends State<ChatHomePage> {
       logger: widget.logger,
     );
     _fileSaver = createFileSaver();
+    _apiClient.setSignedInUser(_signedInUser.userId);
     final welcomeLanguage =
         _normalizeLanguageCode(_selectedLocale.languageCode);
     _messages = <ChatMessage>[
@@ -1579,6 +1672,7 @@ class _ChatHomePageState extends State<ChatHomePage> {
       ),
     );
     unawaited(_initializeSpeechRecognition());
+    unawaited(_loadCases());
     unawaited(_loadAppVersion());
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _scrollToLatest(animated: false);
@@ -1923,6 +2017,10 @@ class _ChatHomePageState extends State<ChatHomePage> {
     if (text.isEmpty || _isSending) {
       return;
     }
+    if (_selectedCase == null) {
+      _showSnackbar('Create or select a case before sending messages.');
+      return;
+    }
     await widget.logger.info(
       'User message submission',
       <String, Object?>{
@@ -2142,6 +2240,108 @@ class _ChatHomePageState extends State<ChatHomePage> {
     );
   }
 
+  Future<void> _loadCases() async {
+    setState(() {
+      _isLoadingCases = true;
+    });
+    try {
+      final cases = await _apiClient.listCases(userId: _signedInUser.userId);
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _cases = cases;
+        _selectedCase = cases.isNotEmpty ? cases.first : null;
+        _apiClient.setActiveCase(_selectedCase?.caseId);
+      });
+    } catch (error) {
+      _showSnackbar('Failed to load cases: $error');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoadingCases = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _createCase() async {
+    if (_cases.length >= 5) {
+      _showSnackbar('Maximum 5 cases allowed. Delete an existing case first.');
+      return;
+    }
+    final controller = TextEditingController();
+    final title = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Create case'),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(labelText: 'Case name'),
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
+          FilledButton(onPressed: () => Navigator.pop(context, controller.text.trim()), child: const Text('Create')),
+        ],
+      ),
+    );
+    if (title == null || title.trim().isEmpty) return;
+    try {
+      final created = await _apiClient.createCase(userId: _signedInUser.userId, title: title.trim());
+      setState(() {
+        _cases = <CaseSummary>[created, ..._cases];
+        _selectedCase = created;
+        _apiClient.setActiveCase(created.caseId);
+      });
+      _showSnackbar('Case created.');
+    } catch (error) {
+      _showSnackbar('$error');
+    }
+  }
+
+  Future<void> _renameSelectedCase() async {
+    final selected = _selectedCase;
+    if (selected == null) return;
+    final controller = TextEditingController(text: selected.title);
+    final title = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Rename case'),
+        content: TextField(controller: controller),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
+          FilledButton(onPressed: () => Navigator.pop(context, controller.text.trim()), child: const Text('Save')),
+        ],
+      ),
+    );
+    if (title == null || title.trim().isEmpty) return;
+    try {
+      final updated = await _apiClient.renameCase(caseId: selected.caseId, userId: _signedInUser.userId, title: title.trim());
+      setState(() {
+        _cases = _cases.map((c) => c.caseId == updated.caseId ? updated : c).toList();
+        _selectedCase = updated;
+      });
+    } catch (error) {
+      _showSnackbar('Failed to rename case: $error');
+    }
+  }
+
+  Future<void> _deleteSelectedCase() async {
+    final selected = _selectedCase;
+    if (selected == null) return;
+    try {
+      await _apiClient.deleteCase(caseId: selected.caseId, userId: _signedInUser.userId);
+      setState(() {
+        _cases = _cases.where((c) => c.caseId != selected.caseId).toList();
+        _selectedCase = _cases.isNotEmpty ? _cases.first : null;
+        _apiClient.setActiveCase(_selectedCase?.caseId);
+      });
+      _showSnackbar('Case deleted.');
+    } catch (error) {
+      _showSnackbar('Failed to delete case: $error');
+    }
+  }
+
   Future<void> _signOut() async {
     _apiClient.resetSession();
     await widget.logger.info(
@@ -2269,6 +2469,44 @@ class _ChatHomePageState extends State<ChatHomePage> {
                   ),
                 ),
                 const SizedBox(height: 8),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  child: Container(
+                    padding: const EdgeInsets.all(10),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(0.94),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: _isLoadingCases
+                              ? const LinearProgressIndicator()
+                              : DropdownButton<CaseSummary>(
+                                  isExpanded: true,
+                                  value: _selectedCase,
+                                  hint: const Text('Select case'),
+                                  items: _cases
+                                      .map((item) => DropdownMenuItem<CaseSummary>(
+                                            value: item,
+                                            child: Text(item.title),
+                                          ))
+                                      .toList(),
+                                  onChanged: (value) {
+                                    setState(() {
+                                      _selectedCase = value;
+                                      _apiClient.setActiveCase(value?.caseId);
+                                    });
+                                  },
+                                ),
+                        ),
+                        IconButton(onPressed: _createCase, icon: const Icon(Icons.add), tooltip: 'Create case'),
+                        IconButton(onPressed: _selectedCase == null ? null : _renameSelectedCase, icon: const Icon(Icons.edit), tooltip: 'Rename case'),
+                        IconButton(onPressed: _selectedCase == null ? null : _deleteSelectedCase, icon: const Icon(Icons.delete_outline), tooltip: 'Delete case'),
+                      ],
+                    ),
+                  ),
+                ),
                 if (_documentPath != null)
                   MaterialBanner(
                     content: Text('Attached document: $_documentPath'),

--- a/src/aijurisdictionagents/api_db/store.py
+++ b/src/aijurisdictionagents/api_db/store.py
@@ -42,6 +42,9 @@ class Case:
     user_id: str
     company_id: str | None
     title: str
+    status: str
+    created_at: str
+    updated_at: str
 
 
 class ApiDatabaseStore:
@@ -360,8 +363,126 @@ class ApiDatabaseStore:
                 """,
                 (case_id, user_id, company_id, title, now, now),
             )
-        return Case(
-            case_id=case_id, user_id=user_id, company_id=company_id, title=title
+        return self.get_case(case_id=case_id)
+
+    def get_case(self, *, case_id: str) -> Case:
+        with self._connect() as conn:
+            row = self._fetchone(
+                conn,
+                """
+                SELECT case_id, user_id, company_id, title, status, created_at, updated_at
+                FROM cases
+                WHERE case_id = ?
+                """,
+                (case_id,),
+            )
+        if row is None:
+            raise KeyError(f"Case {case_id} not found")
+        return _row_to_case(row)
+
+    def list_cases(self, *, user_id: str, include_deleted: bool = False) -> list[Case]:
+        query = """
+            SELECT case_id, user_id, company_id, title, status, created_at, updated_at
+            FROM cases
+            WHERE user_id = ?
+        """
+        if not include_deleted:
+            query += " AND status <> 'deleted'"
+        query += " ORDER BY updated_at DESC"
+        with self._connect() as conn:
+            rows = self._execute(conn, query, (user_id,)).fetchall()
+        return [_row_to_case(row) for row in rows]
+
+    def count_active_cases(self, *, user_id: str) -> int:
+        with self._connect() as conn:
+            row = self._fetchone(
+                conn,
+                """
+                SELECT COUNT(*)
+                FROM cases
+                WHERE user_id = ? AND status <> 'deleted'
+                """,
+                (user_id,),
+            )
+        return int(row[0]) if row else 0
+
+    def update_case_title(self, *, case_id: str, user_id: str, title: str) -> Case:
+        now = _now_iso()
+        with self._connect() as conn:
+            result = self._execute(
+                conn,
+                """
+                UPDATE cases
+                SET title = ?, updated_at = ?
+                WHERE case_id = ? AND user_id = ? AND status <> 'deleted'
+                """,
+                (title, now, case_id, user_id),
+            )
+            if result.rowcount == 0:
+                raise KeyError(f"Case {case_id} not found")
+        return self.get_case(case_id=case_id)
+
+    def soft_delete_case(self, *, case_id: str, user_id: str) -> None:
+        with self._connect() as conn:
+            result = self._execute(
+                conn,
+                """
+                UPDATE cases
+                SET status = 'deleted', updated_at = ?
+                WHERE case_id = ? AND user_id = ? AND status <> 'deleted'
+                """,
+                (_now_iso(), case_id, user_id),
+            )
+            if result.rowcount == 0:
+                raise KeyError(f"Case {case_id} not found")
+
+    def add_case_message(
+        self,
+        *,
+        case_id: str,
+        role: str,
+        content: str,
+        agent_name: str | None = None,
+    ) -> str:
+        summary = f"{role.upper()}: {content.strip()}"
+        if agent_name:
+            summary = f"{summary} (agent={agent_name})"
+        payload = summary.encode("utf-8")
+        return self.add_case_communication(
+            case_id=case_id,
+            channel="chat",
+            summary=summary[:1000],
+            transcript_payload=payload,
+            extension="txt",
+        )
+
+    def add_case_text_document(
+        self,
+        *,
+        case_id: str,
+        original_filename: str,
+        content: str,
+        uploaded_by_user_id: str | None = None,
+    ) -> str:
+        with self._connect() as conn:
+            row = self._fetchone(
+                conn,
+                """
+                SELECT COALESCE(MAX(version), 0)
+                FROM case_documents
+                WHERE case_id = ? AND kind = 'chat_attachment'
+                """,
+                (case_id,),
+            )
+        next_version = int(row[0]) + 1 if row else 1
+        filename = Path(original_filename).name or "attachment.txt"
+        return self.add_case_document(
+            case_id=case_id,
+            kind="chat_attachment",
+            version=next_version,
+            original_filename=filename,
+            payload=content.encode("utf-8"),
+            uploaded_by_user_id=uploaded_by_user_id,
         )
 
     def add_case_document(
@@ -591,6 +712,19 @@ def _row_to_user(row: tuple[object, ...]) -> User:
         first_name=str(values[3]) if values[3] is not None else None,
         last_name=str(values[4]) if values[4] is not None else None,
         full_name=str(values[5]),
+    )
+
+
+def _row_to_case(row: tuple[object, ...]) -> Case:
+    values = list(row)
+    return Case(
+        case_id=str(values[0]),
+        user_id=str(values[1]),
+        company_id=str(values[2]) if values[2] is not None else None,
+        title=str(values[3]),
+        status=str(values[4]),
+        created_at=str(values[5]),
+        updated_at=str(values[6]),
     )
 
 


### PR DESCRIPTION
### Motivation

- Persist chat history and uploaded documents per user 'case' so the mobile app can maintain memory across sessions and devices.
- Provide a simple case lifecycle (create/select/rename/soft-delete) with a user-facing limit to avoid unbounded case growth.
- Surface case selection in the mobile UI and ensure all chat activity is associated with a selected case for storage and later export.

### Description

- Added a new authenticated cases API at `POST/GET/PATCH/DELETE /v1/cases` (`api/aijuristiction-api/app/cases_api.py`) with a maximum of 5 active cases per user enforced on create.  
- Extended the API DB store (`src/aijurisdictionagents/api_db/store.py`) with `Case` metadata and helpers: `create_case`, `get_case`, `list_cases`, `count_active_cases`, `update_case_title`, `soft_delete_case`, plus `add_case_message` and `add_case_text_document` to persist chat messages and document markers.  
- Propagated `case_id` through chat session model and chat endpoints (`api/aijuristiction-api/app/chat/models.py` and `api/aijuristiction-api/app/chat/api.py`) and added hooks that persist user/assistant messages and local-document path markers into the case storage when sessions are case-linked.  
- Wired the new cases router into the FastAPI app (`api/aijuristiction-api/app/main.py`) and updated mobile client (`mobile_app/lib/main.dart`) with `ApiClient` methods for `listCases`, `createCase`, `renameCase`, `deleteCase`, plus `setSignedInUser` and `setActiveCase` and inclusion of `user_id`/`case_id` in session creation payloads.  
- Updated the mobile UI to load cases after login, show a case selector, and provide create/rename/delete (soft delete) dialogs; sending a chat requires a selected case and the app informs the user when the 5-case limit is reached.  
- Documented the change in `docs/MOBILE_TECHNICAL_DESIGN.md` and added an API test `tests/test_cases.py` validating lifecycle and limit behavior.

### Testing

- Ran unit/integration tests in the API with `PYTHONPATH=/workspace/aijurisdictionagents/src pytest -q tests/test_cases.py tests/test_users.py tests/test_health.py` from `api/aijuristiction-api`, and the test suite passed (all tests executed successfully).  
- Performed static checks by compiling key modules with `python -m py_compile` for `api/aijuristiction-api/app/cases_api.py`, `api/aijuristiction-api/app/chat/api.py`, and `src/aijurisdictionagents/api_db/store.py`, which succeeded.  
- Attempted `flutter analyze` for the mobile app but the Flutter CLI is unavailable in this environment, and running `python examples/minimal_demo.py` failed because no local API server was reachable at `localhost:8080` (expected without a running backend).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2da9ec0b4833296465e7dfd48ec32)