### PR TITLE
Introduce subscription model with DB, API endpoints, mobile UI, docs and tests

### DIFF
--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -97,6 +97,15 @@ same `x-api-key` guard as the chat endpoints.
   - request: `phone_number`
 - `PATCH /v1/users/{user_id}`
   - request: `phone_number`, optional `password`, optional `first_name`, optional `last_name`
+- `GET /v1/users/subscriptions/plans`
+  - returns seeded plans: free, case, basic, premium
+- `GET /v1/users/{user_id}/subscriptions`
+  - returns subscription history for a user
+- `POST /v1/users/{user_id}/subscriptions`
+  - request: `plan_code`; creates a pending subscription change while old paid plan remains active
+- `PATCH /v1/users/subscriptions/{subscription_id}`
+  - request: `status` in (`pending`, `paying`, `paid`, `canceled`, `expired`)
+  - monthly plans start a 30-day window when status changes to `paid`
 
 These endpoints persist users through `aijurisdictionagents.api_db.ApiDatabaseStore`
 and use the local SQLite metadata database by default (`DB_OPTION=local`, `DB_LOCAL`, default `./databases/api.sqlite3`, resolved from the repository root). You can switch to PostgreSQL with `DB_OPTION=postgres` + `DB_CLOUD=postgresql://...` (including via `docker compose`). Azure keeps the same PostgreSQL contract via `DB_OPTION=azure`.

--- a/api/aijuristiction-api/app/users/api.py
+++ b/api/aijuristiction-api/app/users/api.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 
 from app.security import require_api_key
 
-from aijurisdictionagents.api_db import ApiDatabaseStore, User
+from aijurisdictionagents.api_db import ApiDatabaseStore, SubscriptionPlan, User, UserSubscription
 
 router = APIRouter(prefix="/v1/users", tags=["users"], dependencies=[Depends(require_api_key)])
 
@@ -43,6 +43,35 @@ class UpdateUserProfileRequest(BaseModel):
     password: str | None = None
     first_name: str | None = None
     last_name: str | None = None
+
+
+class SubscriptionPlanResponse(BaseModel):
+    plan_code: str
+    display_name: str
+    subscription_type: str
+    price_eur: int
+    max_cases: int
+    case_ttl_days: int | None = None
+
+
+class UserSubscriptionResponse(BaseModel):
+    subscription_id: str
+    user_id: str
+    plan_code: str
+    status: str
+    starts_at: str | None = None
+    ends_at: str | None = None
+    case_ids_json: str
+    created_at: str
+    updated_at: str
+
+
+class SubscriptionChangeRequest(BaseModel):
+    plan_code: str = Field(min_length=1)
+
+
+class SubscriptionStatusUpdateRequest(BaseModel):
+    status: str = Field(min_length=1)
 
 
 def get_user_store() -> ApiDatabaseStore:
@@ -109,6 +138,49 @@ def update_user_profile(
     return _to_user_profile_response(user)
 
 
+@router.get("/subscriptions/plans", response_model=list[SubscriptionPlanResponse])
+def list_subscription_plans(
+    store: ApiDatabaseStore = Depends(get_user_store),
+) -> list[SubscriptionPlanResponse]:
+    return [_to_plan_response(plan) for plan in store.list_subscription_plans()]
+
+
+@router.get("/{user_id}/subscriptions", response_model=list[UserSubscriptionResponse])
+def list_user_subscriptions(
+    user_id: str,
+    store: ApiDatabaseStore = Depends(get_user_store),
+) -> list[UserSubscriptionResponse]:
+    return [_to_subscription_response(item) for item in store.list_user_subscriptions(user_id=user_id)]
+
+
+@router.post("/{user_id}/subscriptions", response_model=UserSubscriptionResponse, status_code=status.HTTP_201_CREATED)
+def request_subscription_change(
+    user_id: str,
+    payload: SubscriptionChangeRequest,
+    store: ApiDatabaseStore = Depends(get_user_store),
+) -> UserSubscriptionResponse:
+    try:
+        item = store.request_subscription_change(user_id=user_id, plan_code=payload.plan_code)
+    except sqlite3.IntegrityError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid plan code") from exc
+    return _to_subscription_response(item)
+
+
+@router.patch("/subscriptions/{subscription_id}", response_model=UserSubscriptionResponse)
+def update_subscription_status(
+    subscription_id: str,
+    payload: SubscriptionStatusUpdateRequest,
+    store: ApiDatabaseStore = Depends(get_user_store),
+) -> UserSubscriptionResponse:
+    try:
+        item = store.update_subscription_status(subscription_id=subscription_id, status=payload.status)
+    except KeyError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return _to_subscription_response(item)
+
+
 def _to_user_profile_response(user: User) -> UserProfileResponse:
     return UserProfileResponse(
         user_id=user.user_id,
@@ -117,6 +189,31 @@ def _to_user_profile_response(user: User) -> UserProfileResponse:
         first_name=user.first_name,
         last_name=user.last_name,
         full_name=user.full_name,
+    )
+
+
+def _to_plan_response(plan: SubscriptionPlan) -> SubscriptionPlanResponse:
+    return SubscriptionPlanResponse(
+        plan_code=plan.plan_code,
+        display_name=plan.display_name,
+        subscription_type=plan.subscription_type,
+        price_eur=plan.price_eur,
+        max_cases=plan.max_cases,
+        case_ttl_days=plan.case_ttl_days,
+    )
+
+
+def _to_subscription_response(item: UserSubscription) -> UserSubscriptionResponse:
+    return UserSubscriptionResponse(
+        subscription_id=item.subscription_id,
+        user_id=item.user_id,
+        plan_code=item.plan_code,
+        status=item.status,
+        starts_at=item.starts_at,
+        ends_at=item.ends_at,
+        case_ids_json=item.case_ids_json,
+        created_at=item.created_at,
+        updated_at=item.updated_at,
     )
 
 

--- a/api/aijuristiction-api/tests/test_users.py
+++ b/api/aijuristiction-api/tests/test_users.py
@@ -152,3 +152,60 @@ def test_sign_up_rejects_duplicate_phone_and_email(monkeypatch, tmp_path: Path) 
     )
     assert duplicate_email.status_code == 409
     assert "email" in duplicate_email.json()["detail"].lower()
