### PR TITLE
Add local fake payment service and subscription checkout/confirmation endpoints with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ Conda notes:
   dependencies, and tooling (needed for `pip install -e .`).
 
 
+## Local Fake Payment Service
+
+A fake PayPal-compatible payment simulator is available in `service/` for local integrations and demos.
+
+```bash
+node service/fake_paypal_service.js
+```
+
+Minimal runnable demo:
+
+```bash
+./service/examples/paypal_payment_demo.sh
+```
+
+For full endpoint details, see `service/README.md`.
+
 ## Features
 
 - Document ingestion from `data/` (txt/md, PDF optional)

--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -128,6 +128,41 @@ same `x-api-key` guard as the chat endpoints.
 - `PATCH /v1/users/subscriptions/{subscription_id}`
   - request: `status` in (`pending`, `paying`, `paid`, `canceled`, `expired`)
   - monthly plans start a 30-day window when status changes to `paid`
+- `POST /v1/users/{user_id}/subscriptions/checkout`
+  - request: `plan_code`, `payment_provider` (`paypal` or `google_pay`)
+  - creates a pending subscription change, sets subscription status to `paying`, and returns a fake checkout URL
+- `POST /v1/users/subscriptions/{subscription_id}/confirm-payment`
+  - request: `payment_id` returned from checkout
+  - payment simulation rule: only user phone `+421944400166` is allowed to complete payment successfully
+  - all other phone numbers receive simulated payment failure and the requested subscription is canceled (no upgrade)
+
+### Subscription payment flow (PayPal / Google Pay simulation)
+
+### Mobile-app simulation behavior
+
+- The checkout/confirm API path is the same path used by the mobile app integration.
+- To test a successful payment upgrade in local/dev, create/sign in a user with phone `+421944400166`.
+- To test unsuccessful payment handling, use any other phone number; confirmation returns HTTP `402` and subscription remains not upgraded.
+
+Minimal runnable example:
+
+```bash
+python examples/minimal_demo.py
+```
+
+```bash
+# 1) Start checkout for new subscription
+curl -X POST "http://localhost:8080/v1/users/<USER_ID>/subscriptions/checkout" \
+  -H "x-api-key: aijuris" \
+  -H "Content-Type: application/json" \
+  -d '{"plan_code":"premium","payment_provider":"paypal"}'
+
+# 2) Confirm returned payment_id (simulated webhook/callback)
+curl -X POST "http://localhost:8080/v1/users/subscriptions/<SUBSCRIPTION_ID>/confirm-payment" \
+  -H "x-api-key: aijuris" \
+  -H "Content-Type: application/json" \
+  -d '{"payment_id":"PAY-..."}'
+```
 
 These endpoints persist users through `aijurisdictionagents.api_db.ApiDatabaseStore`
 and support three database modes:

--- a/api/aijuristiction-api/app/users/api.py
+++ b/api/aijuristiction-api/app/users/api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
@@ -72,6 +73,29 @@ class SubscriptionChangeRequest(BaseModel):
 
 class SubscriptionStatusUpdateRequest(BaseModel):
     status: str = Field(min_length=1)
+
+
+class SubscriptionCheckoutRequest(BaseModel):
+    plan_code: str = Field(min_length=1)
+    payment_provider: str = Field(min_length=1, description="paypal or google_pay")
+
+
+class SubscriptionCheckoutResponse(BaseModel):
+    subscription_id: str
+    plan_code: str
+    payment_provider: str
+    payment_id: str
+    payment_status: str
+    amount_eur: int
+    checkout_url: str
+
+
+class SubscriptionPaymentConfirmationRequest(BaseModel):
+    payment_id: str = Field(min_length=1)
+
+
+_payment_sessions: dict[str, dict[str, str | int]] = {}
+_ALLOWED_SUCCESS_PHONE = "+421944400166"
 
 
 def get_user_store() -> ApiDatabaseStore:
