### PR TITLE
Provision frontend ACA from infra workflows

### DIFF
--- a/.github/workflows/infra_deploy.yml
+++ b/.github/workflows/infra_deploy.yml
@@ -37,6 +37,7 @@ jobs:
       AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
       AZURE_CONTAINERAPPS_ENVIRONMENT: ${{ vars.AZURE_CONTAINERAPPS_ENVIRONMENT }}
       AZURE_CONTAINER_APP_NAME: ${{ vars.AZURE_CONTAINER_APP_NAME }}
+      AZURE_FRONTEND_CONTAINER_APP_NAME: ${{ vars.AZURE_FRONTEND_CONTAINER_APP_NAME }}
       AZURE_CONTAINER_REGISTRY: ${{ vars.AZURE_CONTAINER_REGISTRY }}
       AZURE_POSTGRES_SERVER_NAME: ${{ vars.AZURE_POSTGRES_SERVER_NAME }}
       AZURE_POSTGRES_DATABASE_NAME: ${{ vars.AZURE_POSTGRES_DATABASE_NAME }}
@@ -59,7 +60,7 @@ jobs:
       - name: Validate required environment variables
         run: |
           missing=0
-          for key in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_RESOURCE_GROUP AZURE_LOCATION AZURE_CONTAINERAPPS_ENVIRONMENT AZURE_CONTAINER_APP_NAME AZURE_CONTAINER_REGISTRY AZURE_LOG_ANALYTICS_WORKSPACE_NAME AZURE_MANAGED_IDENTITY_NAME AZURE_POSTGRES_SERVER_NAME AZURE_POSTGRES_DATABASE_NAME AZURE_POSTGRES_ADMIN_USERNAME AZURE_POSTGRES_ADMIN_PASSWORD; do
+          for key in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_RESOURCE_GROUP AZURE_LOCATION AZURE_CONTAINERAPPS_ENVIRONMENT AZURE_CONTAINER_APP_NAME AZURE_FRONTEND_CONTAINER_APP_NAME AZURE_CONTAINER_REGISTRY AZURE_LOG_ANALYTICS_WORKSPACE_NAME AZURE_MANAGED_IDENTITY_NAME AZURE_POSTGRES_SERVER_NAME AZURE_POSTGRES_DATABASE_NAME AZURE_POSTGRES_ADMIN_USERNAME AZURE_POSTGRES_ADMIN_PASSWORD; do
             if [ -z "${!key}" ]; then
               echo "Missing GitHub Environment variable: $key"
               missing=1
@@ -162,6 +163,7 @@ jobs:
           identity_location="$(get_location "$AZURE_MANAGED_IDENTITY_NAME" "Microsoft.ManagedIdentity/userAssignedIdentities")"
           postgres_location="$(get_location "$AZURE_POSTGRES_SERVER_NAME" "Microsoft.DBforPostgreSQL/flexibleServers")"
           app_location="$(get_location "$AZURE_CONTAINER_APP_NAME" "Microsoft.App/containerApps")"
+          frontend_location="$(get_location "$AZURE_FRONTEND_CONTAINER_APP_NAME" "Microsoft.App/containerApps")"
           laws_collector_location="$(get_location "${{ steps.laws.outputs.laws_container_app_name }}" "Microsoft.App/containerApps")"
 
           create_log_analytics_workspace=true
@@ -172,6 +174,7 @@ jobs:
           create_managed_identity=true
           create_postgres_server=true
           create_container_app=true
+          create_frontend_container_app=true
           create_laws_collector_container_app=true
 
           [ -n "$log_location" ] && create_log_analytics_workspace=false
@@ -182,6 +185,7 @@ jobs:
           [ -n "$identity_location" ] && create_managed_identity=false
           [ -n "$postgres_location" ] && create_postgres_server=false
           [ -n "$app_location" ] && create_container_app=false
+          [ -n "$frontend_location" ] && create_frontend_container_app=false
           [ -n "$laws_collector_location" ] && create_laws_collector_container_app=false
 
           resolved_location="$AZURE_LOCATION"
@@ -195,6 +199,7 @@ jobs:
           echo "create_managed_identity=$create_managed_identity" >> "$GITHUB_OUTPUT"
           echo "create_postgres_server=$create_postgres_server" >> "$GITHUB_OUTPUT"
           echo "create_container_app=$create_container_app" >> "$GITHUB_OUTPUT"
