### PR TITLE
Gate in-app upgrades to releases with APKs, move version label to footer, bump build

### DIFF
--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -75,7 +75,7 @@ Flutter mobile client prepared for local testing of the AIJurisDictA (AI Juris D
 - If the selected case already has stored attachments, the mobile app shows download buttons for those case documents above the PDF/export controls.
 - After the user uploads case documents, the app now waits until those uploads reach a terminal processing state and then automatically sends a follow-up request asking the backend to summarize and analyze the uploaded material under the selected country law, including problems, risks, missing parts, and outdated clauses.
 - After a backend reply or completed AI discussion, the chat screen now shows a compact case-validation card with the latest validation accuracy, validation summary, legal-data freshness timestamp, and current core model version returned by the API session result metadata.
-- App version is shown in the bottom-left corner of the screen.
+- The chat input row sits above a dedicated footer line, and the app version is shown on the last line in the bottom-left corner of the screen.
 - On startup, app blocks the auth flow until `GET /health` returns healthy.
   - failed health checks show the current API error on screen
   - if the API is reachable but its database is not, the app shows the DB health error returned by `/health`
@@ -293,7 +293,7 @@ Mobile app versioning rule:
 - Example: `0.1.4+7` -> `0.1.4+8`.
 
 For Android automatic upgrade, the GitHub Release must include an `.apk` asset.
-The workflow uses `app-release.apk`, which the app prefers automatically during the update flow.
+The workflow uses `app-release.apk`, which the app prefers automatically during the update flow. Releases without an APK are treated as non-mobile releases, so the in-app upgrade prompt is skipped for them.
 If Android shows "App not installed" due to package/signature conflict, it means
 the installed build was signed differently (for example debug vs release). The app
 now warns about this case; uninstall the existing app and then install the new APK.

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -1501,23 +1501,28 @@ class ApiClient {
       releaseUrl: releaseUrl,
     );
     if (githubRelease != null) {
-      if (githubRelease.version.compareTo(installed) <= 0) {
+      if (!githubRelease.isMobileAppRelease ||
+          githubRelease.version.compareTo(installed) <= 0) {
         return null;
       }
       return MobileAppUpdateInfo(
         version: githubRelease.version,
         releaseUrl: githubRelease.releaseUrl,
+        isMobileAppRelease: githubRelease.isMobileAppRelease,
         apkDownloadUrl: githubRelease.apkDownloadUrl,
       );
     }
     final versionValue = payload['mobile_app_version'] as String? ?? '';
     final latestVersion = SemanticVersion.tryParse(versionValue);
-    if (latestVersion == null || latestVersion.compareTo(installed) <= 0) {
+    if (latestVersion == null ||
+        latestVersion.compareTo(installed) <= 0 ||
+        apkDownloadUrl == null) {
       return null;
     }
     return MobileAppUpdateInfo(
       version: latestVersion,
       releaseUrl: releaseUrl,
+      isMobileAppRelease: true,
       apkDownloadUrl: apkDownloadUrl,
     );
   }
@@ -6207,13 +6212,6 @@ class _ChatHomePageState extends State<ChatHomePage>
                             ),
                           ),
                         ),
-                        Text(
-                          _appVersionLabel,
-                          style: Theme.of(context)
-                              .textTheme
-                              .bodySmall
-                              ?.copyWith(color: const Color(0xFF4A628A)),
-                        ),
                         const SizedBox(width: 8),
                         if (_lastErrorCorrelationId != null &&
                             _lastErrorCorrelationId!.isNotEmpty)