+
+
+def test_subscription_lifecycle(monkeypatch, tmp_path: Path) -> None:
+    _configure_db_env(monkeypatch, tmp_path)
+
+    sign_up_response = client.post(
+        "/v1/users/sign-up",
+        headers=AUTH_HEADERS,
+        json={
+            "phone_number": "+421900121212",
+            "email": "plans@example.com",
+            "password": "secret-pass",
+            "first_name": "Plan",
+            "last_name": "User",
+        },
+    )
+    assert sign_up_response.status_code == 201
+    user_id = sign_up_response.json()["user_id"]
+
+    plans_response = client.get("/v1/users/subscriptions/plans", headers=AUTH_HEADERS)
+    assert plans_response.status_code == 200
+    plans = plans_response.json()
+    assert {item["plan_code"] for item in plans} == {"free", "case", "basic", "premium"}
+
+    subscriptions_response = client.get(f"/v1/users/{user_id}/subscriptions", headers=AUTH_HEADERS)
+    assert subscriptions_response.status_code == 200
+    existing = subscriptions_response.json()
+    assert existing[0]["plan_code"] == "free"
+    assert existing[0]["status"] == "paid"
+
+    request_response = client.post(
+        f"/v1/users/{user_id}/subscriptions",
+        headers=AUTH_HEADERS,
+        json={"plan_code": "basic"},
+    )
+    assert request_response.status_code == 201
+    requested = request_response.json()
+    assert requested["status"] == "pending"
+
+    paying_response = client.patch(
+        f"/v1/users/subscriptions/{requested['subscription_id']}",
+        headers=AUTH_HEADERS,
+        json={"status": "paying"},
+    )
+    assert paying_response.status_code == 200
+    assert paying_response.json()["status"] == "paying"
+
+    paid_response = client.patch(
+        f"/v1/users/subscriptions/{requested['subscription_id']}",
+        headers=AUTH_HEADERS,
+        json={"status": "paid"},
+    )
+    assert paid_response.status_code == 200
+    paid = paid_response.json()
+    assert paid["status"] == "paid"
+    assert paid["starts_at"] is not None
+    assert paid["ends_at"] is not None

--- a/corporate-web/index.html
+++ b/corporate-web/index.html
@@ -264,45 +264,45 @@
         <article class="pricing-card">
           <h3 data-i18n="plan_free_title">Free</h3>
           <p class="price">€0</p>
-          <p data-i18n="plan_free_body">Základný prieskum a 1 prípad.</p>
+          <p data-i18n="plan_free_body">Automaticky pri registrácii, max 5 prípadov na 1 deň.</p>
           <ul>
-            <li data-i18n="plan_free_feature_1">Jedna prípadová workspace</li>
-            <li data-i18n="plan_free_feature_2">Základný chatbot právnika</li>
-            <li data-i18n="plan_free_feature_3">Komunitná podpora</li>
+            <li data-i18n="plan_free_feature_1">Maximálne 5 prípadov</li>
+            <li data-i18n="plan_free_feature_2">Platnosť prípadu 1 deň od vytvorenia</li>
+            <li data-i18n="plan_free_feature_3">Cena €0</li>
           </ul>
         </article>
         <article class="pricing-card">
           <h3 data-i18n="plan_basic_title">Basic</h3>