+          echo "create_frontend_container_app=$create_frontend_container_app" >> "$GITHUB_OUTPUT"
           echo "create_laws_collector_container_app=$create_laws_collector_container_app" >> "$GITHUB_OUTPUT"
 
       - name: Deploy infrastructure from Bicep
@@ -207,6 +212,7 @@ jobs:
               location="${{ steps.existing.outputs.resolved_location }}" \
               environmentName="$AZURE_CONTAINERAPPS_ENVIRONMENT" \
               containerAppName="$AZURE_CONTAINER_APP_NAME" \
+              frontendContainerAppName="$AZURE_FRONTEND_CONTAINER_APP_NAME" \
               lawsCollectorContainerAppName="${{ steps.laws.outputs.laws_container_app_name }}" \
               postgresServerName="$AZURE_POSTGRES_SERVER_NAME" \
               postgresDatabaseName="$AZURE_POSTGRES_DATABASE_NAME" \
@@ -231,11 +237,13 @@ jobs:
               createManagedIdentity="${{ steps.existing.outputs.create_managed_identity }}" \
               createPostgresServer="${{ steps.existing.outputs.create_postgres_server }}" \
               createContainerApp="${{ steps.existing.outputs.create_container_app }}" \
+              createFrontendContainerApp="${{ steps.existing.outputs.create_frontend_container_app }}" \
               createLawsCollectorContainerApp="${{ steps.existing.outputs.create_laws_collector_container_app }}"
 
       - name: Summarize ACA infrastructure
         run: |
           api_result="reused"
+          frontend_result="reused"
           laws_result="reused"
           env_result="reused"
 
@@ -244,6 +252,9 @@ jobs:
           fi
           if [ "${{ steps.existing.outputs.create_container_app }}" = "true" ]; then
             api_result="created"
+          fi
+          if [ "${{ steps.existing.outputs.create_frontend_container_app }}" = "true" ]; then
+            frontend_result="created"
           fi
           if [ "${{ steps.existing.outputs.create_laws_collector_container_app }}" = "true" ]; then
             laws_result="created"
@@ -259,6 +270,16 @@ jobs:
             api_endpoint="https://$api_fqdn"
           fi
 