@@ -6534,65 +6532,82 @@ class _ChatHomePageState extends State<ChatHomePage>
                 ),
                 Padding(
                   padding: const EdgeInsets.fromLTRB(12, 2, 12, 12),
-                  child: Row(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      IconButton(
-                        onPressed: _captureDocument,
-                        icon: const Icon(Icons.camera_alt_outlined),
-                        tooltip: strings.t('capture_document'),
-                      ),
-                      IconButton(
-                        onPressed: _pickDocuments,
-                        icon: const Icon(Icons.upload_file),
-                        tooltip: strings.t('upload_documents'),
-                      ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: TextField(
-                          controller: _inputController,
-                          minLines: 1,
-                          maxLines: 1,
-                          keyboardType: TextInputType.text,
-                          textInputAction: TextInputAction.send,
-                          onSubmitted: (_) => _sendMessage(),
-                          decoration: InputDecoration(
-                            hintText:
-                                _responderMode == ResponderMode.aiUserSimulator
+                      Row(
+                        children: [
+                          IconButton(
+                            onPressed: _captureDocument,
+                            icon: const Icon(Icons.camera_alt_outlined),
+                            tooltip: strings.t('capture_document'),
+                          ),
+                          IconButton(
+                            onPressed: _pickDocuments,
+                            icon: const Icon(Icons.upload_file),
+                            tooltip: strings.t('upload_documents'),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: TextField(
+                              controller: _inputController,
+                              minLines: 1,
+                              maxLines: 1,
+                              keyboardType: TextInputType.text,
+                              textInputAction: TextInputAction.send,
+                              onSubmitted: (_) => _sendMessage(),
+                              decoration: InputDecoration(
+                                hintText: _responderMode ==
+                                        ResponderMode.aiUserSimulator
                                     ? strings.t('case_input_discussion')
                                     : strings.t('case_input_question'),
-                            filled: true,
-                            fillColor: Colors.white,
-                            border: const OutlineInputBorder(),
+                                filled: true,
+                                fillColor: Colors.white,
+                                border: const OutlineInputBorder(),
+                              ),
+                            ),
                           ),
-                        ),
+                          const SizedBox(width: 8),
+                          IconButton(
+                            onPressed:
+                                _speechEnabled ? _toggleSpeechInput : null,
+                            icon: Icon(
+                              _isListening ? Icons.mic : Icons.mic_none,
+                              color: _isListening
+                                  ? Theme.of(context).colorScheme.primary
+                                  : null,
+                            ),
+                            tooltip: _isListening
+                                ? strings.t('stop_speech_input')
+                                : strings.t('speech_input'),
+                          ),
+                          const SizedBox(width: 8),
+                          IconButton(
+                            onPressed: _isSending ? null : _sendMessage,
+                            icon: _isSending
+                                ? const SizedBox(
+                                    width: 16,
+                                    height: 16,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                    ),
+                                  )
+                                : const Icon(Icons.send),
+                            tooltip:
+                                _responderMode == ResponderMode.aiUserSimulator
+                                    ? strings.t('start_ai_discussion')
+                                    : strings.t('send_to_api'),
+                          ),
+                        ],
                       ),
-                      const SizedBox(width: 8),
-                      IconButton(
-                        onPressed: _speechEnabled ? _toggleSpeechInput : null,
-                        icon: Icon(
-                          _isListening ? Icons.mic : Icons.mic_none,
-                          color: _isListening
-                              ? Theme.of(context).colorScheme.primary
-                              : null,
+                      const SizedBox(height: 6),
+                      Padding(
+                        padding: const EdgeInsets.only(left: 12),
+                        child: Text(
+                          _appVersionLabel,
+                          style: Theme.of(context).textTheme.bodySmall
+                              ?.copyWith(color: const Color(0xFF4A628A)),
                         ),
-                        tooltip: _isListening
-                            ? strings.t('stop_speech_input')
-                            : strings.t('speech_input'),
-                      ),
-                      const SizedBox(width: 8),
-                      IconButton(
-                        onPressed: _isSending ? null : _sendMessage,
-                        icon: _isSending
-                            ? const SizedBox(
-                                width: 16,
-                                height: 16,
-                                child:
-                                    CircularProgressIndicator(strokeWidth: 2),
-                              )
-                            : const Icon(Icons.send),
-                        tooltip: _responderMode == ResponderMode.aiUserSimulator
-                            ? strings.t('start_ai_discussion')
-                            : strings.t('send_to_api'),
                       ),
                     ],
                   ),

--- a/mobile_app/lib/update/github_release.dart
+++ b/mobile_app/lib/update/github_release.dart
@@ -58,12 +58,14 @@ class GithubReleaseInfo {
     required this.version,
     required this.releaseUrl,
     required this.apkDownloadUrl,
+    required this.isMobileAppRelease,
   });
 
   final String tagName;
   final SemanticVersion version;
   final String releaseUrl;
   final String? apkDownloadUrl;
+  final bool isMobileAppRelease;
 }
 
 GithubReleaseInfo? parseGithubReleaseInfo(Map<String, dynamic> payload) {
@@ -74,11 +76,13 @@ GithubReleaseInfo? parseGithubReleaseInfo(Map<String, dynamic> payload) {
     return null;
   }
   final assets = payload['assets'];
+  final apkDownloadUrl = pickGithubApkAssetDownloadUrl(assets);
   return GithubReleaseInfo(
     tagName: tagName,
     version: version,
     releaseUrl: releaseUrl,
-    apkDownloadUrl: pickGithubApkAssetDownloadUrl(assets),
+    apkDownloadUrl: apkDownloadUrl,
+    isMobileAppRelease: apkDownloadUrl != null,
   );
 }
 

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ai_jurisdiction_mobile
-version: 0.1.5+35
+version: 0.1.5+36
 publish_to: none
 
 environment:

--- a/mobile_app/test/github_release_test.dart
+++ b/mobile_app/test/github_release_test.dart
@@ -37,10 +37,28 @@ void main() {
 
       expect(release, isNotNull);
       expect(release!.version.toString(), '0.1.2');
+      expect(release.isMobileAppRelease, isTrue);
       expect(
         release.apkDownloadUrl,
         'https://example.invalid/app-release.apk',
       );
+    });
+
+    test('marks releases without apk assets as non-mobile releases', () {
+      final release = parseGithubReleaseInfo(<String, dynamic>{
+        'tag_name': '0.1.3',
+        'html_url': 'https://github.com/example/release',
+        'assets': <Map<String, String>>[
+          <String, String>{
+            'name': 'notes.txt',
+            'browser_download_url': 'https://example.invalid/notes.txt',
+          },
+        ],
+      });
+
+      expect(release, isNotNull);
+      expect(release!.apkDownloadUrl, isNull);
+      expect(release.isMobileAppRelease, isFalse);
     });
 
     test('returns null when release tag is not semantic version', () {
@@ -71,6 +89,7 @@ void main() {
 
       expect(release, isNotNull);
       expect(release!.version.toString(), '0.1.5+29');
+      expect(release.isMobileAppRelease, isTrue);
       expect(
         release.apkDownloadUrl,
         'https://example.invalid/app-release.apk',


### PR DESCRIPTION
### Motivation
- Prevent showing in-app upgrade prompts for releases that are not intended for mobile (no APK asset) to avoid confusing users. 
- Move the chat input up by one visual line and show the app version on a dedicated footer line to improve layout and make the version less prominent in the header. 
- Keep mobile build metadata consistent by incrementing the revision/build number per the mobile versioning rule.

### Description
- Add `isMobileAppRelease` to `GithubReleaseInfo` and set it based on whether an APK asset was found in `parseGithubReleaseInfo` in `mobile_app/lib/update/github_release.dart`.
- Require `isMobileAppRelease` for GitHub-release-based upgrades and require an APK URL for API-fallback upgrades in `fetchMobileAppUpdateInfo` in `mobile_app/lib/main.dart` so upgrades are only surfaced when an APK is available.
- Move `_appVersionLabel` out of the header row and render it in a dedicated footer line below the chat input by restructuring the input/footer widgets in `mobile_app/lib/main.dart` so the input row appears one line higher.
- Add unit assertions to `mobile_app/test/github_release_test.dart` to assert `isMobileAppRelease` for APK-bearing releases and add a new test that marks releases without APK assets as non-mobile releases.
- Update `mobile_app/README.md` to document the footer/version behavior and clarify that releases without APKs are treated as non-mobile releases, and bump `mobile_app/pubspec.yaml` build number from `0.1.5+35` to `0.1.5+36`.

### Testing
- Ran `git diff --check` with no issues reported. (success)
- Executed `python examples/minimal_demo.py`, which failed because the local API expected by the demo is not running in this environment (connection refused). (environment-related failure)
- Attempted to run `flutter` formatting and `flutter test` but Flutter/Dart tooling is not installed in this environment, so Flutter tests/formatting could not be executed. (not run)
- Updated unit tests in `mobile_app/test/github_release_test.dart` to cover the new `isMobileAppRelease` behavior, but these Flutter tests were not executed here due to missing Flutter tooling. (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfa213b7808332a25931fc55c0ea98)