### PR TITLE
Fix shared ACA role assignment naming

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -168,6 +168,7 @@ Existing-resource behavior:
 
 - If a named resource already exists in the target resource group, deployment reuses it instead of creating it again.
 - The deploy script requires existing named resources to already be in the requested location. If a resource with the same name exists in a different region, deployment fails with a location mismatch instead of silently switching regions.
+- Shared RBAC assignments for the user-assigned managed identity are intentionally keyed only by `scope + principal + role`. This keeps `AcrPull` and `Storage Blob Data Contributor` idempotent across `infra_deploy`, laws collector, frontend, and document processor workflows.
 
 Parameter resolution priority in `deploy_api.ps1`:
 

--- a/infra/bicep/document_processor.job.bicep
+++ b/infra/bicep/document_processor.job.bicep
@@ -46,7 +46,7 @@ resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' e
 }
 
 resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(acr.id, managedIdentity.id, 'AcrPull', jobName)
+  name: guid(acr.id, managedIdentity.id, 'AcrPull')
   scope: acr
   properties: {
     principalId: managedIdentity.properties.principalId
@@ -56,7 +56,7 @@ resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-
 }
 
 resource storageBlobDataRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(storageAccount.id, managedIdentity.id, 'StorageBlobDataContributor', jobName)
+  name: guid(storageAccount.id, managedIdentity.id, 'StorageBlobDataContributor')
   scope: storageAccount
   properties: {
     principalId: managedIdentity.properties.principalId

--- a/infra/bicep/frontend.containerapp.bicep
+++ b/infra/bicep/frontend.containerapp.bicep
@@ -19,7 +19,7 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-
 }
 
 resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(acr.id, managedIdentity.id, 'AcrPull', containerAppName)
+  name: guid(acr.id, managedIdentity.id, 'AcrPull')
   scope: acr
   properties: {
     principalId: managedIdentity.properties.principalId

--- a/infra/bicep/laws_collector.containerapp.bicep
+++ b/infra/bicep/laws_collector.containerapp.bicep
@@ -28,7 +28,7 @@ resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' e
 }
 
 resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(acr.id, managedIdentity.id, 'AcrPull', containerAppName)
+  name: guid(acr.id, managedIdentity.id, 'AcrPull')
   scope: acr
   properties: {
     principalId: managedIdentity.properties.principalId


### PR DESCRIPTION
## Summary
- make shared ACA ACR pull role assignments deterministic across workflows
- make the document processor storage RBAC assignment deterministic too
- document that shared managed-identity RBAC is keyed by scope, principal, and role

## Validation
- az bicep build --file infra/bicep/main.bicep