@@ -178,6 +202,95 @@ def update_subscription_status(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return _to_subscription_response(item)
+
+
+@router.post(
+    "/{user_id}/subscriptions/checkout",
+    response_model=SubscriptionCheckoutResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def checkout_subscription_change(
+    user_id: str,
+    payload: SubscriptionCheckoutRequest,
+    store: ApiDatabaseStore = Depends(get_user_store),
+) -> SubscriptionCheckoutResponse:
+    provider = payload.payment_provider.strip().lower()
+    if provider not in {"paypal", "google_pay"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unsupported payment provider. Use paypal or google_pay",
+        )
+
+    plans = {plan.plan_code: plan for plan in store.list_subscription_plans()}
+    plan_code = payload.plan_code.strip().lower()
+    if plan_code not in plans:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid plan code")
+
+    try:
+        subscription = store.request_subscription_change(user_id=user_id, plan_code=plan_code)
+        subscription = store.update_subscription_status(subscription_id=subscription.subscription_id, status="paying")
+    except sqlite3.IntegrityError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid plan code") from exc
+
+    payment_id = f"PAY-{uuid4()}"
+    checkout_token = str(uuid4())
+    checkout_base = "https://www.sandbox.paypal.com/checkoutnow"
+    if provider == "google_pay":
+        checkout_base = "https://pay.google.com/gp/p/ui/pay"
+    checkout_url = f"{checkout_base}?token={checkout_token}&paymentId={payment_id}"
+
+    _payment_sessions[payment_id] = {
+        "subscription_id": subscription.subscription_id,
+        "user_id": user_id,
+        "payment_provider": provider,
+        "plan_code": plan_code,
+        "payment_status": "pending",
+        "amount_eur": plans[plan_code].price_eur,
+    }
+
+    return SubscriptionCheckoutResponse(
+        subscription_id=subscription.subscription_id,
+        plan_code=plan_code,
+        payment_provider=provider,
+        payment_id=payment_id,
+        payment_status="pending",
+        amount_eur=plans[plan_code].price_eur,
+        checkout_url=checkout_url,
+    )
+
+
+@router.post("/subscriptions/{subscription_id}/confirm-payment", response_model=UserSubscriptionResponse)
+def confirm_subscription_payment(
+    subscription_id: str,
+    payload: SubscriptionPaymentConfirmationRequest,
+    store: ApiDatabaseStore = Depends(get_user_store),
+) -> UserSubscriptionResponse:
+    payment = _payment_sessions.get(payload.payment_id)
+    if payment is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Payment not found")
+    if payment["subscription_id"] != subscription_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Payment does not match subscription")
+
+    user_id = str(payment["user_id"])
+    try:
+        user = store.get_user(user_id=user_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+    if user.phone_number != _ALLOWED_SUCCESS_PHONE:
+        payment["payment_status"] = "failed"
+        item = store.update_subscription_status(subscription_id=subscription_id, status="canceled")
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={
+                "message": "Payment failed (simulated). Subscription was not upgraded.",
+                "subscription": _to_subscription_response(item).model_dump(),
+            },
+        )
+
+    payment["payment_status"] = "paid"
+    item = store.update_subscription_status(subscription_id=subscription_id, status="paid")
     return _to_subscription_response(item)
 
 

--- a/api/aijuristiction-api/tests/test_users.py
+++ b/api/aijuristiction-api/tests/test_users.py
@@ -209,3 +209,112 @@ def test_subscription_lifecycle(monkeypatch, tmp_path: Path) -> None:
     assert paid["status"] == "paid"
     assert paid["starts_at"] is not None
     assert paid["ends_at"] is not None
+
+
+def test_subscription_checkout_payment_failure_does_not_upgrade_for_non_whitelisted_phone(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _configure_db_env(monkeypatch, tmp_path)
+
+    sign_up_response = client.post(
+        "/v1/users/sign-up",
+        headers=AUTH_HEADERS,
+        json={
+            "phone_number": "+421900565656",
+            "email": "checkout@example.com",
+            "password": "secret-pass",
+            "first_name": "Checkout",
+            "last_name": "User",
+        },
+    )
+    assert sign_up_response.status_code == 201
+    user_id = sign_up_response.json()["user_id"]
+
+    checkout_response = client.post(
+        f"/v1/users/{user_id}/subscriptions/checkout",
+        headers=AUTH_HEADERS,
+        json={"plan_code": "premium", "payment_provider": "paypal"},
+    )
+    assert checkout_response.status_code == 201
+    checkout = checkout_response.json()
+    assert checkout["payment_provider"] == "paypal"
+    assert checkout["payment_status"] == "pending"
+    assert checkout["amount_eur"] == 100
+    assert checkout["checkout_url"].startswith("https://www.sandbox.paypal.com")
+
+    confirm_response = client.post(
+        f"/v1/users/subscriptions/{checkout['subscription_id']}/confirm-payment",
+        headers=AUTH_HEADERS,
+        json={"payment_id": checkout["payment_id"]},
+    )
+    assert confirm_response.status_code == 402
+
+    subscriptions_response = client.get(f"/v1/users/{user_id}/subscriptions", headers=AUTH_HEADERS)
+    assert subscriptions_response.status_code == 200
+    subscriptions = subscriptions_response.json()
+    assert subscriptions[0]["subscription_id"] == checkout["subscription_id"]
+    assert subscriptions[0]["status"] == "canceled"
+    assert subscriptions[1]["plan_code"] == "free"
+    assert subscriptions[1]["status"] == "paid"
+
+
+def test_subscription_checkout_and_payment_confirmation_success_for_whitelisted_phone(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _configure_db_env(monkeypatch, tmp_path)
+
+    sign_up_response = client.post(
+        "/v1/users/sign-up",
+        headers=AUTH_HEADERS,
+        json={
+            "phone_number": "+421944400166",
+            "email": "checkout-allowed@example.com",
+            "password": "secret-pass",
+            "first_name": "Allowed",
+            "last_name": "User",
+        },
+    )
+    assert sign_up_response.status_code == 201
+    user_id = sign_up_response.json()["user_id"]
+
+    checkout_response = client.post(
+        f"/v1/users/{user_id}/subscriptions/checkout",
+        headers=AUTH_HEADERS,
+        json={"plan_code": "premium", "payment_provider": "paypal"},
+    )
+    assert checkout_response.status_code == 201
+    checkout = checkout_response.json()
+
+    confirm_response = client.post(
+        f"/v1/users/subscriptions/{checkout['subscription_id']}/confirm-payment",
+        headers=AUTH_HEADERS,
+        json={"payment_id": checkout["payment_id"]},
+    )
+    assert confirm_response.status_code == 200
+    assert confirm_response.json()["status"] == "paid"
+
+
+def test_subscription_checkout_accepts_google_pay(monkeypatch, tmp_path: Path) -> None:
+    _configure_db_env(monkeypatch, tmp_path)
+
+    sign_up_response = client.post(
+        "/v1/users/sign-up",
+        headers=AUTH_HEADERS,
+        json={
+            "phone_number": "+421900676767",
+            "email": "googlepay@example.com",
+            "password": "secret-pass",
+            "first_name": "Google",
+            "last_name": "Pay",
+        },
+    )
+    assert sign_up_response.status_code == 201
+    user_id = sign_up_response.json()["user_id"]
+
+    checkout_response = client.post(
+        f"/v1/users/{user_id}/subscriptions/checkout",
+        headers=AUTH_HEADERS,
+        json={"plan_code": "basic", "payment_provider": "google_pay"},
+    )
+    assert checkout_response.status_code == 201
+    assert checkout_response.json()["checkout_url"].startswith("https://pay.google.com")

--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,43 @@
+# Fake PayPal Payment Service
+
+A lightweight local fake payment service that simulates a subset of the PayPal payment flow.
+
+## Run
+
+```bash
+node service/fake_paypal_service.js
+```
+
+Environment variables:
+
+- `PAYMENT_SERVICE_HOST` (default `0.0.0.0`)
+- `PAYMENT_SERVICE_PORT` (default `8088`)
+
+## Endpoints
+
+- `GET /health`
+- `POST /paypal/payments`
+- `GET /paypal/payments/:id`
+- `POST /paypal/payments/:id/execute`
+
+## Minimal runnable example
+
+1. Start the service:
+
+```bash
+node service/fake_paypal_service.js
+```
+
+2. In another terminal run:
+
+```bash
+./service/examples/paypal_payment_demo.sh
+```
+
+The script creates a payment, fetches it, and executes it.
+
+## Local test
+
+```bash
+node service/tests/fake_paypal_service.test.js
+```

--- a/service/examples/paypal_payment_demo.sh
+++ b/service/examples/paypal_payment_demo.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost:8088}"
+
+printf 'Creating fake PayPal payment...\n'
+create_response=$(curl -sS -X POST "$BASE_URL/paypal/payments" \
+  -H 'content-type: application/json' \
+  -d '{"amount":59.99,"currency":"eur","payerEmail":"buyer@example.com","description":"Subscription renewal"}')
+
+printf '%s\n' "$create_response"
+
+payment_id=$(printf '%s' "$create_response" | sed -n 's/.*"id": "\(PAY-[^"]*\)".*/\1/p' | head -n 1)
+
+if [[ -z "$payment_id" ]]; then
+  printf 'Unable to parse payment id from response.\n' >&2
+  exit 1
+fi
+
+printf '\nFetching payment %s...\n' "$payment_id"
+curl -sS "$BASE_URL/paypal/payments/$payment_id"
+
+printf '\n\nExecuting payment %s...\n' "$payment_id"
+curl -sS -X POST "$BASE_URL/paypal/payments/$payment_id/execute"
+
+printf '\n\nDone.\n'

--- a/service/fake_paypal_service.js
+++ b/service/fake_paypal_service.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+const http = require('http');
+const { randomUUID } = require('crypto');
+
+const host = process.env.PAYMENT_SERVICE_HOST ?? '0.0.0.0';
+const port = Number.parseInt(process.env.PAYMENT_SERVICE_PORT ?? '8088', 10);
+
+/** @type {Map<string, {id:string, amount:number, currency:string, payerEmail:string, description:string, status:string, createdAt:string, executedAt:string|null}>} */
+const payments = new Map();
+
+const json = (res, code, payload) => {
+  res.writeHead(code, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(payload, null, 2));
+};
+
+const parseBody = async (req) => {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  if (chunks.length === 0) {
+    return {};
+  }
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+  } catch {
+    const err = new Error('Request body must be valid JSON.');
+    err.statusCode = 400;
+    throw err;
+  }
+};
+
+const validateCreatePaymentRequest = (body) => {
+  if (typeof body.amount !== 'number' || Number.isNaN(body.amount) || body.amount <= 0) {
+    return 'amount must be a positive number';
+  }
+  if (typeof body.currency !== 'string' || body.currency.trim().length !== 3) {
+    return 'currency must be a 3-letter code';
+  }
+  if (typeof body.payerEmail !== 'string' || !body.payerEmail.includes('@')) {
+    return 'payerEmail must be a valid email-like string';
+  }
+  if (typeof body.description !== 'string' || body.description.trim().length === 0) {
+    return 'description must be a non-empty string';
+  }
+  return null;
+};
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+
+    if (req.method === 'GET' && url.pathname === '/health') {
+      return json(res, 200, {
+        service: 'fake-paypal-service',
+        status: 'ok',
+        payments: payments.size,
+      });
+    }
+
+    if (req.method === 'POST' && url.pathname === '/paypal/payments') {
+      const body = await parseBody(req);
+      const validationError = validateCreatePaymentRequest(body);
+      if (validationError) {
+        return json(res, 400, { error: validationError });
+      }
+
+      const paymentId = `PAY-${randomUUID()}`;
+      const record = {
+        id: paymentId,
+        amount: body.amount,
+        currency: body.currency.toUpperCase(),
+        payerEmail: body.payerEmail,
+        description: body.description,
+        status: 'CREATED',
+        createdAt: new Date().toISOString(),
+        executedAt: null,
+      };
+      payments.set(paymentId, record);
+
+      return json(res, 201, {
+        payment: record,
+        links: {
+          approvalUrl: `https://www.sandbox.paypal.com/checkoutnow?token=${paymentId}`,
+          executeUrl: `/paypal/payments/${paymentId}/execute`,
+        },
+      });
+    }
+
+    const executeMatch = url.pathname.match(/^\/paypal\/payments\/(PAY-[a-f0-9-]+)\/execute$/i);
+    if (req.method === 'POST' && executeMatch) {
+      const paymentId = executeMatch[1];
+      const payment = payments.get(paymentId);
+      if (!payment) {
+        return json(res, 404, { error: 'Payment not found' });
+      }
+      if (payment.status === 'COMPLETED') {
+        return json(res, 409, { error: 'Payment already completed', payment });
+      }
+      payment.status = 'COMPLETED';
+      payment.executedAt = new Date().toISOString();
+      return json(res, 200, {
+        message: 'Payment executed in fake PayPal sandbox.',
+        payment,
+      });
+    }
+
+    const getMatch = url.pathname.match(/^\/paypal\/payments\/(PAY-[a-f0-9-]+)$/i);
+    if (req.method === 'GET' && getMatch) {
+      const paymentId = getMatch[1];
+      const payment = payments.get(paymentId);
+      if (!payment) {
+        return json(res, 404, { error: 'Payment not found' });
+      }
+      return json(res, 200, { payment });
+    }
+
+    return json(res, 404, {
+      error: 'Not found',
+      availableEndpoints: [
+        'GET /health',
+        'POST /paypal/payments',
+        'GET /paypal/payments/:id',
+        'POST /paypal/payments/:id/execute',
+      ],
+    });
+  } catch (error) {
+    return json(res, error.statusCode ?? 500, {
+      error: error.message ?? 'Unexpected server error',
+    });
+  }
+});
+
+server.listen(port, host, () => {
+  console.log(`Fake PayPal service is running at http://${host}:${port}`);
+});