-          <p class="price">€39</p>
-          <p data-i18n="plan_basic_body">Pre menšie kancelárie.</p>
+          <p class="price">€30 / month</p>
+          <p data-i18n="plan_basic_body">10 prípadov s neobmedzenou platnosťou.</p>
           <ul>
-            <li data-i18n="plan_basic_feature_1">Neobmedzené prípady</li>
-            <li data-i18n="plan_basic_feature_2">Ingest dokumentov</li>
-            <li data-i18n="plan_basic_feature_3">AI právnik + sudca</li>
+            <li data-i18n="plan_basic_feature_1">Mesačný plán</li>
+            <li data-i18n="plan_basic_feature_2">Aktivácia po potvrdení platby</li>
+            <li data-i18n="plan_basic_feature_3">Platnosť 1 mesiac od aktivácie</li>
           </ul>
         </article>
         <article class="pricing-card highlight">
-          <h3 data-i18n="plan_pro_title">Pro</h3>
-          <p class="price">€89</p>
-          <p data-i18n="plan_pro_body">Pokročilá príprava a debaty.</p>
+          <h3 data-i18n="plan_pro_title">Case</h3>
+          <p class="price">€10 / case</p>
+          <p data-i18n="plan_pro_body">1 prípad bez časového limitu.</p>
           <ul>
-            <li data-i18n="plan_pro_feature_1">Multiagentné debaty</li>
-            <li data-i18n="plan_pro_feature_2">Tlačiteľný brief</li>
-            <li data-i18n="plan_pro_feature_3">Prioritná podpora</li>
+            <li data-i18n="plan_pro_feature_1">Jednorazový plán na 1 prípad</li>
+            <li data-i18n="plan_pro_feature_2">Priradené používateľovi aj prípadu</li>
+            <li data-i18n="plan_pro_feature_3">Aktivácia po potvrdení platby</li>
           </ul>
         </article>
         <article class="pricing-card">
-          <h3 data-i18n="plan_ultra_title">Ultra</h3>
-          <p class="price">€179</p>
-          <p data-i18n="plan_ultra_body">Regulované tímy a government.</p>
+          <h3 data-i18n="plan_ultra_title">Premium</h3>
+          <p class="price">€100 / month</p>
+          <p data-i18n="plan_ultra_body">100 prípadov s neobmedzenou platnosťou.</p>
           <ul>
-            <li data-i18n="plan_ultra_feature_1">Validácia a odporúčanie zákonov</li>
-            <li data-i18n="plan_ultra_feature_2">Auditné reporty</li>
-            <li data-i18n="plan_ultra_feature_3">Dedikovan? prostredie</li>
+            <li data-i18n="plan_ultra_feature_1">Mesačný plán</li>
+            <li data-i18n="plan_ultra_feature_2">Aktivácia po potvrdení platby</li>
+            <li data-i18n="plan_ultra_feature_3">Platnosť 1 mesiac od aktivácie</li>
           </ul>
         </article>
       </div>
-      <p class="pricing-note" data-i18n="pricing_note">Basic, Pro a Ultra sú dostupné mesačne alebo ročne.</p>
+      <p class="pricing-note" data-i18n="pricing_note">Stavy predplatného: čaká na spracovanie, spracúva sa, aktívne, zrušené, expirované.</p>
     </section>
 
     <section id="faq" class="section alt">

--- a/docs/API_DATABASE_LAYER.md
+++ b/docs/API_DATABASE_LAYER.md
@@ -112,3 +112,21 @@ DB_OPTION=postgres DB_CLOUD=postgresql://postgres:postgres@localhost:5432/aijuri
 - Use secrets for `DB_CLOUD` and `STORE_CLOUD`.
 - Keep `DB_OPTION=azure` and `STORAGE_OPTION=azure`.
 - This commit validates env contracts; production adapters can be plugged in next.
+
+## Subscription model (Task #86)
+
+The API database now seeds four subscription plans and tracks user subscription lifecycle:
+
+- `free` (`none`): assigned on sign-up, max 5 cases, 1 day case TTL.
+- `case` (`perCase`): €10, max 1 case, unlimited case time, assigned to user/case usage.
+- `basic` (`monthly`): €30/month, max 10 cases.
+- `premium` (`monthly`): €100/month, max 100 cases.
+
+Status model: `pending`, `paying`, `paid`, `canceled`, `expired`.
+For monthly plans, `starts_at` and `ends_at` are set when status switches to `paid`.
+
+Minimal runnable example:
+
+```bash
+python examples/subscription_minimal_demo.py
+```

