### PR TITLE
Protect /app routes for unauthenticated users (#100)

### DIFF
--- a/docs/FRONTEND_DEMO.md
+++ b/docs/FRONTEND_DEMO.md
@@ -60,6 +60,11 @@ npm run preview
 
 When authenticated, the home page swaps to a 3-column workspace layout: case sidebar, active workspace, and AI configuration panel. On narrow screens the side panels collapse and the center workspace takes full width.
 
+Route access behavior:
+- All `/app/*` routes are protected by auth state.
+- Unauthenticated users attempting `/app/*` are redirected to `/`.
+- After logout, protected routes are no longer accessible until sign-in.
+
 Case sidebar behavior:
 - `+ New case` creates a mock case and makes it active.
 - Clicking a case loads its data into the center workspace and AI configuration panel.

--- a/frontend/aijurisdictionfronend/README.md
+++ b/frontend/aijurisdictionfronend/README.md
@@ -31,6 +31,14 @@ The UI includes an in-memory auth state used for local development. It resets on
 
 When authenticated, the home page switches to a 3-column workspace layout (case sidebar, active workspace, AI configuration). On smaller screens the side panels collapse for a single-column layout.
 
+## Protected App Routes
+
+All `/app/*` routes are guarded by mock auth state.
+
+- Unauthenticated users are redirected to `/`
+- Authenticated users can access the full app area (`/app`, `/app/profile`, `/app/workspace`, etc.)
+- Logging out from the profile dropdown immediately removes access to protected routes
+
 ## Navbar Branding
 
 The signed-out navigation includes the same app logo treatment used in the signed-in sidebar (`AJ` mark + app name/tagline).

--- a/frontend/aijurisdictionfronend/src/App.tsx
+++ b/frontend/aijurisdictionfronend/src/App.tsx
@@ -1,6 +1,7 @@
-﻿import React from "react";
+import React from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 import { PageLayout } from "./components/PageLayout";
+import { useAuth } from "./auth/mockAuth";
 import AuthCallbackView from "./auth/AuthCallbackView";
 import Home from "./pages/Home";
 import Auth from "./pages/Auth";
@@ -18,6 +19,20 @@ import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
 import NotFound from "./pages/NotFound";
 
+interface ProtectedRouteProps {
+  children: React.ReactElement;
+}
+
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
+  const { isAuthenticated } = useAuth();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/" replace />;
+  }
+
+  return children;
+};
+
 const App: React.FC = () => {
   return (
     <PageLayout>
@@ -29,14 +44,70 @@ const App: React.FC = () => {
           element={<AuthCallbackView onSessionReady={() => undefined} />}
         />
         <Route path="/pricing" element={<Pricing />} />
-        <Route path="/app" element={<AppDashboard />} />
-        <Route path="/app/case" element={<CaseIntake />} />
-        <Route path="/app/workspace" element={<LawyerWorkspace />} />
-        <Route path="/app/advice" element={<AdviceSummary />} />
-        <Route path="/app/communications" element={<Communication />} />
-        <Route path="/app/law-validation" element={<LawValidation />} />
-        <Route path="/app/law-recommendation" element={<LawRecommendation />} />
-        <Route path="/app/profile" element={<Profile />} />
+        <Route
+          path="/app"
+          element={
+            <ProtectedRoute>
+              <AppDashboard />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/app/case"
+          element={
+            <ProtectedRoute>
+              <CaseIntake />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/app/workspace"
+          element={
+            <ProtectedRoute>
+              <LawyerWorkspace />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/app/advice"
+          element={
+            <ProtectedRoute>
+              <AdviceSummary />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/app/communications"
+          element={
+            <ProtectedRoute>
+              <Communication />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/app/law-validation"
+          element={
+            <ProtectedRoute>
+              <LawValidation />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/app/law-recommendation"
+          element={
+            <ProtectedRoute>
+              <LawRecommendation />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/app/profile"
+          element={
+            <ProtectedRoute>
+              <Profile />
+            </ProtectedRoute>
+          }
+        />
         <Route path="/privacy" element={<PrivacyPolicy />} />
         <Route path="/disclaimer" element={<Disclaimer />} />
         <Route path="/terms" element={<TermsOfService />} />

--- a/frontend/aijurisdictionfronend/src/__tests__/appProtectedRoutes.test.tsx
+++ b/frontend/aijurisdictionfronend/src/__tests__/appProtectedRoutes.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import App from "../App";
+
+const authState = vi.hoisted(() => ({ isAuthenticated: false }));
+
+vi.mock("../auth/mockAuth", () => ({
+  useAuth: () => ({
+    isAuthenticated: authState.isAuthenticated
+  })
+}));
+
+vi.mock("../components/PageLayout", () => ({
+  PageLayout: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}));
+
+vi.mock("../auth/AuthCallbackView", () => ({
+  default: () => <div>Auth Callback</div>
+}));
+
+vi.mock("../pages/Home", () => ({
+  default: () => <div>Home Page</div>
+}));
+
+vi.mock("../pages/Auth", () => ({
+  default: () => <div>Auth Page</div>
+}));
+
+vi.mock("../pages/Pricing", () => ({
+  default: () => <div>Pricing Page</div>
+}));
+
+vi.mock("../pages/AppDashboard", () => ({
+  default: () => <div>App Dashboard</div>
+}));
+
+vi.mock("../pages/CaseIntake", () => ({
+  default: () => <div>Case Intake</div>
+}));
+
+vi.mock("../pages/LawyerWorkspace", () => ({
+  default: () => <div>Lawyer Workspace</div>
+}));
+
+vi.mock("../pages/AdviceSummary", () => ({
+  default: () => <div>Advice Summary</div>
+}));
+
+vi.mock("../pages/Communication", () => ({
+  default: () => <div>Communication</div>
+}));
+
+vi.mock("../pages/LawValidation", () => ({
+  default: () => <div>Law Validation</div>
+}));
+
+vi.mock("../pages/LawRecommendation", () => ({
+  default: () => <div>Law Recommendation</div>
+}));
+
+vi.mock("../pages/Profile", () => ({
+  default: () => <div>Profile Page</div>
+}));
+
+vi.mock("../pages/Disclaimer", () => ({
+  default: () => <div>Disclaimer</div>
+}));
+
+vi.mock("../pages/PrivacyPolicy", () => ({
+  default: () => <div>Privacy</div>
+}));
+
+vi.mock("../pages/TermsOfService", () => ({
+  default: () => <div>Terms</div>
+}));
+
+vi.mock("../pages/NotFound", () => ({
+  default: () => <div>Not Found</div>
+}));
+
+describe("App protected routes", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("redirects unauthenticated users from /app to /", () => {
+    authState.isAuthenticated = false;
+
+    render(
+      <MemoryRouter initialEntries={["/app"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Home Page")).toBeDefined();
+    expect(screen.queryByText("App Dashboard")).toBeNull();
+  });
+
+  it("redirects unauthenticated users from nested /app route to /", () => {
+    authState.isAuthenticated = false;
+
+    render(
+      <MemoryRouter initialEntries={["/app/workspace"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Home Page")).toBeDefined();
+    expect(screen.queryByText("Lawyer Workspace")).toBeNull();
+  });
+
+  it("allows authenticated users to access /app/profile", () => {
+    authState.isAuthenticated = true;
+
+    render(
+      <MemoryRouter initialEntries={["/app/profile"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Profile Page")).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add a ProtectedRoute wrapper in App routing
- guard all /app/* routes and redirect unauthenticated users to /
- keep authenticated access unchanged
- add route-level tests for redirect and allowed access
- update frontend docs with protected route behavior

## Verification
- npm run test

Closes #100