### PR TITLE
Policy-driven document task planning for chat + auth refactor and tests

### DIFF
--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -59,6 +59,39 @@ Document processing mode:
 - `DOCUMENT_PROCESSOR=azure`: uploads stay pending until the Azure Container Apps document-processor job runs.
 - Recommended deployed value: `DOCUMENT_PROCESSOR=azure`
 
+### Policy-driven multi-intent document task planning
+
+The chat reply path now uses a single legal agent with a reusable policy layer for uploaded-document intents. Each matched policy contributes ordered tasks and communication rules before the legal agent is prompted.
+
+Implementation note: the policy logic now lives in a dedicated chat service module so `app/chat/api.py` can stay focused on endpoint mapping and request/response handling.
+
+Examples:
+
+- `Fix uploaded document based on current law and send me summary from document`
+- `Analyze uploaded agreement, rebuild outdated clauses, and summarize the result`
+
+When the same message asks for multiple document actions, the API keeps the user's intent order and instructs the model to execute the tasks in sequence, for example:
+
+1. review uploaded document
+2. update/rebuild if current law requires it
+3. prepare summary
+
+Current built-in policies:
+
+- `document_analysis`
+- `document_modernization`
+- `document_summary`
+
+The summary step is instructed to describe the updated result when both update + summary are requested together. Future policies can add their own tasks/guidance while still using the same single-agent flow.
+
+If summary-like output is requested before uploaded documents are processed, the policy note tells the agent to defer content-specific summary output until processed documents are available.
+
+Minimal runnable example:
+
+```bash
+python examples/document_task_plan_demo.py
+```
+
 When using API key auth, leave `AZURE_OPENAI_AD_TOKEN` unset instead of setting it to an empty string. Likewise, leave `AZURE_OPENAI_API_KEY` unset when using Entra ID auth. The shared Azure Foundry loader strips blank auth values, but direct SDK smoke scripts can fail with an invalid `Authorization: Bearer ` header when an empty token variable is present.
 
 Optional explicit override:

--- a/api/aijuristiction-api/app/auth/service.py
+++ b/api/aijuristiction-api/app/auth/service.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+
+API_KEY_HEADER_NAME = "x-api-key"
+HARDCODED_API_KEY = "aijuris"
+
+
+def validate_api_key(api_key: str | None) -> None:
+    if api_key != HARDCODED_API_KEY:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API key",
+        )

--- a/api/aijuristiction-api/app/chat/api.py
+++ b/api/aijuristiction-api/app/chat/api.py
@@ -24,6 +24,10 @@ from reportlab.pdfbase.ttfonts import TTFont  # type: ignore[import-untyped]
 from reportlab.pdfgen import canvas  # type: ignore[import-untyped]
 
 from app.chat.core_runtime import core_message_role, run_orchestration
+from app.chat.intent_policy_service import (
+    build_document_task_plan_note,
+    is_document_summary_request,
+)
 from app.chat.models import Message, MessageRole, Session, SessionResult, SessionState
 from app.chat.repository import InMemoryChatRepository
 from app.chat.result_metadata import build_session_result_metadata
@@ -79,8 +83,6 @@ class InputDocument(BaseModel):
     doc_id: str = Field(default="doc")
     path: str
     content: str
-
-
 
 
 def _get_store() -> ApiDatabaseStore:
@@ -225,35 +227,6 @@ def _requests_all_processed_documents(query: str) -> bool:
     return any(phrase in normalized for phrase in phrases)
 
 
-def _is_document_summary_request(query: str) -> bool:
-    normalized = " ".join(query.lower().split())
-    summary_terms = (
-        "summary",
-        "summar",
-        "summarize",
-        "summarise",
-        "short summary",
-        "sumar",
-        "sumariz",
-        "sumarizovanie",
-        "zhrn",
-        "zhrnut",
-        "zusammenfass",
-    )
-    document_terms = (
-        "document",
-        "documents",
-        "uploaded",
-        "pdf",
-        "dokument",
-        "dokumenty",
-        "dokumente",
-    )
-    return any(term in normalized for term in summary_terms) and any(
-        term in normalized for term in document_terms
-    )
-
-
 def _prepend_document_status_note(*, reply: str, processed_names: list[str], unprocessed_names: list[str]) -> str:
     if not processed_names and not unprocessed_names:
         return reply