--- a/service/tests/fake_paypal_service.test.js
+++ b/service/tests/fake_paypal_service.test.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+const assert = require('assert/strict');
+const { spawn } = require('child_process');
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const run = async () => {
+  const port = 18088;
+  const server = spawn('node', ['service/fake_paypal_service.js'], {
+    env: { ...process.env, PAYMENT_SERVICE_PORT: String(port), PAYMENT_SERVICE_HOST: '127.0.0.1' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let startupLogs = '';
+  server.stdout.on('data', (chunk) => {
+    startupLogs += chunk.toString('utf-8');
+  });
+  server.stderr.on('data', (chunk) => {
+    startupLogs += chunk.toString('utf-8');
+  });
+
+  try {
+    for (let i = 0; i < 30; i += 1) {
+      try {
+        const health = await fetch(`http://127.0.0.1:${port}/health`);
+        if (health.ok) {
+          break;
+        }
+      } catch {
+        await wait(100);
+      }
+    }
+
+    const createResponse = await fetch(`http://127.0.0.1:${port}/paypal/payments`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        amount: 12.34,
+        currency: 'usd',
+        payerEmail: 'buyer@example.com',
+        description: 'Test payment',
+      }),
+    });
+
+    assert.equal(createResponse.status, 201);
+    const created = await createResponse.json();
+    assert.equal(created.payment.status, 'CREATED');
+    assert.ok(created.payment.id.startsWith('PAY-'));
+
+    const executeResponse = await fetch(
+      `http://127.0.0.1:${port}/paypal/payments/${created.payment.id}/execute`,
+      { method: 'POST' },
+    );
+
+    assert.equal(executeResponse.status, 200);
+    const executed = await executeResponse.json();
+    assert.equal(executed.payment.status, 'COMPLETED');
+
+    const duplicateExecute = await fetch(
+      `http://127.0.0.1:${port}/paypal/payments/${created.payment.id}/execute`,
+      { method: 'POST' },
+    );
+
+    assert.equal(duplicateExecute.status, 409);
+    console.log('fake_paypal_service test passed');
+  } finally {
+    server.kill('SIGTERM');
+    await wait(50);
+    if (server.exitCode === null) {
+      server.kill('SIGKILL');
+    }
+    if (startupLogs.length > 0) {
+      process.stderr.write(startupLogs);
+    }
+  }
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/aijurisdictionagents/api_db/store.py
+++ b/src/aijurisdictionagents/api_db/store.py
@@ -436,6 +436,21 @@ class ApiDatabaseStore:
             return None
         return _row_to_user(row)
 
+    def get_user(self, *, user_id: str) -> User:
+        with self._connect() as conn:
+            row = self._fetchone(
+                conn,
+                """
+                SELECT user_id, phone_number, email, first_name, last_name, full_name
+                FROM users
+                WHERE user_id = ?
+                """,
+                (user_id,),
+            )
+        if row is None:
+            raise KeyError(f"User {user_id} not found")
+        return _row_to_user(row)
+
     def update_user(
         self,
         *,


### PR DESCRIPTION
### Motivation

- Provide a local PayPal/Google Pay-compatible simulator and API paths to exercise subscription checkout and confirmation flows for demos and mobile-app integration testing.
- Allow testing of successful and failed payments in the local environment without calling real payment providers.

### Description

- Add a lightweight fake payment service in `service/` including `fake_paypal_service.js`, a README, an example demo script `service/examples/paypal_payment_demo.sh`, and a node test `service/tests/fake_paypal_service.test.js` to simulate create/fetch/execute payment flows.
- Introduce subscription checkout and confirmation endpoints in the API at `POST /v1/users/{user_id}/subscriptions/checkout` and `POST /v1/users/subscriptions/{subscription_id}/confirm-payment` with new Pydantic models (`SubscriptionCheckoutRequest`, `SubscriptionCheckoutResponse`, `SubscriptionPaymentConfirmationRequest`) and an in-memory `_payment_sessions` store and a whitelisted phone constant `_ALLOWED_SUCCESS_PHONE` for simulating success vs failure.
- Update API docs in `api/aijuristiction-api/README.md` and the repo `README.md` to document the local fake payment service and the checkout/confirm endpoints and example flows.
- Add server-side helper `get_user` to the database store (`ApiDatabaseStore.get_user`) to fetch users by `user_id` and raise `KeyError` if not found.
- Add comprehensive tests in `api/aijuristiction-api/tests/test_users.py` covering checkout creation, failure path for non-whitelisted phones, success path for the whitelisted phone, and acceptance of `google_pay` as a provider.

### Testing

- Ran the API unit tests with `pytest api/aijuristiction-api/tests` which executed the expanded subscription lifecycle and checkout/confirmation tests and they passed.
- Ran the local fake payment service test with Node using `node service/tests/fake_paypal_service.test.js` which started the service, exercised create/execute/duplicate-execute scenarios, and the test passed.
- Manually exercised the demo script `./service/examples/paypal_payment_demo.sh` against the running fake service during development (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5628782cc83328220db5e258af927)