--- a/examples/subscription_minimal_demo.py
+++ b/examples/subscription_minimal_demo.py
@@ -1,0 +1,51 @@
+"""Minimal demo for the subscription model introduced in task #86.
+
+Run:
+    python examples/subscription_minimal_demo.py
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from aijurisdictionagents.api_db import ApiDatabaseStore
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="subscription-demo-") as tmp:
+        root = Path(tmp)
+        store = ApiDatabaseStore(
+            db_path=root / "api.sqlite3",
+            blob_root=root / "blob",
+        )
+        store.initialize()
+
+        user = store.create_user(
+            phone_number="+421900123456",
+            email="demo@example.com",
+            password="demo-secret",
+            first_name="Demo",
+            last_name="User",
+        )
+
+        plans = store.list_subscription_plans()
+        print("Available plans:")
+        for plan in plans:
+            print(
+                f"- {plan.plan_code}: {plan.display_name}, {plan.subscription_type}, "
+                f"€{plan.price_eur}, max_cases={plan.max_cases}, case_ttl_days={plan.case_ttl_days}"
+            )
+
+        request = store.request_subscription_change(user_id=user.user_id, plan_code="basic")
+        print(f"\nRequested plan change: {request.plan_code} ({request.status})")
+
+        paid = store.update_subscription_status(
+            subscription_id=request.subscription_id,
+            status="paid",
+        )
+        print(f"Activated: status={paid.status}, starts_at={paid.starts_at}, ends_at={paid.ends_at}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mobile_app/lib/auth/local_auth_store.dart
+++ b/mobile_app/lib/auth/local_auth_store.dart
@@ -3,6 +3,64 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
+class SubscriptionPlanInfo {
+  const SubscriptionPlanInfo({
+    required this.planCode,
+    required this.displayName,
+    required this.subscriptionType,
+    required this.priceEur,
+    required this.maxCases,
+    this.caseTtlDays,
+  });
+
+  final String planCode;
+  final String displayName;
+  final String subscriptionType;
+  final int priceEur;
+  final int maxCases;
+  final int? caseTtlDays;
+
+  static SubscriptionPlanInfo fromJson(Map<String, dynamic> json) {
+    return SubscriptionPlanInfo(
+      planCode: json['plan_code'] as String? ?? '',
+      displayName: json['display_name'] as String? ?? '',
+      subscriptionType: json['subscription_type'] as String? ?? '',
+      priceEur: json['price_eur'] as int? ?? 0,
+      maxCases: json['max_cases'] as int? ?? 0,
+      caseTtlDays: json['case_ttl_days'] as int?,
+    );
+  }
+}
+
+class UserSubscriptionInfo {
+  const UserSubscriptionInfo({
+    required this.subscriptionId,
+    required this.userId,
+    required this.planCode,
+    required this.status,
+    this.startsAt,
+    this.endsAt,
+  });
+
+  final String subscriptionId;
+  final String userId;
+  final String planCode;
+  final String status;
+  final String? startsAt;
+  final String? endsAt;
+
+  static UserSubscriptionInfo fromJson(Map<String, dynamic> json) {
+    return UserSubscriptionInfo(
+      subscriptionId: json['subscription_id'] as String? ?? '',
+      userId: json['user_id'] as String? ?? '',
+      planCode: json['plan_code'] as String? ?? '',
+      status: json['status'] as String? ?? '',
+      startsAt: json['starts_at'] as String?,
+      endsAt: json['ends_at'] as String?,
+    );
+  }
+}
+
 class LocalAuthUser {
   const LocalAuthUser({
     required this.userId,
@@ -288,6 +346,41 @@ class LocalAuthStore {
     final updated = _userFromApiResponse(response, password: password);
     await _cacheSignedInUser(updated);
     return updated;
+  }
+
+  Future<List<SubscriptionPlanInfo>> listSubscriptionPlans() async {
+    final response = await http.get(baseUri.resolve('/v1/users/subscriptions/plans'), headers: _headers);
+    if (response.statusCode != 200) {
+      throw Exception(_extractErrorDetail(response));
+    }
+    final decoded = jsonDecode(response.body) as List<dynamic>;
+    return decoded
+        .whereType<Map<String, dynamic>>()
+        .map(SubscriptionPlanInfo.fromJson)
+        .toList(growable: false);
+  }
+
+  Future<List<UserSubscriptionInfo>> listUserSubscriptions({required String userId}) async {
+    final response = await http.get(baseUri.resolve('/v1/users/$userId/subscriptions'), headers: _headers);
+    if (response.statusCode != 200) {
+      throw Exception(_extractErrorDetail(response));
+    }
+    final decoded = jsonDecode(response.body) as List<dynamic>;
+    return decoded
+        .whereType<Map<String, dynamic>>()
+        .map(UserSubscriptionInfo.fromJson)
+        .toList(growable: false);
+  }
+
+  Future<UserSubscriptionInfo> requestSubscriptionChange({required String userId, required String planCode}) async {
+    final response = await _postJson(
+      path: '/v1/users/$userId/subscriptions',
+      payload: <String, Object?>{'plan_code': planCode},
+    );
+    if (response.statusCode != 201) {
+      throw Exception(_extractErrorDetail(response));
+    }
+    return UserSubscriptionInfo.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
   }
 
   Future<void> _cacheSignedInUser(LocalAuthUser user) async {

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -168,6 +168,10 @@ class AppStrings {
       'saving': 'Ukladam...',
       'update_sign_in_profile': 'Upravit prihlasovaci profil',
       'profile_update_failed': 'Aktualizacia profilu zlyhala: {{error}}',
+      'subscription': 'Predplatne',
+      'subscription_change_requested': 'Zmena predplatneho bola odoslana (pending).',
+      'subscription_change_failed': 'Zmena predplatneho zlyhala: {{error}}',
+      'subscription_status': 'Stav: {{status}}',
       'update_available': 'Dostupna aktualizacia',
       'update_body':
           'Na GitHube je nova verzia.\n\nAktualna: {{current}}\nNajnovsia: {{latest}}',
@@ -280,6 +284,10 @@ class AppStrings {
       'saving': 'Saving...',
       'update_sign_in_profile': 'Update sign in profile',
       'profile_update_failed': 'Profile update failed: {{error}}',
+      'subscription': 'Subscription',
+      'subscription_change_requested': 'Subscription change requested (pending).',
+      'subscription_change_failed': 'Failed to change subscription: {{error}}',
+      'subscription_status': 'Status: {{status}}',
       'update_available': 'Update available',
       'update_body':
           'A newer version is available on GitHub.\n\nCurrent: {{current}}\nLatest: {{latest}}',
@@ -387,6 +395,10 @@ class AppStrings {
       'saving': 'Speichere...',
       'update_sign_in_profile': 'Anmeldeprofil aktualisieren',
       'profile_update_failed': 'Profilaktualisierung fehlgeschlagen: {{error}}',
+      'subscription': 'Abonnement',
+      'subscription_change_requested': 'Abo-Aenderung gesendet (pending).',
+      'subscription_change_failed': 'Abo-Aenderung fehlgeschlagen: {{error}}',
+      'subscription_status': 'Status: {{status}}',
       'update_available': 'Update verfuegbar',
       'update_body':
           'Auf GitHub ist eine neuere Version verfuegbar.\n\nAktuell: {{current}}\nNeueste: {{latest}}',
@@ -2189,8 +2201,20 @@ class _AccountSettingsPageState extends State<AccountSettingsPage> {
   late final TextEditingController _firstNameController;
   late final TextEditingController _lastNameController;
   bool _isSaving = false;
+  bool _isLoadingSubscriptions = false;
+  bool _isUpdatingSubscription = false;
+  List<SubscriptionPlanInfo> _plans = <SubscriptionPlanInfo>[];
+  List<UserSubscriptionInfo> _subscriptions = <UserSubscriptionInfo>[];
+  String? _selectedPlanCode;
 
   AppStrings get _strings => AppStrings(widget.languageCode);
+
+  UserSubscriptionInfo? get _latestSubscription {
+    if (_subscriptions.isEmpty) {
+      return null;
+    }
+    return _subscriptions.first;
+  }
 
   @override
   void initState() {
@@ -2201,6 +2225,80 @@ class _AccountSettingsPageState extends State<AccountSettingsPage> {
         TextEditingController(text: widget.user.firstName ?? '');
     _lastNameController =
         TextEditingController(text: widget.user.lastName ?? '');
+    _loadSubscriptions();
+  }
+
+  Future<void> _loadSubscriptions() async {
+    setState(() {
+      _isLoadingSubscriptions = true;
+    });
+    try {
+      final plans = await widget.authStore.listSubscriptionPlans();
+      final subscriptions = await widget.authStore
+          .listUserSubscriptions(userId: widget.user.userId);
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _plans = plans;
+        _subscriptions = subscriptions;
+        _selectedPlanCode = subscriptions.isNotEmpty
+            ? subscriptions.first.planCode
+            : (plans.isNotEmpty ? plans.first.planCode : null);
+      });
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _plans = <SubscriptionPlanInfo>[];
+        _subscriptions = <UserSubscriptionInfo>[];
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoadingSubscriptions = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _requestSubscriptionChange() async {
+    final selectedPlanCode = _selectedPlanCode;
+    if (_isUpdatingSubscription || selectedPlanCode == null || selectedPlanCode.isEmpty) {
+      return;
+    }
+    setState(() {
+      _isUpdatingSubscription = true;
+    });
+    try {
+      await widget.authStore.requestSubscriptionChange(
+        userId: widget.user.userId,
+        planCode: selectedPlanCode,
+      );
+      await _loadSubscriptions();
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(_strings.t('subscription_change_requested'))),
+      );
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(_strings.t('subscription_change_failed', <String, String>{'error': '$error'})),
+        ),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isUpdatingSubscription = false;
+        });
+      }
+    }
   }
 
   @override
@@ -2291,6 +2389,41 @@ class _AccountSettingsPageState extends State<AccountSettingsPage> {
               labelText: strings.t('last_name'),
             ),
           ),
+          const SizedBox(height: 20),
+          Text(
+            strings.t('subscription'),
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          if (_isLoadingSubscriptions)
+            const LinearProgressIndicator()
+          else ...[
+            DropdownButtonFormField<String>(
+              value: _selectedPlanCode,
+              items: _plans
+                  .map((plan) => DropdownMenuItem<String>(
+                        value: plan.planCode,
+                        child: Text('${plan.displayName} (€${plan.priceEur})'),
+                      ))
+                  .toList(growable: false),
+              onChanged: (value) {
+                setState(() {
+                  _selectedPlanCode = value;
+                });
+              },
+            ),
+            const SizedBox(height: 8),
+            Text(
+              strings.t('subscription_status', <String, String>{
+                'status': _latestSubscription?.status ?? 'unknown',
+              }),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton(
+              onPressed: _isUpdatingSubscription ? null : _requestSubscriptionChange,
+              child: Text(strings.t('subscription')),
+            ),
+          ],
           const SizedBox(height: 20),
           FilledButton(
             onPressed: _isSaving ? null : _save,

--- a/src/aijurisdictionagents/api_db/__init__.py
+++ b/src/aijurisdictionagents/api_db/__init__.py
@@ -1,5 +1,14 @@
 from .config import ApiDataConfig
-from .store import ApiDatabaseStore, Case, CaseCommunication, CaseDocument, Company, User
+from .store import (
+    ApiDatabaseStore,
+    Case,
+    CaseCommunication,
+    CaseDocument,
+    Company,
+    SubscriptionPlan,
+    User,
+    UserSubscription,
+)
 
 __all__ = [
     "ApiDataConfig",
@@ -8,5 +17,7 @@ __all__ = [
     "CaseCommunication",
     "CaseDocument",
     "Company",
+    "SubscriptionPlan",
     "User",
+    "UserSubscription",
 ]

--- a/src/aijurisdictionagents/api_db/store.py
+++ b/src/aijurisdictionagents/api_db/store.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import hashlib
 import hmac
 import os
@@ -28,6 +28,29 @@ class User:
     first_name: str | None
     last_name: str | None
     full_name: str
+
+
+@dataclass(frozen=True)
+class SubscriptionPlan:
+    plan_code: str
+    display_name: str
+    subscription_type: str
+    price_eur: int
+    max_cases: int
+    case_ttl_days: int | None
+
+
+@dataclass(frozen=True)
+class UserSubscription:
+    subscription_id: str
+    user_id: str
+    plan_code: str
+    status: str
+    starts_at: str | None
+    ends_at: str | None
+    case_ids_json: str
+    created_at: str
+    updated_at: str
 
 
 @dataclass(frozen=True)
@@ -179,9 +202,35 @@ class ApiDatabaseStore:
                     created_at TEXT NOT NULL,
                     FOREIGN KEY(case_id) REFERENCES cases(case_id) ON DELETE CASCADE
                 );
+
+                CREATE TABLE IF NOT EXISTS subscription_plans (
+                    plan_code TEXT PRIMARY KEY,
+                    display_name TEXT NOT NULL,
+                    subscription_type TEXT NOT NULL,
+                    price_eur INTEGER NOT NULL,
+                    max_cases INTEGER NOT NULL,
+                    case_ttl_days INTEGER,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS user_subscriptions (
+                    subscription_id TEXT PRIMARY KEY,
+                    user_id TEXT NOT NULL,
+                    plan_code TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    starts_at TEXT,
+                    ends_at TEXT,
+                    case_ids_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    FOREIGN KEY(user_id) REFERENCES users(user_id) ON DELETE CASCADE,
+                    FOREIGN KEY(plan_code) REFERENCES subscription_plans(plan_code)
+                );
                 """,
             )
             self._ensure_user_schema(conn)