@@ -374,7 +347,6 @@ def reply_to_session(session_id: UUID, payload: ReplyRequest) -> Message:
             "- Produce the finalized draft-oriented response for PDF export in this turn.\n"
             "- Include CASE_UPDATE_JSON after the user-facing content."
         )
-
     case_documents: list[CoreDocument] = []
     processed_names: list[str] = []
     unprocessed_names: list[str] = []
@@ -391,16 +363,12 @@ def reply_to_session(session_id: UUID, payload: ReplyRequest) -> Message:
                 'Use processed documents as case evidence and explicitly mention any unprocessed documents.'
             )
             prompt_override = f"{prompt_override}{context_note}"
-        if case_documents and _is_document_summary_request(content):
-            summary_note = (
-                "\n\nDOCUMENT SUMMARY MODE:\n"
-                "- The user asked for a concise summary of uploaded case documents.\n"
-                "- Start with a plain-language summary of the document contents in no more than 5 sentences.\n"
-                "- Mention the main document purpose, parties, dates, obligations, and obvious missing items if available.\n"
-                "- If the user also asked for issues or risks, mention them only after the short summary.\n"
-                "- Do not answer with validation metadata only.\n"
-            )
-            prompt_override = f"{prompt_override}{summary_note}"
+    task_plan_note = build_document_task_plan_note(
+        query=content,
+        has_processed_documents=bool(case_documents),
+    )
+    if task_plan_note:
+        prompt_override = f"{prompt_override}{task_plan_note}"
 
     lawyer_message = lawyer.respond(
         conversation=conversation,

--- a/api/aijuristiction-api/app/chat/intent_policy_service.py
+++ b/api/aijuristiction-api/app/chat/intent_policy_service.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic import BaseModel
+
+
+class PlannedDocumentTask(BaseModel):
+    task_id: str
+    description: str
+
+
+@dataclass(frozen=True)
+class DocumentIntentPolicy:
+    policy_id: str
+    phrases: tuple[str, ...]
+    required_document_terms: tuple[str, ...]
+    tasks: tuple[PlannedDocumentTask, ...]
+    guidance_lines: tuple[str, ...]
+    requires_processed_documents: bool = False
+
+
+@dataclass(frozen=True)
+class DocumentPolicyMatch:
+    policy: DocumentIntentPolicy
+    position: int
+
+
+@dataclass(frozen=True)
+class DocumentPolicyPlan:
+    ordered_policies: tuple[DocumentIntentPolicy, ...]
+    ordered_tasks: tuple[PlannedDocumentTask, ...]
+
+
+_DOCUMENT_POLICY_REQUIRED_TERMS = (
+    "document",
+    "documents",
+    "uploaded",
+    "upload",
+    "contract",
+    "agreement",
+    "pdf",
+    "dokument",
+    "dokumenty",
+    "dokumente",
+    "zmluv",
+    "vertrag",
+)
+
+_DOCUMENT_INTENT_POLICIES: tuple[DocumentIntentPolicy, ...] = (
+    DocumentIntentPolicy(
+        policy_id="document_analysis",
+        phrases=(
+            "analyze",
+            "analyse",
+            "analysis",
+            "review",
+            "validate",
+            "check",
+            "inspect",
+            "analyz",
+            "skontrol",
+            "posud",
+            "preskum",
+            "kontroll",
+            "pruf",
+        ),
+        required_document_terms=_DOCUMENT_POLICY_REQUIRED_TERMS,
+        tasks=(
+            PlannedDocumentTask(
+                task_id="review_uploaded_document",
+                description="Review the uploaded document and identify legal risks, gaps, or outdated clauses.",
+            ),
+        ),
+        guidance_lines=(
+            "- This is an analysis/review request for an uploaded document.",
+            "- Ask only focused analysis questions that improve legal accuracy.",
+            "- Do not switch into generic new-document drafting unless the user explicitly asks for it.",
+        ),
+    ),
+    DocumentIntentPolicy(
+        policy_id="document_modernization",
+        phrases=(
+            "update",
+            "rebuild",
+            "rewrite",
+            "recreate",
+            "fix",
+            "correct document",
+            "bring it up to date",
+            "current law",
+            "new law",
+            "latest law",
+            "old law",
+            "outdated",
+            "aktualiz",
+            "prepracuj",
+            "oprav",
+            "podla noveho zakona",
+            "podla aktualneho zakona",
+            "stareho zakona",
+            "nach aktuellem recht",
+            "neuem recht",
+            "aktualisieren",
+            "uberarbeiten",
+            "veralt",
+        ),
+        required_document_terms=_DOCUMENT_POLICY_REQUIRED_TERMS,
+        tasks=(
+            PlannedDocumentTask(
+                task_id="review_uploaded_document",
+                description="Review the uploaded document and identify relevant legal gaps or outdated clauses before any rewrite.",
+            ),
+            PlannedDocumentTask(
+                task_id="update_based_on_current_law",
+                description="If the uploaded document is outdated under current law, update or rebuild it before later tasks.",
+            ),
+        ),
+        guidance_lines=(
+            "- This is a document modernization request tied to current law.",
+            "- Start by reviewing the uploaded document before deciding whether a rewrite is needed.",
+            "- If current law requires changes, prepare the updated document before any requested summary.",
+            "- Do not ask generic new-document intake questions when the uploaded document already contains the needed facts.",
+        ),
+    ),
+    DocumentIntentPolicy(
+        policy_id="document_summary",
+        phrases=(
+            "summary",
+            "summar",
+            "summarize",
+            "summarise",
+            "short summary",
+            "sumar",
+            "sumariz",
+            "sumarizovanie",
+            "zhrn",
+            "zhrnut",
+            "zusammenfass",
+        ),
+        required_document_terms=_DOCUMENT_POLICY_REQUIRED_TERMS,
+        tasks=(
+            PlannedDocumentTask(
+                task_id="prepare_summary",
+                description="Prepare the requested plain-language summary after completing any earlier document-review or update tasks.",
+            ),
+        ),
+        guidance_lines=(
+            "- This is a summary request for uploaded document content.",
+            "- Start with a plain-language summary of the document contents in no more than 5 sentences.",
+            "- Mention the main purpose, parties, dates, obligations, and obvious missing items if available.",
+            "- If the user also asked for issues or risks, mention them only after the short summary.",
+            "- Do not answer with validation metadata only.",
+        ),
+        requires_processed_documents=True,
+    ),
+)
+
+
+def is_document_summary_request(query: str) -> bool:
+    return query_matches_policy(query, policy_id="document_summary")
+
+
+def is_document_analysis_request(query: str) -> bool:
+    return query_matches_policy(query, policy_id="document_analysis")
+
+
+def is_document_modernization_request(query: str) -> bool:
+    return query_matches_policy(query, policy_id="document_modernization")
+
+
+def normalize_document_intent_query(query: str) -> str:
+    return " ".join(query.lower().split())
+
+
+def query_matches_policy(query: str, *, policy_id: str) -> bool:
+    normalized = normalize_document_intent_query(query)
+    policy = next((item for item in _DOCUMENT_INTENT_POLICIES if item.policy_id == policy_id), None)
+    if policy is None:
+        return False
+    if not any(term in normalized for term in policy.required_document_terms):
+        return False
+    return any(phrase in normalized for phrase in policy.phrases)
+
+
+def match_document_intent_policies(query: str) -> tuple[DocumentPolicyMatch, ...]:
+    normalized = normalize_document_intent_query(query)
+    matches: list[DocumentPolicyMatch] = []
+    for policy in _DOCUMENT_INTENT_POLICIES:
+        if not any(term in normalized for term in policy.required_document_terms):
+            continue
+        hits = [normalized.find(phrase) for phrase in policy.phrases if phrase in normalized]
+        if not hits:
+            continue
+        matches.append(DocumentPolicyMatch(policy=policy, position=min(hits)))
+    return tuple(sorted(matches, key=lambda item: item.position))
+
+
+def build_document_policy_plan(query: str) -> DocumentPolicyPlan:
+    matches = match_document_intent_policies(query)
+    ordered_policies = tuple(match.policy for match in matches)
+    ordered_tasks: list[PlannedDocumentTask] = []
+    seen_task_ids: set[str] = set()
+    for policy in ordered_policies:
+        for task in policy.tasks:
+            if task.task_id in seen_task_ids:
+                continue
+            ordered_tasks.append(task)
+            seen_task_ids.add(task.task_id)
+    return DocumentPolicyPlan(
+        ordered_policies=ordered_policies,
+        ordered_tasks=tuple(ordered_tasks),
+    )
+
+
+def planned_document_tasks(query: str) -> list[PlannedDocumentTask]:
+    return list(build_document_policy_plan(query).ordered_tasks)
+
+
+def build_document_task_plan_note(
+    *,
+    query: str,
+    has_processed_documents: bool,
+) -> str:
+    plan = build_document_policy_plan(query)
+    if not plan.ordered_policies:
+        return ""
+
+    lines = [
+        "",
+        "",
+        "DOCUMENT TASK PLAN MODE:",
+        "- Use a single policy-driven legal agent response.",
+        "- The user may have requested multiple document tasks in one message.",
+        "- Execute the requested document tasks in the same order as the user's intent.",
+        "- Do not skip earlier tasks before performing later tasks.",
+        "- Ask only the minimum clarifying questions needed for the current active task.",
+        "- Keep behavior policy-driven so future document policies/tasks can be added without changing the overall agent pattern.",
+    ]
+    lines.append("- Active policies in user-intent order:")
+    for index, policy in enumerate(plan.ordered_policies, start=1):
+        lines.append(f"  {index}. {policy.policy_id}")
+        if policy.requires_processed_documents and not has_processed_documents:
+            lines.append("     - The uploaded documents are not processed yet, so defer content-specific output until processed.")
+            continue
+        for guidance in policy.guidance_lines:
+            lines.append(f"     {guidance}")
+    if any(task.task_id == "prepare_summary" for task in plan.ordered_tasks):
+        lines.append(
+            "- If both update/rebuild and summary are requested, summarize the updated result unless the user clearly asked for the original document summary."
+        )
+    lines.append("- Planned task order:")
+    for index, task in enumerate(plan.ordered_tasks, start=1):
+        lines.append(f"  {index}. {task.task_id}: {task.description}")
+    return "\n".join(lines)

--- a/api/aijuristiction-api/app/security.py
+++ b/api/aijuristiction-api/app/security.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
-from fastapi import HTTPException, Security, status
+from fastapi import Security
 from fastapi.security import APIKeyHeader
 
-API_KEY_HEADER_NAME = "x-api-key"
-HARDCODED_API_KEY = "aijuris"
+from app.auth.service import API_KEY_HEADER_NAME, validate_api_key
 
 api_key_header = APIKeyHeader(name=API_KEY_HEADER_NAME, auto_error=False)
 
 
 def require_api_key(api_key: str | None = Security(api_key_header)) -> None:
-    if api_key != HARDCODED_API_KEY:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid API key",
-        )
+    validate_api_key(api_key)

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -15,6 +15,71 @@ client = TestClient(app)
 AUTH_HEADERS = {"x-api-key": "aijuris"}
 
 
