### PR TITLE
Fix #211 navbar logo visibility and My Cases navigation

### DIFF
--- a/docs/FRONTEND_DEMO.md
+++ b/docs/FRONTEND_DEMO.md
@@ -54,6 +54,8 @@ npm run preview
   - Sign-in link when logged out
   - Profile trigger when logged in with dropdown options: `My Profile`, `My Cases`, `Log Out`
   - `My Profile` navigates to `/profile`
+  - `My Cases` currently navigates to `/` (homepage workspace)
+  - Brand/logo is shown for signed-in non-home routes and for signed-in home when the sidebar is collapsed
   - Dropdown closes on outside click, option click, and `Escape`
   - Keyboard support includes `ArrowUp`/`ArrowDown` navigation and `Home`/`End` shortcuts
 

--- a/examples/frontend_navbar_task_211_minimal_demo.py
+++ b/examples/frontend_navbar_task_211_minimal_demo.py
@@ -1,0 +1,54 @@
+"""Minimal runnable verification for frontend task #211 navbar/profile changes.
+
+Run:
+    python examples/frontend_navbar_task_211_minimal_demo.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NAVIGATION_PATH = (
+    REPO_ROOT
+    / "frontend"
+    / "aijurisdictionfronend"
+    / "src"
+    / "components"
+    / "Navigation.tsx"
+)
+PAGE_LAYOUT_PATH = (
+    REPO_ROOT
+    / "frontend"
+    / "aijurisdictionfronend"
+    / "src"
+    / "components"
+    / "PageLayout.tsx"
+)
+
+
+def _require_contains(path: Path, token: str, message: str) -> None:
+    content = path.read_text(encoding="utf-8")
+    if token not in content:
+        raise AssertionError(f"{message}\nMissing token: {token}\nChecked file: {path}")
+
+
+if __name__ == "__main__":
+    _require_contains(
+        NAVIGATION_PATH,
+        'navigate("/")',
+        "My Cases action must route to homepage.",
+    )
+    _require_contains(
+        NAVIGATION_PATH,
+        "const showBrand = !isAuthenticated || pathname !== \"/\" || isSidebarCollapsed;",
+        "Navbar branding logic must include signed-in non-home and collapsed-sidebar homepage cases.",
+    )
+    _require_contains(
+        PAGE_LAYOUT_PATH,
+        "<Navigation isSidebarCollapsed={!sidebarOpen} />",
+        "PageLayout must pass sidebar collapse state into Navigation for homepage behavior.",
+    )
+
+    print("Frontend task #211 minimal demo checks passed.")

--- a/frontend/aijurisdictionfronend/README.md
+++ b/frontend/aijurisdictionfronend/README.md
@@ -43,7 +43,9 @@ All `/app/*` routes and `/profile` are guarded by mock auth state.
 
 The signed-out navigation includes the same app logo treatment used in the signed-in sidebar (`AJ` mark + app name/tagline).
 
-- The logo is rendered on the left side of the navbar only when the user is not signed in.
+- The logo is rendered on the left side of the navbar for signed-out views.
+- The logo is also rendered for signed-in views on non-home routes (for example `/app` and `/profile`).
+- On signed-in homepage (`/`), the navbar logo is shown when the workspace sidebar is collapsed.
 - The logo links to `/` (marketing homepage).
 - The navbar layout is responsive so brand, links, and actions do not overlap at mobile widths.
 
@@ -53,6 +55,7 @@ In signed-in state, the profile icon opens a click-triggered dropdown menu in th
 
 - Options: `My Profile`, `My Cases`, `Log Out`
 - `My Profile` navigates to `/profile`
+- `My Cases` currently navigates to `/` (homepage workspace)
 - Menu closes on outside click, on option click, and on `Escape`
 - Keyboard navigation is supported with `ArrowUp`, `ArrowDown`, `Home`, and `End`
 - Mobile layout keeps the dropdown anchored under the trigger with viewport-safe width
@@ -120,4 +123,10 @@ npm run preview
 
 ```bash
 python examples/minimal_demo.py
+```
+
+Task-specific frontend check:
+
+```bash
+python examples/frontend_navbar_task_211_minimal_demo.py
 ```

--- a/frontend/aijurisdictionfronend/src/__tests__/navigation.test.tsx
+++ b/frontend/aijurisdictionfronend/src/__tests__/navigation.test.tsx
@@ -21,6 +21,8 @@ vi.mock("../auth/mockAuth", () => ({
 }));
 
 const labels: Record<string, string> = {
+  appName: "AI Jurisdiction",
+  tagline: "Agentic legal workspace",
   navHome: "Home",
   navPricing: "Pricing",
   navApp: "App",
@@ -41,15 +43,21 @@ vi.mock("../components/LanguageSwitcher", () => ({
   LanguageSwitcher: () => <div data-testid="language-switcher" />
 }));
 
-function renderNavigation() {
+function renderNavigation({
+  initialEntries = ["/"],
+  isSidebarCollapsed = false
+}: {
+  initialEntries?: string[];
+  isSidebarCollapsed?: boolean;
+} = {}) {
   const PathIndicator = () => {
     const location = useLocation();
     return <div data-testid="current-path">{location.pathname}</div>;
   };
 
   return render(
-    <MemoryRouter>
-      <Navigation />
+    <MemoryRouter initialEntries={initialEntries}>
+      <Navigation isSidebarCollapsed={isSidebarCollapsed} />
       <PathIndicator />
     </MemoryRouter>
   );
@@ -138,5 +146,36 @@ describe("Navigation profile dropdown", () => {
     await waitFor(() => {
       expect(screen.getByTestId("current-path").textContent).toBe("/profile");
     });
+  });
+
+  it("navigates to / when My Cases is clicked", async () => {
+    const user = userEvent.setup();
+    renderNavigation({ initialEntries: ["/profile"] });
+
+    expect(screen.getByTestId("current-path").textContent).toBe("/profile");
+    await user.click(screen.getByLabelText("Profile"));
+    await user.click(screen.getByRole("menuitem", { name: "My Cases" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("current-path").textContent).toBe("/");
+    });
+  });
+
+  it("shows navbar brand on non-home routes for signed-in users", () => {
+    renderNavigation({ initialEntries: ["/app"] });
+
+    expect(screen.getByText("AI Jurisdiction")).toBeDefined();
+  });
+
+  it("shows navbar brand on home when sidebar is collapsed", () => {
+    renderNavigation({ initialEntries: ["/"], isSidebarCollapsed: true });
+
+    expect(screen.getByText("AI Jurisdiction")).toBeDefined();
+  });
+
+  it("hides navbar brand on home when sidebar is expanded", () => {
+    renderNavigation({ initialEntries: ["/"], isSidebarCollapsed: false });
+
+    expect(screen.queryByText("AI Jurisdiction")).toBeNull();
   });
 });

--- a/frontend/aijurisdictionfronend/src/components/Navigation.tsx
+++ b/frontend/aijurisdictionfronend/src/components/Navigation.tsx
@@ -1,11 +1,16 @@
 import React from "react";
-import { Link, NavLink, useNavigate } from "react-router-dom";
+import { Link, NavLink, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../auth/mockAuth";
 import { useLanguage } from "./LanguageProvider";
 import { LanguageSwitcher } from "./LanguageSwitcher";
 
-export const Navigation: React.FC = () => {
+type NavigationProps = {
+  isSidebarCollapsed?: boolean;
+};
+
+export const Navigation: React.FC<NavigationProps> = ({ isSidebarCollapsed = false }) => {
   const navigate = useNavigate();
+  const { pathname } = useLocation();
   const { t } = useLanguage();
   const { isAuthenticated, user, signOut } = useAuth();
   const [profileOpen, setProfileOpen] = React.useState(false);
@@ -30,7 +35,7 @@ export const Navigation: React.FC = () => {
         return;
       }
       if (action === "cases") {
-        navigate("/app/workspace");
+        navigate("/");
         return;
       }
       signOut();
@@ -142,11 +147,12 @@ export const Navigation: React.FC = () => {
   const profileName = user?.name ?? "User";
   const profileEmail = user?.email ?? "";
   const profileInitial = profileName.slice(0, 1).toUpperCase();
+  const showBrand = !isAuthenticated || pathname !== "/" || isSidebarCollapsed;
 
   return (
     <header className="site-header">
       <nav className="nav">
-        {!isAuthenticated ? (
+        {showBrand ? (
           <Link className="brand nav-brand" to="/">
             <div className="brand-mark" aria-hidden="true">
               AJ

--- a/frontend/aijurisdictionfronend/src/components/PageLayout.tsx
+++ b/frontend/aijurisdictionfronend/src/components/PageLayout.tsx
@@ -30,7 +30,7 @@ export const PageLayout: React.FC<{ children: React.ReactNode }> = ({ children }
           </button>
         ) : null}
         <div className="app-shell__main">
-          <Navigation />
+          <Navigation isSidebarCollapsed={!sidebarOpen} />
           <main className="main-content">{children}</main>
           <Footer />
         </div>
@@ -40,7 +40,7 @@ export const PageLayout: React.FC<{ children: React.ReactNode }> = ({ children }
 
   return (
     <div className="app-shell">
-      <Navigation />
+      <Navigation isSidebarCollapsed={false} />
       <main className="main-content">{children}</main>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- show the navbar brand/logo for signed-in non-home routes
- show the navbar brand/logo on signed-in home when the sidebar is collapsed
- route My Cases from profile dropdown to / (homepage workspace)
- add navigation tests for new routing and logo visibility behavior
- update frontend docs and add task-specific minimal runnable verification script

## Validation
- 
pm run test -- --run src/__tests__/navigation.test.tsx
- 
pm run lint
- python examples/frontend_navbar_task_211_minimal_demo.py

Closes #211