+          frontend_fqdn="$(az containerapp show \
+            --name "$AZURE_FRONTEND_CONTAINER_APP_NAME" \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --query "properties.configuration.ingress.fqdn" \
+            --output tsv)"
+          frontend_endpoint="n/a"
+          if [ -n "$frontend_fqdn" ]; then
+            frontend_endpoint="https://$frontend_fqdn"
+          fi
+
           {
             echo "## ACA deployment summary"
             echo ""
@@ -266,5 +287,6 @@ jobs:
             echo "| --- | --- | --- | --- |"
             echo "| Managed environment | $AZURE_CONTAINERAPPS_ENVIRONMENT | $env_result | n/a |"
             echo "| API container app | $AZURE_CONTAINER_APP_NAME | $api_result | $api_endpoint |"
+            echo "| Frontend container app | $AZURE_FRONTEND_CONTAINER_APP_NAME | $frontend_result | $frontend_endpoint |"
             echo "| Laws collector container app | ${{ steps.laws.outputs.laws_container_app_name }} | $laws_result | internal ingress |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/web_build_deploy.yml
+++ b/.github/workflows/web_build_deploy.yml
@@ -63,16 +63,18 @@ jobs:
       AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+      AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
       AZURE_CONTAINERAPPS_ENVIRONMENT: ${{ vars.AZURE_CONTAINERAPPS_ENVIRONMENT }}
       AZURE_FRONTEND_CONTAINER_APP_NAME: ${{ vars.AZURE_FRONTEND_CONTAINER_APP_NAME }}
       AZURE_CONTAINER_REGISTRY: ${{ vars.AZURE_CONTAINER_REGISTRY }}
+      AZURE_MANAGED_IDENTITY_NAME: ${{ vars.AZURE_MANAGED_IDENTITY_NAME }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Validate required environment variables
         run: |
           missing=0
-          for key in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_RESOURCE_GROUP AZURE_CONTAINERAPPS_ENVIRONMENT AZURE_FRONTEND_CONTAINER_APP_NAME AZURE_CONTAINER_REGISTRY; do
+          for key in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_RESOURCE_GROUP AZURE_LOCATION AZURE_CONTAINERAPPS_ENVIRONMENT AZURE_FRONTEND_CONTAINER_APP_NAME AZURE_CONTAINER_REGISTRY AZURE_MANAGED_IDENTITY_NAME; do
             if [ -z "${!key}" ]; then
               echo "Missing GitHub Environment variable: $key"
               missing=1
@@ -121,14 +123,31 @@ jobs:
         run: |
           app_name="${AZURE_FRONTEND_CONTAINER_APP_NAME}"
           rg="${AZURE_RESOURCE_GROUP}"
+          location="${AZURE_LOCATION}"
           acr_name="${{ steps.acr.outputs.acr_name }}"
           acr_server="${{ steps.acr.outputs.acr_login_server }}"
           image_ref="${{ steps.acr.outputs.acr_login_server }}/aijurisdiction-frontend:${{ github.sha }}"
+          deployment_result="updated"
 
           if ! az resource show --resource-group "$rg" --resource-type "Microsoft.App/containerApps" --name "$app_name" --output none 2>/dev/null; then
-            echo "::error::Container App '$app_name' was not found in resource group '$rg'."
-            exit 1
+            echo "Container App '$app_name' was not found in resource group '$rg'. Provisioning it first."
+            az deployment group create \
+              --resource-group "$rg" \
+              --name "frontend-${{ github.run_id }}-${{ github.run_attempt }}" \
+              --template-file infra/bicep/frontend.containerapp.bicep \
+              --parameters \
+                location="$location" \
+                managedEnvironmentName="$AZURE_CONTAINERAPPS_ENVIRONMENT" \
+                containerAppName="$app_name" \
+                acrName="$acr_name" \
+                managedIdentityName="$AZURE_MANAGED_IDENTITY_NAME" \
+                image="$image_ref" \
+              --only-show-errors \
+              --output none
+            deployment_result="created"
           fi
+
+          echo "FRONTEND_ACA_RESULT=$deployment_result" >> "$GITHUB_ENV"
 
           provisioning_state="$(az containerapp show --name "$app_name" --resource-group "$rg" --query "properties.provisioningState" --output tsv 2>/dev/null || true)"
           provisioning_state="${provisioning_state:-Unknown}"
@@ -265,5 +284,5 @@ jobs:
             echo "| Resource | Name | Result | Endpoint |"
             echo "| --- | --- | --- | --- |"
             echo "| Managed environment | $AZURE_CONTAINERAPPS_ENVIRONMENT | reused | n/a |"
-            echo "| Frontend container app | $app_name | updated | $endpoint |"
+            echo "| Frontend container app | $app_name | ${FRONTEND_ACA_RESULT:-updated} | $endpoint |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -95,6 +95,7 @@ These are used by infrastructure deployment and API deployment workflows:
 | Variable | Purpose |
 | --- | --- |
 | `AZURE_CONTAINER_APP_NAME` | API Azure Container App name |
+| `AZURE_FRONTEND_CONTAINER_APP_NAME` | Frontend Azure Container App name provisioned by `infra_deploy` and updated by `web_build_deploy` |
 | `AZURE_APPLICATION_INSIGHTS_NAME` | Application Insights resource name |
 | `LLM_PROVIDER` | Runtime LLM provider, keep `azurefoundry` for deployed Azure environments |
 | `AZURE_OPENAI_ENDPOINT` | Azure OpenAI / Foundry endpoint URL used by chat and document embeddings |
@@ -137,6 +138,17 @@ These are used by the web frontend deployment workflow:
 | Variable | Purpose |
 | --- | --- |
 | `AZURE_FRONTEND_CONTAINER_APP_NAME` | Frontend Azure Container App name |
+
+The frontend workflow also reuses these shared Azure deployment variables:
+
+- `AZURE_CLIENT_ID`
+- `AZURE_TENANT_ID`
+- `AZURE_SUBSCRIPTION_ID`
+- `AZURE_RESOURCE_GROUP`
+- `AZURE_LOCATION`
+- `AZURE_CONTAINERAPPS_ENVIRONMENT`
+- `AZURE_CONTAINER_REGISTRY`
+- `AZURE_MANAGED_IDENTITY_NAME`
 
 ## 7. Configure Document Processor Variables
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -162,6 +162,7 @@ The Bicep deployment provisions or reuses:
 - PostgreSQL database for the Slovak laws corpus (`AZURE_LAWS_POSTGRES_DATABASE_NAME_SK`, default `laws_sk`)
 - firewall rule for Azure services
 - `azure.extensions=vector`
+- Public frontend Azure Container App (`AZURE_FRONTEND_CONTAINER_APP_NAME`)
 - Private Azure Container App for the laws collector (`AZURE_LAWS_COLLECTOR_CONTAINER_APP_NAME`, default `laws-collector`)
 
 Existing-resource behavior:
@@ -418,9 +419,14 @@ New frontend deployment assets:
 - `.github/workflows/web_build_deploy.yml`: frontend CI/CD workflow
 - `.github/workflows/infra_deploy.yml`: infrastructure provisioning workflow (Bicep)
 
-Required GitHub Environment variable for frontend deployment:
+Required GitHub Environment variables for frontend deployment:
 
 - `AZURE_FRONTEND_CONTAINER_APP_NAME`
+- `AZURE_LOCATION`
+- `AZURE_MANAGED_IDENTITY_NAME`
+
+`infra_deploy` now provisions or reuses the frontend Container App shell using `AZURE_FRONTEND_CONTAINER_APP_NAME`.
+`web_build_deploy` updates that app with the built frontend image and can also bootstrap it directly if the shell was not provisioned yet.
 
 For a repo-level checklist to create additional GitHub Environments such as `test`
 and `prod`, see `docs/GITHUB_ENVIRONMENTS.md`.

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -1,6 +1,7 @@
 param location string = resourceGroup().location
 param environmentName string
 param containerAppName string
+param frontendContainerAppName string
 param acrName string
 param storageAccountName string = toLower('staijur${uniqueString(subscription().subscriptionId, resourceGroup().name)}')
 param storageContainerName string = 'case-documents'
@@ -26,6 +27,7 @@ param createStorageAccount bool = true
 param createManagedIdentity bool = true
 param createApplicationInsights bool = true
 param createContainerApp bool = true
+param createFrontendContainerApp bool = true
 param createLawsCollectorContainerApp bool = true
 param createPostgresServer bool = true
 param tags object = {}
@@ -403,6 +405,28 @@ resource containerAppExisting 'Microsoft.App/containerApps@2024-03-01' existing 
   name: containerAppName
 }
 
+module frontendContainerApp 'frontend.containerapp.bicep' = if (createFrontendContainerApp) {
+  name: 'frontendContainerApp'
+  params: {
+    location: location
+    managedEnvironmentName: environmentName
+    containerAppName: frontendContainerAppName
+    acrName: acrName
+    managedIdentityName: managedIdentityName
+    image: 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+    tags: tags
+  }
+  dependsOn: [
+    managedEnvironment
+    acr
+    managedIdentity
+  ]
+}
+
+resource frontendContainerAppExisting 'Microsoft.App/containerApps@2024-03-01' existing = if (!createFrontendContainerApp) {
+  name: frontendContainerAppName
+}
+
 module lawsCollectorContainerApp 'laws_collector.containerapp.bicep' = if (createLawsCollectorContainerApp) {
   name: 'lawsCollectorContainerApp'
   params: {
@@ -447,6 +471,15 @@ output containerAppFqdn string = createContainerApp
 output containerAppUrl string = createContainerApp
   ? 'https://${containerApp.properties.configuration.ingress.fqdn}'
   : 'https://${containerAppExisting.properties.configuration.ingress.fqdn}'
+output frontendContainerAppName string = createFrontendContainerApp
+  ? frontendContainerApp.outputs.containerAppName
+  : frontendContainerAppExisting.name
+output frontendContainerAppFqdn string = createFrontendContainerApp
+  ? frontendContainerApp.outputs.containerAppFqdn
+  : frontendContainerAppExisting.properties.configuration.ingress.fqdn
+output frontendContainerAppUrl string = createFrontendContainerApp
+  ? frontendContainerApp.outputs.containerAppUrl
+  : 'https://${frontendContainerAppExisting.properties.configuration.ingress.fqdn}'
 output containerAppsEnvironmentName string = createManagedEnvironment
   ? managedEnvironment.name
   : managedEnvironmentExisting.name

--- a/infra/bicep/main.parameters.example.json
+++ b/infra/bicep/main.parameters.example.json
@@ -11,6 +11,9 @@
     "containerAppName": {
       "value": "ca-aijuristiction-api-dev"
     },
+    "frontendContainerAppName": {
+      "value": "ca-aijurisdiction-frontend-dev"
+    },
     "lawsCollectorContainerAppName": {
       "value": "laws-collector"
     },


### PR DESCRIPTION
## Summary
- provision or reuse the frontend Container App from infra_deploy using AZURE_FRONTEND_CONTAINER_APP_NAME
- let web_build_deploy bootstrap the frontend ACA if it is missing
- align infra and GitHub Environment docs with the frontend ACA requirements

## Validation
- az bicep build --file infra/bicep/main.bicep
- az bicep build --file infra/bicep/frontend.containerapp.bicep