+            self._seed_subscription_plans(conn)
 
     def create_user(
         self,
@@ -227,6 +276,16 @@ class ApiDatabaseStore:
                     now,
                 ),
             )
+            self._execute(
+                conn,
+                """
+                INSERT INTO user_subscriptions(
+                    subscription_id, user_id, plan_code, status, starts_at, ends_at, case_ids_json, created_at, updated_at
+                )
+                VALUES (?, ?, 'free', 'paid', ?, NULL, '[]', ?, ?)
+                """,
+                (str(uuid.uuid4()), user_id, now, now, now),
+            )
         return User(
             user_id=user_id,
             phone_number=normalized_phone,
@@ -235,6 +294,112 @@ class ApiDatabaseStore:
             last_name=normalized_last,
             full_name=resolved_full_name,
         )
+
+    def list_subscription_plans(self) -> list[SubscriptionPlan]:
+        with self._connect() as conn:
+            rows = self._execute(
+                conn,
+                """
+                SELECT plan_code, display_name, subscription_type, price_eur, max_cases, case_ttl_days
+                FROM subscription_plans
+                ORDER BY price_eur ASC
+                """,
+            ).fetchall()
+        return [_row_to_subscription_plan(row) for row in rows]
+
+    def list_user_subscriptions(self, *, user_id: str) -> list[UserSubscription]:
+        with self._connect() as conn:
+            rows = self._execute(
+                conn,
+                """
+                SELECT subscription_id, user_id, plan_code, status, starts_at, ends_at, case_ids_json, created_at, updated_at
+                FROM user_subscriptions
+                WHERE user_id = ?
+                ORDER BY created_at DESC
+                """,
+                (user_id,),
+            ).fetchall()
+        return [_row_to_user_subscription(row) for row in rows]
+
+    def request_subscription_change(self, *, user_id: str, plan_code: str) -> UserSubscription:
+        now = _now_iso()
+        subscription_id = str(uuid.uuid4())
+        normalized_plan = plan_code.strip().lower()
+        with self._connect() as conn:
+            self._execute(
+                conn,
+                """
+                INSERT INTO user_subscriptions(
+                    subscription_id, user_id, plan_code, status, starts_at, ends_at, case_ids_json, created_at, updated_at
+                )
+                VALUES (?, ?, ?, 'pending', NULL, NULL, '[]', ?, ?)
+                """,
+                (subscription_id, user_id, normalized_plan, now, now),
+            )
+            row = self._fetchone(
+                conn,
+                """
+                SELECT subscription_id, user_id, plan_code, status, starts_at, ends_at, case_ids_json, created_at, updated_at
+                FROM user_subscriptions
+                WHERE subscription_id = ?
+                """,
+                (subscription_id,),
+            )
+        if row is None:
+            raise KeyError(f"Subscription {subscription_id} not found")
+        return _row_to_user_subscription(row)
+
+    def update_subscription_status(self, *, subscription_id: str, status: str) -> UserSubscription:
+        normalized_status = status.strip().lower()
+        if normalized_status not in {"pending", "paying", "paid", "canceled", "expired"}:
+            raise ValueError("Unsupported subscription status")
+
+        with self._connect() as conn:
+            current = self._fetchone(
+                conn,
+                """
+                SELECT subscription_id, user_id, plan_code, status, starts_at, ends_at, case_ids_json, created_at, updated_at
+                FROM user_subscriptions
+                WHERE subscription_id = ?
+                """,
+                (subscription_id,),
+            )
+            if current is None:
+                raise KeyError(f"Subscription {subscription_id} not found")
+            current_subscription = _row_to_user_subscription(current)
+
+            starts_at = current_subscription.starts_at
+            ends_at = current_subscription.ends_at
+            if normalized_status == "paid":
+                starts_at = _now_iso()
+                ends_at = self._resolve_subscription_end(
+                    conn,
+                    plan_code=current_subscription.plan_code,
+                    starts_at=starts_at,
+                )
+
+            now = _now_iso()
+            self._execute(
+                conn,
+                """
+                UPDATE user_subscriptions
+                SET status = ?, starts_at = ?, ends_at = ?, updated_at = ?
+                WHERE subscription_id = ?
+                """,
+                (normalized_status, starts_at, ends_at, now, subscription_id),
+            )
+            updated = self._fetchone(
+                conn,
+                """
+                SELECT subscription_id, user_id, plan_code, status, starts_at, ends_at, case_ids_json, created_at, updated_at
+                FROM user_subscriptions
+                WHERE subscription_id = ?
+                """,
+                (subscription_id,),
+            )
+        if updated is None:
+            raise KeyError(f"Subscription {subscription_id} not found")
+        return _row_to_user_subscription(updated)
 
     def authenticate_user(self, *, email: str, password: str) -> User | None:
         with self._connect() as conn:
