### PR TITLE
Add local+Azure API/mobile testing runbook and readiness checker

### DIFF
--- a/docs/LOCAL_AZURE_API_MOBILE_TESTING.md
+++ b/docs/LOCAL_AZURE_API_MOBILE_TESTING.md
@@ -1,0 +1,160 @@
+# Local + Azure API/PostgreSQL/Mobile Testing Runbook
+
+This runbook defines how to validate:
+
+1. Local API with local PostgreSQL.
+2. Mobile app against local API.
+3. Azure infrastructure deployment (including Azure Database for PostgreSQL Flexible Server).
+4. API deployment configured to use Azure PostgreSQL.
+5. Local mobile app against deployed Azure API.
+
+It also includes a fallback readiness workflow for constrained environments where Docker/Flutter/Azure CLI are not installed.
+
+## Quick readiness check (minimal runnable example)
+
+Run from repository root:
+
+```bash
+python examples/local_azure_readiness_check.py
+```
+
+The script verifies required tools, local ports, API health, and required Azure environment variables.
+
+## Prerequisites
+
+- Docker + Docker Compose
+- PowerShell (`pwsh`) for bundled project skills
+- Azure CLI (`az`) with active login
+- Flutter SDK
+- Python 3.11+
+- API dependencies installed (`pip install -e "api/aijuristiction-api[dev]"` from repo root or inside env)
+
+## 1) Validate local PostgreSQL + API
+
+Preferred path (PowerShell skill scripts):
+
+```powershell
+.\skills\start-postgress\scripts\start_postgress.ps1
+.\skills\start-api\scripts\start_api.ps1 -Background -LlmProvider mock -DatabaseOption postgres
+```
+
+Manual Linux fallback:
+
+```bash
+cd databases
+docker compose up -d postgres
+cd ..
+cd api/aijuristiction-api
+DB_OPTION=postgres \
+DB_CLOUD="postgresql://postgres:postgres@localhost:5432/aijurisdiction" \
+STORAGE_OPTION=local \
+LLM_PROVIDER=mock \
+python -m uvicorn app.main:app --host 127.0.0.1 --port 8080
+```
+
+Health checks:
+
+```bash
+curl -fsS http://127.0.0.1:8080/health
+python examples/minimal_demo.py
+```
+
+## 2) Validate local mobile app with local API
+
+Preferred skill command:
+
+```powershell
+.\skills\start-mobile-app\scripts\start_mobile_app.ps1 -Background -ApiMode localApi -DatabaseOption postgres
+```
+
+Manual fallback:
+
+```bash
+cd mobile_app
+flutter run -d chrome --web-port 7357 --dart-define=AIJ_API_BASE_URL=http://127.0.0.1:8080
+```
+
+Smoke check:
+
+- Open `http://127.0.0.1:7357`.
+- Perform sign-in/sign-up and one chat request.
+- Confirm API logs show incoming requests.
+
+## 3) Deploy Azure infrastructure + ensure Azure PostgreSQL exists
+
+```bash
+az login
+az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+```
+
+Use repo deployment script:
+
+```powershell
+.\infra\scripts\deploy_api.ps1 -SubscriptionId <sub-id> -AcrName <unique-acr>
+```
+
+Verify Azure PostgreSQL Flexible Server:
+
+```bash
+az postgres flexible-server show \
+  --name "$AZURE_DB_SERVER_NAME" \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --query "{name:name,state:state,version:version,publicAccess:network.publicNetworkAccess}" -o json
+```
+
+## 4) Deploy API configured for Azure PostgreSQL
+
+Ensure container app env vars include:
+
+- `DB_OPTION=azure`
+- `DB_CLOUD=postgresql://<user>:<password>@<server>.postgres.database.azure.com:5432/<db>?sslmode=require`
+- `STORAGE_OPTION=azure|local` (as desired)
+- `STORE_CLOUD=<storage connection string>` if `STORAGE_OPTION=azure`
+
+Run DB bootstrap/migrations against Azure DB before or during startup:
+
+```bash
+DB_OPTION=azure \
+DB_CLOUD="postgresql://...sslmode=require" \
+PYTHONPATH=src python databases/scripts/apply_db_migrations.py --project api
+
+DB_OPTION=azure \
+DB_CLOUD="postgresql://...sslmode=require" \
+PYTHONPATH=src python databases/scripts/apply_api_db_schema.py
+```
+
+Validate deployed API:
+
+```bash
+curl -fsS https://<deployed-api-host>/health
+curl -fsS https://<deployed-api-host>/version
+```
+
+## 5) Validate local mobile app against Azure-deployed API
+
+```bash
+cd mobile_app
+flutter run -d chrome --web-port 7357 --dart-define=AIJ_API_BASE_URL=https://<deployed-api-host>
+```
+
+Check:
+
+- Auth endpoints return success.
+- Chat/session endpoints persist metadata to Azure PostgreSQL.
+- New data appears in Azure DB tables (`users`, `subscriptions`, `case_documents`, etc.).
+
+## Environment-constrained fallback plan
+
+If current workstation/container is missing required tooling:
+
+1. Run `python examples/local_azure_readiness_check.py` and capture JSON output.
+2. Install missing tools (`docker`, `pwsh`, `flutter`, `az`) or switch to a dev VM that has them.
+3. Re-run readiness check until all `tool:*` checks pass.
+4. Execute steps 1-5 in this runbook.
+5. Archive outputs:
+   - Health check responses
+   - Deployment command logs
+   - API revision details
+   - Mobile smoke-test recording/screenshot
+
+This provides a reproducible test/deploy workflow even when immediate execution is not possible in the active environment.

