### PR TITLE
Add parent-law year/number to Slovak laws collector storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ Technical design details: `docs/MOBILE_TECHNICAL_DESIGN.md`.
 The laws collector package lives in `src/services/laws_collector`.
 It now selects a country-specific implementation by `LAWS_COUNTRY`.
 Only `slovak_laws_collector` is implemented today, and it keeps using PostgreSQL database `laws_sk`.
+For Slovak records, the collector persists law year/number and also stores an optional parent law year/number when the imported act is an amendment of another law.
 
 Quick start:
 

--- a/databases/migrations/laws/0001_create_laws_schema.sql
+++ b/databases/migrations/laws/0001_create_laws_schema.sql
@@ -14,6 +14,8 @@ CREATE TABLE IF NOT EXISTS law_documents (
     first_effective_date DATE NOT NULL,
     applicable_to TEXT,
     superseded_by_url TEXT NOT NULL DEFAULT '',
+    parent_law_year INTEGER,
+    parent_law_number INTEGER,
     first_stored_at TIMESTAMPTZ NOT NULL,
     last_stored_at TIMESTAMPTZ NOT NULL,
     last_checked_at TIMESTAMPTZ NOT NULL,

--- a/docs/LAWS_COLLECTOR.md
+++ b/docs/LAWS_COLLECTOR.md
@@ -75,7 +75,11 @@ These are the most important columns now:
 - `official_name`: the official law name as published
 - `lawyer_title`: the practical title lawyers are likely to search for
 - `publication_date`
+- `law_year`
+- `law_number`
 - `first_effective_date`
+- `parent_law_year` (optional amendment target reference)
+- `parent_law_number` (optional amendment target reference)
 - `first_stored_at`
 - `last_stored_at`
 - `last_checked_at`
@@ -235,6 +239,7 @@ Implemented upgrades include:
 - richer law metadata stored with each document:
   - `applicable_to`,
   - `superseded_by_url` (link to newer law),
+  - `parent_law_year` / `parent_law_number` for Slovak amendment acts that update another law,
   - existing lifecycle timestamps and status fields.
 - deterministic vector generation per law version (`embedding_vector`) for semantic retrieval bootstrap.
 - PostgreSQL store support (`LAWS_DB_BACKEND=postgres`) plus migration project `databases/migrations/laws`.

--- a/examples/laws_collector_minimal_demo.py
+++ b/examples/laws_collector_minimal_demo.py
@@ -50,6 +50,7 @@ def main() -> None:
         print("Provisions in DB:", counts.provisions)
         print("Update events in DB:", counts.update_events)
         print("First document:", overview[0])
+        print("Amendment sample parent law:", (overview[2].law_year, overview[2].law_number), "->", (overview[2].parent_law_year, overview[2].parent_law_number))
         print("SQLite path:", store.db_path)
 
 

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260325"
+__version__ = "1.0.260328"

--- a/src/services/laws_collector/domain.py
+++ b/src/services/laws_collector/domain.py
@@ -33,6 +33,8 @@ class LawSnapshot:
     status: str = "published"
     applicable_to: str | None = None
     superseded_by_url: str = ""
+    parent_law_year: int | None = None
+    parent_law_number: int | None = None
     http_etag: str = ""
     http_last_modified: str = ""
 
@@ -53,6 +55,8 @@ class LawSnapshot:
             "status": self.status,
             "applicable_to": self.applicable_to,
             "superseded_by_url": self.superseded_by_url,
+            "parent_law_year": self.parent_law_year,
+            "parent_law_number": self.parent_law_number,
             "source_url": self.source_url,
             "provisions": [
                 {

--- a/src/services/laws_collector/postgres_store.py
+++ b/src/services/laws_collector/postgres_store.py
@@ -59,12 +59,14 @@ class PostgresLawStore:
                     INSERT INTO law_documents(
                         document_id, country_code, collection_code, law_year, law_number, official_name,
                         lawyer_title, source_url, publication_date, current_status, first_effective_date,
-                        applicable_to, superseded_by_url, first_stored_at, last_stored_at, last_checked_at,
+                        applicable_to, superseded_by_url, parent_law_year, parent_law_number,
+                        first_stored_at, last_stored_at, last_checked_at,
                         last_download_status, last_download_error, download_attempt_count, created_at, updated_at
                     ) VALUES (
                         %(document_id)s, %(country)s, %(collection)s, %(year)s, %(number)s, %(official_name)s,
                         %(lawyer_title)s, %(source_url)s, %(publication_date)s, %(status)s, %(effective_from)s,
-                        %(applicable_to)s, %(superseded_by_url)s, %(now)s, %(now)s, %(now)s, 'stored', '', 1,
+                        %(applicable_to)s, %(superseded_by_url)s, %(parent_law_year)s, %(parent_law_number)s,
+                        %(now)s, %(now)s, %(now)s, 'stored', '', 1,
                         %(now)s, %(now)s
                     )
                     """,
@@ -82,6 +84,8 @@ class PostgresLawStore:
                         "effective_from": snapshot.effective_from,
                         "applicable_to": snapshot.applicable_to,
                         "superseded_by_url": snapshot.superseded_by_url,
+                        "parent_law_year": snapshot.parent_law_year,
+                        "parent_law_number": snapshot.parent_law_number,
                         "now": now,
                     },
                 )
@@ -99,6 +103,8 @@ class PostgresLawStore:
                     current_status = %(status)s,
                     applicable_to = %(applicable_to)s,
                     superseded_by_url = %(superseded_by_url)s,
+                    parent_law_year = %(parent_law_year)s,
+                    parent_law_number = %(parent_law_number)s,
                     last_stored_at = %(now)s,
                     last_checked_at = %(now)s,
                     last_download_status = 'stored',
@@ -116,6 +122,8 @@ class PostgresLawStore:
                     "status": snapshot.status,
                     "applicable_to": snapshot.applicable_to,
                     "superseded_by_url": snapshot.superseded_by_url,
+                    "parent_law_year": snapshot.parent_law_year,
+                    "parent_law_number": snapshot.parent_law_number,
                     "now": now,
                 },
             )

--- a/src/services/laws_collector/slovak_source_fixtures.py
+++ b/src/services/laws_collector/slovak_source_fixtures.py
@@ -154,6 +154,8 @@ def delta_snapshots() -> tuple[LawSnapshot, ...]:
             ),
             status="published",
             applicable_to="digital public services",
+            parent_law_year=2025,
+            parent_law_number=25,
             http_etag="sk-421-v20251215",
             http_last_modified="2025-12-10T15:45:00Z",
         ),

--- a/src/services/laws_collector/sqlite_store.py
+++ b/src/services/laws_collector/sqlite_store.py
@@ -29,6 +29,8 @@ class LawDocumentOverview:
     first_effective_date: str
     applicable_to: str | None
     superseded_by_url: str
+    parent_law_year: int | None
+    parent_law_number: int | None
     last_stored_at: str
     last_checked_at: str
     last_download_status: str
@@ -69,6 +71,8 @@ class SqliteLawStore:
                     first_effective_date TEXT NOT NULL,
                     applicable_to TEXT,
                     superseded_by_url TEXT NOT NULL,
+                    parent_law_year INTEGER,
+                    parent_law_number INTEGER,
                     first_stored_at TEXT NOT NULL,
                     last_stored_at TEXT NOT NULL,
                     last_checked_at TEXT NOT NULL,
@@ -171,10 +175,11 @@ class SqliteLawStore:
                     INSERT INTO law_documents(
                         document_id, country_code, collection_code, law_year, law_number, official_name,
                         lawyer_title, source_url, publication_date, current_status, first_effective_date,
-                        applicable_to, superseded_by_url, first_stored_at, last_stored_at, last_checked_at,
+                        applicable_to, superseded_by_url, parent_law_year, parent_law_number,
+                        first_stored_at, last_stored_at, last_checked_at,
                         last_download_status, last_download_error, download_attempt_count, created_at, updated_at
                     )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         document_id,
@@ -190,6 +195,8 @@ class SqliteLawStore:
                         snapshot.effective_from,
                         snapshot.applicable_to,
                         snapshot.superseded_by_url,
+                        snapshot.parent_law_year,
+                        snapshot.parent_law_number,
                         now,
                         now,
                         now,
@@ -208,6 +215,7 @@ class SqliteLawStore:
                 UPDATE law_documents
                 SET official_name = ?, lawyer_title = ?, source_url = ?, publication_date = ?,
                     current_status = ?, applicable_to = ?, superseded_by_url = ?,
+                    parent_law_year = ?, parent_law_number = ?,
                     last_stored_at = ?, last_checked_at = ?,
                     last_download_status = ?, last_download_error = '',
                     download_attempt_count = download_attempt_count + 1, updated_at = ?
@@ -221,6 +229,8 @@ class SqliteLawStore:
                     snapshot.status,
                     snapshot.applicable_to,
                     snapshot.superseded_by_url,
+                    snapshot.parent_law_year,
+                    snapshot.parent_law_number,
                     now,
                     now,
                     "stored",
@@ -472,6 +482,7 @@ class SqliteLawStore:
                 """
                 SELECT law_year, law_number, official_name, lawyer_title, publication_date,
                        first_effective_date, applicable_to, superseded_by_url,
+                       parent_law_year, parent_law_number,
                        last_stored_at, last_checked_at, last_download_status, download_attempt_count
                 FROM law_documents
                 ORDER BY law_year, law_number
@@ -488,6 +499,8 @@ class SqliteLawStore:
                 first_effective_date=str(row["first_effective_date"]),
                 applicable_to=(str(row["applicable_to"]) if row["applicable_to"] else None),
                 superseded_by_url=str(row["superseded_by_url"]),
+                parent_law_year=(int(row["parent_law_year"]) if row["parent_law_year"] is not None else None),
+                parent_law_number=(int(row["parent_law_number"]) if row["parent_law_number"] is not None else None),
                 last_stored_at=str(row["last_stored_at"]),
                 last_checked_at=str(row["last_checked_at"]),
                 last_download_status=str(row["last_download_status"]),

--- a/tests/test_laws_collector.py
+++ b/tests/test_laws_collector.py
@@ -51,6 +51,8 @@ def test_laws_collector_baseline_sync_creates_documents_and_versions(tmp_path: P
     assert overview[0].download_attempt_count == 1
     assert overview[0].applicable_to == "all construction permits"
     assert overview[0].superseded_by_url == ""
+    assert overview[0].parent_law_year is None
+    assert overview[0].parent_law_number is None
 
 
 def test_laws_collector_delta_sync_adds_new_act_and_new_version(tmp_path: Path) -> None:
@@ -73,6 +75,9 @@ def test_laws_collector_delta_sync_adds_new_act_and_new_version(tmp_path: Path) 
     assert overview[0].download_attempt_count == 2
     assert overview[0].last_download_status == "stored"
     assert overview[0].superseded_by_url == "https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/2026/11/"
+    assert overview[2].law_number == 421
+    assert overview[2].parent_law_year == 2025
+    assert overview[2].parent_law_number == 25
 
 
 def test_laws_collector_config_resolves_relative_db_from_repo_root(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- Collectors must record not only a law's own `year`/`number` but also an optional reference to the parent law when an imported Slovak act amends another law so the system can trace amendment relationships.
- Including parent-law fields in the normalized payload ensures checksum/versioning and update-plan logic account for amendment targets.

### Description
- Added optional `parent_law_year` and `parent_law_number` fields to the `LawSnapshot` model and included them in `normalized_payload` for deterministic checksums (`src/services/laws_collector/domain.py`).
- Persisted parent-law references in the SQLite store by extending the `law_documents` schema, insert/update SQL and `LawDocumentOverview` projection (`src/services/laws_collector/sqlite_store.py`).
- Extended PostgreSQL upsert logic to write and update `parent_law_year`/`parent_law_number` in create and update flows (`src/services/laws_collector/postgres_store.py`).
- Updated the laws database migration to add `parent_law_year` and `parent_law_number` columns to `law_documents` (`databases/migrations/laws/0001_create_laws_schema.sql`).
- Added a Slovak delta fixture that models an amendment referencing a parent law and updated unit test assertions to validate storage of the parent reference (`src/services/laws_collector/slovak_source_fixtures.py`, `tests/test_laws_collector.py`).
- Updated docs and the minimal demo output to document and show the new parent-law linkage, and bumped the package revision per project versioning rules (`docs/LAWS_COLLECTOR.md`, `README.md`, `examples/laws_collector_minimal_demo.py`, `src/aijurisdictionagents/__init__.py`).

### Testing
- Ran quick static compile check with `python -m py_compile src/services/laws_collector/domain.py src/services/laws_collector/sqlite_store.py src/services/laws_collector/postgres_store.py src/services/laws_collector/slovak_source_fixtures.py examples/laws_collector_minimal_demo.py`, which completed successfully.
- Executed `pytest -q tests/test_laws_collector.py`, which failed during test collection due to a pre-existing syntax error in `src/services/laws_collector/config.py` that is unrelated to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7e31b6c04833284f572fa8cb203cb)