+def test_planned_document_tasks_keep_user_intent_order() -> None:
+    from app.chat.intent_policy_service import planned_document_tasks
+
+    tasks = planned_document_tasks(
+        "Recreate the uploaded document based on new law and send me summary from document."
+    )
+
+    assert [task.task_id for task in tasks] == [
+        "review_uploaded_document",
+        "update_based_on_current_law",
+        "prepare_summary",
+    ]
+
+
+def test_document_policy_plan_keeps_policy_order_for_future_extension() -> None:
+    from app.chat.intent_policy_service import build_document_policy_plan
+
+    plan = build_document_policy_plan(
+        "Please recreate the uploaded document under current law and then summarize it."
+    )
+
+    assert [policy.policy_id for policy in plan.ordered_policies] == [
+        "document_modernization",
+        "document_summary",
+    ]
+    assert [task.task_id for task in plan.ordered_tasks] == [
+        "review_uploaded_document",
+        "update_based_on_current_law",
+        "prepare_summary",
+    ]
+
+
+def test_document_task_plan_note_describes_multi_task_execution_order() -> None:
+    from app.chat.intent_policy_service import build_document_task_plan_note
+
+    note = build_document_task_plan_note(
+        query="Fix uploaded document based on current laws and send me summary from document.",
+        has_processed_documents=True,
+    )
+
+    assert "DOCUMENT TASK PLAN MODE" in note
+    assert "Use a single policy-driven legal agent response." in note
+    assert "Execute the requested document tasks in the same order as the user's intent." in note
+    assert "Active policies in user-intent order:" in note
+    assert "1. document_modernization" in note
+    assert "2. document_summary" in note
+    assert "1. review_uploaded_document" in note
+    assert "2. update_based_on_current_law" in note
+    assert "3. prepare_summary" in note
+    assert "summarize the updated result" in note
+
+
+def test_document_task_plan_note_defers_summary_output_until_documents_are_processed() -> None:
+    from app.chat.intent_policy_service import build_document_task_plan_note
+
+    note = build_document_task_plan_note(
+        query="Send me summary from uploaded document.",
+        has_processed_documents=False,
+    )
+
+    assert "document_summary" in note
+    assert "defer content-specific output until processed" in note
+    assert "Start with a plain-language summary" not in note
+
+
 def test_create_session_and_messages_roundtrip() -> None:
     session_response = client.post(
         "/v1/chat/sessions",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,4 +34,16 @@ Each agent message includes:
 9. Orchestrator synthesizes a final recommendation and rationale in the requested output language and stores trace artifacts.
 10. For Slovak advice runs, the CLI persists a case folder under `cases/` with documents and discussion logs.
 
+## API document-task planning
+
+The API chat reply flow can add policy-driven task-planning guidance for uploaded-document requests before sending the prompt to the lawyer agent.
+
+- Mixed requests such as "review/update uploaded document and summarize it" are converted into an ordered internal task plan.
+- The task order follows the user message order.
+- A policy layer maps matched intents to ordered tasks plus communication rules while keeping a single legal agent/persona.
+- The intent-policy feature is implemented in a dedicated chat service module so the API router can stay focused on endpoint mapping and auth wiring.
+- For modernization requests, the plan explicitly instructs the model to review the uploaded document first, then update it under current law, and only then prepare any requested summary.
+- Policies can also defer content-specific steps when uploaded documents are still unprocessed, instead of forcing the agent to improvise around missing evidence.
+- This planning layer is separate from developer/runtime Codex skills; it is application orchestration logic used to keep user-facing communication aligned with the requested task and make future policies/tasks easier to add.
+
 See `docs/SEQUENCE.md` for a high-level sequence diagram.

--- a/examples/document_task_plan_demo.py
+++ b/examples/document_task_plan_demo.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+API_ROOT = REPO_ROOT / "api" / "aijuristiction-api"
+if str(API_ROOT) not in sys.path:
+    sys.path.insert(0, str(API_ROOT))
+
+from app.chat.intent_policy_service import build_document_policy_plan
+
+
+def main() -> None:
+    query = "Recreate the uploaded document based on new law and send me summary from document."
+    print(f"Query: {query}")
+    plan = build_document_policy_plan(query)
+    print("Policies:")
+    for index, policy in enumerate(plan.ordered_policies, start=1):
+        print(f"{index}. {policy.policy_id}")
+    print("Planned tasks:")
+    for index, task in enumerate(plan.ordered_tasks, start=1):
+        print(f"{index}. {task.task_id} -> {task.description}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Introduce a reusable, policy-driven layer to interpret multi-intent uploaded-document user requests and ensure tasks are executed in user-intent order before prompting the legal agent.
- Keep endpoint/router code focused on HTTP mapping by moving document-intent logic into a dedicated service module.
- Make API key validation reusable and centralized so auth logic is not duplicated in `app.security`.

### Description
- Add a new intent planning module `app.chat.intent_policy_service` that defines `DocumentIntentPolicy`, matching logic, plan assembly, and `build_document_task_plan_note` which produces a prompt-safe task plan note for the LLM.
- Integrate the planning layer into the chat flow by importing `build_document_task_plan_note` and `is_document_summary_request` in `app/chat/api.py`, replacing the previous inline summary heuristics with the unified task plan note injected into `system_prompt_override`.
- Extract API key constants and validation into `app/auth/service.py` and update `app/security.py` to call `validate_api_key` via the FastAPI `Security` dependency.
- Add tests covering policy matching, task ordering, and plan-note behavior in `api/aijuristiction-api/tests/test_chat.py`, and include a runnable example `examples/document_task_plan_demo.py` plus README/docs updates describing the feature and runtime notes.

### Testing
- Ran the API unit tests in `api/aijuristiction-api/tests` with `pytest`, including new tests `test_planned_document_tasks_keep_user_intent_order`, `test_document_policy_plan_keeps_policy_order_for_future_extension`, and `test_document_task_plan_note_*`, and all tests passed.
- Exercised the example script `python examples/document_task_plan_demo.py` to validate plan output formatting and ordering which produced the expected policy and task lists.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0f15776f8833288a15b1c8b549e14)