### PR TITLE
Fix mobile speech-flow unit test; bump build number and refresh lockfile

### DIFF
--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -270,6 +270,10 @@ Speech service unit tests now initialize `TestWidgetsFlutterBinding` before cons
 `FlutterTts`-backed services, which keeps the CI `flutter test` step stable after speech
 service factory coverage was added.
 
+Speech flow expectations now assert the actual localized Slovak prompt with diacritics
+(`Ahoj, Martin, počúvam vás.`), so the unit test matches the current UI copy used by
+the app.
+
 ## Snapshot
 
 Reference UI snapshot prepared for review of the mobile chat layout.

--- a/mobile_app/pubspec.lock
+++ b/mobile_app/pubspec.lock
@@ -340,10 +340,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -729,10 +729,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   typed_data:
     dependency: transitive
     description:

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ai_jurisdiction_mobile
-version: 0.1.5+25
+version: 0.1.5+26
 publish_to: none
 
 environment:

--- a/mobile_app/test/speech_flow_test.dart
+++ b/mobile_app/test/speech_flow_test.dart
@@ -65,7 +65,7 @@ void main() {
     test('localizes the listening prompt for Slovak', () {
       expect(
         speechInputReadyMessage('SK', firstName: 'Martin'),
-        'Ahoj, Martin, pocuvam vas.',
+        'Ahoj, Martin, počúvam vás.',
       );
     });
   });


### PR DESCRIPTION
### Motivation
- A Flutter unit test for the mobile speech flow failed because the test expected an ASCII representation of the Slovak prompt instead of the localized string with diacritics. 
- Any app-visible change requires a build number bump per mobile versioning rules. 
- Running the local Flutter toolchain updated dependency resolution, so the lockfile was refreshed to keep CI/tooling deterministic.

### Description
- Updated the Slovak speech prompt expectation in `mobile_app/test/speech_flow_test.dart` to `Ahoj, Martin, počúvam vás.`. 
- Bumped mobile app build number in `mobile_app/pubspec.yaml` from `0.1.5+25` to `0.1.5+26`.
- Documented the test expectation change in `mobile_app/README.md`. 
- Refreshed `mobile_app/pubspec.lock` after running the local Flutter toolchain (resolved transitive versions such as `matcher` and `test_api`).

### Testing
- Ran `cd mobile_app && flutter analyze --no-fatal-infos`, which completed successfully. 
- Ran `cd mobile_app && flutter test`, which passed after the test update. 
- Ran `cd mobile_app && flutter build web --release --dart-define=AIJ_API_BASE_URL=http://127.0.0.1:8080`, which produced a successful web build. 
- Ran `cd mobile_app && flutter build apk --debug --build-name=0.1.5 --build-number=26 --dart-define=AIJ_API_BASE_URL=http://127.0.0.1:8080`, which produced a debug APK successfully. 
- Attempted `flutter build apk --release` in this environment but the Gradle/release process stalled after startup, so release APK build was not verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc607832f48332b14e06ba264babbe)