### PR TITLE
Harden API deploy container app updates

### DIFF
--- a/.github/workflows/api_build_deploy.yml
+++ b/.github/workflows/api_build_deploy.yml
@@ -151,9 +151,116 @@ jobs:
           containerAppEnvironment: ${{ env.AZURE_CONTAINERAPPS_ENVIRONMENT }}
           imageToDeploy: ${{ steps.acr.outputs.acr_login_server }}/aijuristiction-api:${{ github.sha }}
 
+      - name: Wait for Container App provisioning to settle
+        shell: bash
+        run: |
+          wait_for_container_app_ready() {
+            local attempts="${1:-30}"
+            local sleep_seconds="${2:-10}"
+            local state=""
+            for attempt in $(seq 1 "$attempts"); do
+              state="$(az containerapp show \
+                --name "$AZURE_CONTAINER_APP_NAME" \
+                --resource-group "$AZURE_RESOURCE_GROUP" \
+                --query properties.provisioningState \
+                --output tsv 2>/dev/null || true)"
+              if [ "$state" = "Succeeded" ]; then
+                echo "Container App provisioning state is Succeeded."
+                return 0
+              fi
+              if [ -n "$state" ]; then
+                echo "Container App provisioning state: $state (attempt $attempt/$attempts)"
+              else
+                echo "Container App provisioning state unavailable yet (attempt $attempt/$attempts)"
+              fi
+              sleep "$sleep_seconds"
+            done
+
+            echo "::error::Container App '$AZURE_CONTAINER_APP_NAME' did not reach provisioningState=Succeeded."
+            az containerapp show \
+              --name "$AZURE_CONTAINER_APP_NAME" \
+              --resource-group "$AZURE_RESOURCE_GROUP" \
+              --output jsonc || true
+            return 1
+          }
+
+          wait_for_container_app_ready
+
       - name: Configure API database environment
         shell: bash
         run: |
+          wait_for_container_app_ready() {
+            local attempts="${1:-18}"
+            local sleep_seconds="${2:-10}"
+            local state=""
+            for attempt in $(seq 1 "$attempts"); do
+              state="$(az containerapp show \
+                --name "$AZURE_CONTAINER_APP_NAME" \
+                --resource-group "$AZURE_RESOURCE_GROUP" \
+                --query properties.provisioningState \
+                --output tsv 2>/dev/null || true)"
+              if [ "$state" = "Succeeded" ]; then
+                return 0
+              fi
+              if [ -n "$state" ]; then
+                echo "Waiting for Container App provisioning state to settle: $state (attempt $attempt/$attempts)"
+              else
+                echo "Waiting for Container App provisioning state to become available (attempt $attempt/$attempts)"
+              fi
+              sleep "$sleep_seconds"
+            done
+
+            echo "::error::Container App '$AZURE_CONTAINER_APP_NAME' did not become ready for configuration."
+            az containerapp show \
+              --name "$AZURE_CONTAINER_APP_NAME" \
+              --resource-group "$AZURE_RESOURCE_GROUP" \
+              --output jsonc || true
+            return 1
+          }
+
+          retry_containerapp_command() {
+            local description="$1"
+            shift
+            local max_attempts=8
+            local log_file=""
+            local exit_code=0
+
+            log_file="$(mktemp)"
+
+            for attempt in $(seq 1 "$max_attempts"); do
+              wait_for_container_app_ready
+
+              set +e
+              "$@" >"$log_file" 2>&1
+              exit_code=$?
+              set -e
+
+              cat "$log_file"
+              if [ "$exit_code" -eq 0 ]; then
+                wait_for_container_app_ready
+                rm -f "$log_file"
+                return 0
+              fi
+
+              if ! grep -q "ContainerAppOperationInProgress" "$log_file"; then
+                rm -f "$log_file"
+                return "$exit_code"
+              fi
+
+              if [ "$attempt" -eq "$max_attempts" ]; then
+                echo "::error::$description failed because the Container App stayed busy after $max_attempts attempts."
+                rm -f "$log_file"
+                return "$exit_code"
+              fi
+
+              sleep_seconds=$((attempt * 10))
+              echo "::warning::$description hit an active Container App provisioning operation; retrying in ${sleep_seconds}s (attempt $attempt/$max_attempts)."
+              sleep "$sleep_seconds"
+            done
+
+            rm -f "$log_file"
+          }
+
           db_cloud="$(python - <<'PY'
           import os
           from urllib.parse import quote
@@ -184,7 +291,8 @@ jobs:
           if [ -n "${AZURE_OPENAI_API_KEY:-}" ]; then
             secret_values+=("azure-openai-api-key=$AZURE_OPENAI_API_KEY")
           fi
-          az containerapp secret set \
+          retry_containerapp_command "Setting Container App secrets" \
+            az containerapp secret set \
             --name "$AZURE_CONTAINER_APP_NAME" \
             --resource-group "$AZURE_RESOURCE_GROUP" \
             --secrets "${secret_values[@]}" \
@@ -225,7 +333,8 @@ jobs:
           if [ -n "${CORS_ALLOW_ORIGINS:-}" ]; then
             env_vars+=(CORS_ALLOW_ORIGINS="$CORS_ALLOW_ORIGINS")
           fi
-          az containerapp update \
+          retry_containerapp_command "Updating Container App environment variables" \
+            az containerapp update \
             --name "$AZURE_CONTAINER_APP_NAME" \
             --resource-group "$AZURE_RESOURCE_GROUP" \
             --set-env-vars "${env_vars[@]}" \

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -228,6 +228,7 @@ Some workflows default to `dev` for push-based execution.
 That means:
 
 - `API Build and Deploy` now deploys automatically to `dev` on `push` to `main` after tests/build pass
+- `API Build and Deploy` waits for Azure Container App provisioning to settle before applying secret and environment updates, which reduces transient `ContainerAppOperationInProgress` failures during deployment
 - `test` and `prod` remain manual `workflow_dispatch` targets unless a workflow is explicitly changed to auto-deploy them
 
 ## 12. Quick Validation Checklist

--- a/infra/README.md
+++ b/infra/README.md
@@ -273,6 +273,8 @@ az ad app federated-credential create --id $ClientId --parameters $tempFile
 - Push to `main`: automatically deploys to the `dev` GitHub Environment after tests/build pass
 - Inputs: `deploy=true`, `github_environment=<environment>`
   - Manual `workflow_dispatch` is still the path for non-`dev` environments such as `test` and `prod`
+- After the image deploy step, the workflow now waits for the Container App provisioning state to return to `Succeeded` before applying secrets and environment variables.
+- If Azure still reports `ContainerAppOperationInProgress`, the workflow retries the secret/env update commands automatically instead of failing on the first race.
 
 ## GitHub workflow for database schema upgrades only
 


### PR DESCRIPTION
## Summary
- wait for Azure Container App provisioning to settle after image deployment
- retry secret and environment updates when Azure returns ContainerAppOperationInProgress
- document the updated API deployment behavior

## Validation
- traced the failing GitHub Actions run to the post-deploy ContainerAppOperationInProgress race
- validated .github/workflows/api_build_deploy.yml as YAML