@@ -767,6 +932,79 @@ class ApiDatabaseStore:
             WHERE full_name IS NULL OR TRIM(full_name) = ''
             """,
         )
+
+    def _seed_subscription_plans(self, conn: sqlite3.Connection | PostgresConnection[Any]) -> None:
+        now = _now_iso()
+        plans = [
+            ("free", "Free", "none", 0, 5, 1),
+            ("case", "Case", "perCase", 10, 1, None),
+            ("basic", "Basic", "monthly", 30, 10, None),
+            ("premium", "Premium", "monthly", 100, 100, None),
+        ]
+        for plan in plans:
+            self._execute(
+                conn,
+                """
+                INSERT INTO subscription_plans(
+                    plan_code, display_name, subscription_type, price_eur, max_cases, case_ttl_days, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(plan_code) DO UPDATE SET
+                    display_name = excluded.display_name,
+                    subscription_type = excluded.subscription_type,
+                    price_eur = excluded.price_eur,
+                    max_cases = excluded.max_cases,
+                    case_ttl_days = excluded.case_ttl_days,
+                    updated_at = excluded.updated_at
+                """,
+                (*plan, now, now),
+            )
+
+    def _resolve_subscription_end(
+        self,
+        conn: sqlite3.Connection | PostgresConnection[Any],
+        *,
+        plan_code: str,
+        starts_at: str,
+    ) -> str | None:
+        row = self._fetchone(
+            conn,
+            "SELECT subscription_type FROM subscription_plans WHERE plan_code = ?",
+            (plan_code,),
+        )
+        if row is None:
+            return None
+        plan_type = str(row[0]).lower()
+        if plan_type != "monthly":
+            return None
+        start_dt = datetime.fromisoformat(starts_at.replace("Z", "+00:00"))
+        return (start_dt + timedelta(days=30)).isoformat().replace("+00:00", "Z")
+
+
+def _row_to_subscription_plan(row: tuple[object, ...]) -> SubscriptionPlan:
+    values = list(row)
+    return SubscriptionPlan(
+        plan_code=str(values[0]),
+        display_name=str(values[1]),
+        subscription_type=str(values[2]),
+        price_eur=int(values[3]),
+        max_cases=int(values[4]),
+        case_ttl_days=int(values[5]) if values[5] is not None else None,
+    )
+
+
+def _row_to_user_subscription(row: tuple[object, ...]) -> UserSubscription:
+    values = list(row)
+    return UserSubscription(
+        subscription_id=str(values[0]),
+        user_id=str(values[1]),
+        plan_code=str(values[2]),
+        status=str(values[3]),
+        starts_at=str(values[4]) if values[4] is not None else None,
+        ends_at=str(values[5]) if values[5] is not None else None,
+        case_ids_json=str(values[6]),
+        created_at=str(values[7]),
+        updated_at=str(values[8]),
+    )
 
 
 def _now_iso() -> str:


### PR DESCRIPTION
### Motivation

- Implement a simple subscription model to track plans, per-user subscriptions and lifecycle states so users can change plans and the mobile app can display/trigger them.
- Seed default plans and ensure new users receive the `free` plan automatically for immediate usage limits enforcement.
- Expose the subscription operations through the local API and wire them into the mobile client UI.

### Description

- Add `SubscriptionPlan` and `UserSubscription` dataclasses and persist them by creating `subscription_plans` and `user_subscriptions` tables in `ApiDatabaseStore`, plus seeding of four plans (`free`, `case`, `basic`, `premium`).
- Implement subscription store operations: `list_subscription_plans`, `list_user_subscriptions`, `request_subscription_change`, `update_subscription_status`, and `_resolve_subscription_end`, and insert a `free` `user_subscriptions` row on user creation. 
- Add API endpoints under `/v1/users`: `GET /subscriptions/plans`, `GET /{user_id}/subscriptions`, `POST /{user_id}/subscriptions`, and `PATCH /subscriptions/{subscription_id}` with appropriate request/response models in `app/users/api.py`.
- Export new models from `src/aijurisdictionagents/api_db/__init__.py`, add `examples/subscription_minimal_demo.py`, and update `docs/API_DATABASE_LAYER.md` with the subscription model overview.
- Integrate client-side support in the mobile app by adding `SubscriptionPlanInfo` and `UserSubscriptionInfo` models, HTTP client methods in `LocalAuthStore`, UI controls and strings in `AccountSettingsPage` to list plans, request changes and show subscription status.
- Add an automated test `test_subscription_lifecycle` to `api/aijuristiction-api/tests/test_users.py` that exercises sign-up, listing plans, listing user subscriptions, requesting a plan change, and transitioning subscription status to `paid`.

### Testing

- Ran the API unit tests in `api/aijuristiction-api/tests`, including `test_subscription_lifecycle`, which completed successfully. 
- Verified the new example by running `python examples/subscription_minimal_demo.py` locally to exercise the store seeding and status transition logic. 
- No automated failures were observed in the modified test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b41ab487e08332b5f8d96dfa1262a6)