--- a/examples/local_azure_readiness_check.py
+++ b/examples/local_azure_readiness_check.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Readiness checker for local+Azure API/mobile verification workflow."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, List
+from urllib import error, request
+
+
+@dataclass
+class CheckResult:
+    name: str
+    ok: bool
+    details: str
+
+
+def has_command(name: str) -> bool:
+    return shutil.which(name) is not None
+
+
+def run_command(command: List[str]) -> str:
+    try:
+        completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    except OSError as exc:
+        return f"failed to execute: {exc}"
+
+    output = (completed.stdout or "") + (completed.stderr or "")
+    output = output.strip() or "(no output)"
+    return f"exit={completed.returncode}; {output.splitlines()[0]}"
+
+
+def tcp_reachable(host: str, port: int, timeout: float = 1.0) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(timeout)
+        return sock.connect_ex((host, port)) == 0
+
+
+def fetch_json(url: str) -> Dict[str, object]:
+    with request.urlopen(url, timeout=5) as response:  # noqa: S310
+        payload = response.read().decode("utf-8")
+    return json.loads(payload)
+
+
+def check_api_health() -> CheckResult:
+    base_url = os.getenv("AIJ_API_BASE_URL", "http://127.0.0.1:8080")
+    health_url = f"{base_url}/health"
+    try:
+        payload = fetch_json(health_url)
+        return CheckResult("api_health", True, f"{health_url} responded: {payload}")
+    except (error.URLError, json.JSONDecodeError, TimeoutError) as exc:
+        return CheckResult("api_health", False, f"{health_url} unreachable or invalid JSON: {exc}")
+
+
+def check_env_vars() -> List[CheckResult]:
+    required = [
+        "AZURE_SUBSCRIPTION_ID",
+        "AZURE_RESOURCE_GROUP",
+        "AZURE_LOCATION",
+        "AZURE_DB_HOST",
+        "AZURE_DB_NAME",
+        "AZURE_DB_USER",
+        "AZURE_DB_PASSWORD",
+    ]
+    results: List[CheckResult] = []
+    for name in required:
+        value = os.getenv(name)
+        masked = "set" if value else "missing"
+        results.append(CheckResult(f"env:{name}", value is not None and value != "", masked))
+    return results
+
+
+def main() -> None:
+    checks: List[CheckResult] = []
+
+    tools = {
+        "python": ["python", "--version"],
+        "docker": ["docker", "--version"],
+        "az": ["az", "version"],
+        "flutter": ["flutter", "--version"],
+        "powershell": ["pwsh", "-Version"],
+    }
+    for name, probe in tools.items():
+        installed = has_command(name if name != "powershell" else "pwsh")
+        details = run_command(probe) if installed else "command not found"
+        checks.append(CheckResult(f"tool:{name}", installed, details))
+
+    checks.append(CheckResult("port:5432", tcp_reachable("127.0.0.1", 5432), "PostgreSQL local port probe"))
+    checks.append(CheckResult("port:8080", tcp_reachable("127.0.0.1", 8080), "API local port probe"))
+    checks.append(CheckResult("port:7357", tcp_reachable("127.0.0.1", 7357), "Flutter web local port probe"))
+    checks.append(check_api_health())
+    checks.extend(check_env_vars())
+
+    report = {
+        "repo_root": str(Path(__file__).resolve().parents[1]),
+        "checks": [asdict(check) for check in checks],
+    }
+
+    failures = [item for item in checks if not item.ok]
+    print(json.dumps(report, indent=2))
+    if failures:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide a reproducible verification and deployment runbook for validating local API + PostgreSQL + mobile flows and for deploying the API to Azure with an Azure PostgreSQL backend when the environment is properly provisioned.
- Offer a minimal, runnable readiness checker to detect missing tooling/services and required Azure environment variables in constrained environments so the full workflow can be executed reliably on a dev machine or CI runner.

### Description

- Add `docs/LOCAL_AZURE_API_MOBILE_TESTING.md` containing a step-by-step runbook for: local PostgreSQL + API validation, mobile app validation, Azure infra deployment (including Azure DB verification), API deployment configured for Azure PostgreSQL, and local mobile app testing against the deployed API.
- Add `examples/local_azure_readiness_check.py`, a minimal readiness checker that probes for required CLI tools (`docker`, `az`, `flutter`, `pwsh`), checks local ports (`5432`, `8080`, `7357`), calls the API `/health` endpoint, and verifies required Azure env vars.
- Adjusted run instructions in the runbook to use the repository-local `api/aijuristiction-api` path when invoking `uvicorn` for local API manual fallback.
- Provide clear manual and PowerShell skill-based commands and a constrained-environment fallback plan to run the entire verification/deploy workflow on a properly provisioned host.

### Testing

- `python -m py_compile examples/local_azure_readiness_check.py` succeeded confirming the checker is syntactically valid.
- Running `python examples/local_azure_readiness_check.py` produced a JSON report and exited non-zero because `docker`, `az`, `flutter`, `pwsh` and local services were not present in this environment (expected failure in constrained container).
- Running `python examples/minimal_demo.py` failed with connection refused because the local API was not running at `http://localhost:8080` in this environment.
- Attempts to run `pwsh` scripts and to query `docker --version`, `az version`, and `flutter --version` all reported `command not found` in this container, which is documented in the runbook and handled by the readiness checker.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b445a33a2083329725c939328890e5)