### PR TITLE
Fix GitHub laws collector build failures

### DIFF
--- a/.github/workflows/api_build_deploy.yml
+++ b/.github/workflows/api_build_deploy.yml
@@ -62,7 +62,7 @@ jobs:
   deploy_to_azure:
     runs-on: ubuntu-latest
     needs: test_and_build
-    if: github.event_name != 'workflow_dispatch' || inputs.deploy == 'true'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.deploy == 'true')
     environment: ${{ github.event_name == 'workflow_dispatch' && inputs.github_environment || 'dev' }}
     permissions:
       id-token: write

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -269,6 +269,7 @@ Some workflows default to `dev` for push-based execution.
 That means:
 
 - `API Build and Deploy` now deploys automatically to `dev` on `push` to `main` after tests/build pass
+- `API Build and Deploy` does not deploy on `pull_request`; PR runs validate build, lint, type checks, and tests only
 - `API Build and Deploy` waits for Azure Container App provisioning to settle before applying secret and environment updates, which reduces transient `ContainerAppOperationInProgress` failures during deployment
 - `API Build and Deploy` now fails during environment validation when `AZURE_OPENAI_API_KEY` is empty, because the deployed API always requires that secret for Azure OpenAI access
 - `Laws Collector Build and Deploy` now deploys automatically to `dev` on `push` to `main` after its tests/build pass

--- a/docs/LAWS_COLLECTOR.md
+++ b/docs/LAWS_COLLECTOR.md
@@ -214,6 +214,7 @@ Add these to `.env` when you start wiring the service into real runs:
 - `LAWS_HISTORICAL_IMPORT_FROM=1946-01-01`
 
 `LAWS_COUNTRY` selects the country-specific collector implementation. The current implementation supports only `SK`, so the service still defaults to `SK` when the variable is unset.
+If `LAWS_DB_LOCAL` or `LAWS_STORAGE_LOCAL` are unset, the service now falls back to country-specific defaults automatically.
 
 For PostgreSQL naming, keep the database mapping country-specific:
 
@@ -283,17 +284,17 @@ Start the local worker loop with the new project skill:
 
 This runs the collector worker (`services.laws_collector.worker`) with local SQLite defaults and is useful for repeatable smoke tests.
 
-## Azure Container App deployment (laws-collector)
+## Azure Container Apps Job deployment (laws-collector)
 
-Deployment assets for a dedicated Azure Container App named `laws-collector` are now included:
+Deployment assets for a dedicated Azure Container Apps Job named `laws-collector` are now included:
 
-- `infra/bicep/laws_collector.containerapp.bicep`
+- `infra/bicep/laws_collector.job.bicep`
 - `infra/scripts/deploy_laws_collector.ps1`
-- `infra/bicep/laws_collector.containerapp.parameters.example.json`
+- `infra/bicep/laws_collector.job.parameters.example.json`
 - container image definition: `src/services/laws_collector/Dockerfile`
 - GitHub Actions workflow: `.github/workflows/laws_collector_build_deploy.yml`
 
-The deploy script builds the image in ACR and deploys it to Azure Container Apps with PostgreSQL env configuration.
+The deploy script builds the image in ACR and deploys it to Azure Container Apps Jobs with PostgreSQL env configuration.
 
 
 ## SlovLex import order for Slovakia
@@ -314,4 +315,4 @@ Preview the planned windows with:
 PYTHONPATH=src python -m services.laws_collector --plan-import
 PYTHONPATH=src python -m services.laws_collector --plan-import --initial-window-complete
 ```
-The shared `infra_deploy` workflow now also provisions the `laws_sk` PostgreSQL database and a placeholder private Container App for `laws-collector`, which the dedicated laws collector workflow later updates with the real image.
+The shared `infra_deploy` workflow now also provisions the `laws_sk` PostgreSQL database and a placeholder private ACA Job for `laws-collector`, which the dedicated laws collector workflow later updates with the real image.

--- a/examples/laws_collector_minimal_demo.py
+++ b/examples/laws_collector_minimal_demo.py
@@ -4,9 +4,12 @@ from datetime import date
 from pathlib import Path
 import tempfile
 
-from services.laws_collector import LawsCollectorConfig, SlovLexImportPlanner, SlovakLawsCollectorService, SqliteLawStore
-from services.laws_collector.source_fixtures import baseline_snapshots, delta_snapshots
-from services.laws_collector import  get_country_laws_collector_definition
+from services.laws_collector import (
+    LawsCollectorConfig,
+    SlovLexImportPlanner,
+    SqliteLawStore,
+    get_country_laws_collector_definition,
+)
 
 
 def main() -> None:
@@ -26,14 +29,14 @@ def main() -> None:
         collector_definition = get_country_laws_collector_definition(config.country_code)
         store = SqliteLawStore.from_config(config)
         store.initialize()
-        service = SlovakLawsCollectorService(config=config, store=store)
+        service = collector_definition.create_service(config=config, store=store)
         planner = SlovLexImportPlanner(config=config)
 
-        baseline_snapshots = collector_definition.baseline_snapshots()
-        delta_snapshots = collector_definition.delta_snapshots()
-        baseline = service.sync(baseline_snapshots)
-        delta = service.sync(delta_snapshots)
-        plan = service.plan_updates(known_snapshots=baseline_snapshots, latest_snapshots=delta_snapshots)
+        baseline = collector_definition.baseline_snapshots()
+        delta = collector_definition.delta_snapshots()
+        baseline_summary = service.sync(baseline)
+        delta_summary = service.sync(delta)
+        plan = service.plan_updates(known_snapshots=baseline, latest_snapshots=delta)
         counts = store.get_counts()
         overview = store.list_document_overview()
 
@@ -42,8 +45,8 @@ def main() -> None:
         print("Collector:", collector_definition.collector_name)
         print("Country:", config.country_code)
         print("Cloud DB name:", collector_definition.cloud_database_name)
-        print("Baseline sync:", baseline)
-        print("Delta sync:", delta)
+        print("Baseline sync:", baseline_summary)
+        print("Delta sync:", delta_summary)
         print("Planned updates:", plan.items_with_updates)
         print("Documents in DB:", counts.documents)
         print("Versions in DB:", counts.versions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aijurisdictionagents"
-version = "1.0.260325"
+version = "1.0.260329"
 description = "Multi-agent legal discussion scaffold."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260328"
+__version__ = "1.0.260329"

--- a/src/services/laws_collector/config.py
+++ b/src/services/laws_collector/config.py
@@ -23,33 +23,20 @@ class LawsCollectorConfig:
     @classmethod
     def from_env(cls) -> "LawsCollectorConfig":
         country_code = os.getenv("LAWS_COUNTRY", "SK").strip().upper()
-        default_sqlite_path = f"./databases/laws-collector/{country_code.lower()}_laws.sqlite3"
-        
-        return cls(
-            country_code=country_code,
-            db_backend=os.getenv("LAWS_DB_BACKEND", "sqlite").strip().lower(),
-            db_local=os.getenv("LAWS_DB_LOCAL", default_sqlite_path).strip(),
-            db_cloud=os.getenv("LAWS_DB_CLOUD", "").strip(),
-            storage_local=os.getenv("LAWS_STORAGE_LOCAL", f"./storage/laws/{country_code.lower()}").strip(),
-            db_local = os.getenv("LAWS_DB_LOCAL", "").strip()
-            storage_local = os.getenv("LAWS_STORAGE_LOCAL", "").strip()
-            if not db_local:
-                db_local = cls.default_local_db_path_for(country_code)
-            if not storage_local:
-                storage_local = cls.default_local_storage_path_for(country_code)
+        db_local = os.getenv("LAWS_DB_LOCAL", "").strip()
+        storage_local = os.getenv("LAWS_STORAGE_LOCAL", "").strip()
+
+        if not db_local:
+            db_local = cls.default_local_db_path_for(country_code)
+        if not storage_local:
+            storage_local = cls.default_local_storage_path_for(country_code)
 
         return cls(
             country_code=country_code,
             db_backend=os.getenv("LAWS_DB_BACKEND", "sqlite").strip().lower(),
-            db_local=os.getenv("LAWS_DB_LOCAL", default_sqlite_path).strip(),
+            db_local=db_local,
             db_cloud=os.getenv("LAWS_DB_CLOUD", "").strip(),
-            storage_local=os.getenv("LAWS_STORAGE_LOCAL", f"./storage/laws/{country_code.lower()}").strip(),
-            db_local = os.getenv("LAWS_DB_LOCAL", "").strip()
-            storage_local = os.getenv("LAWS_STORAGE_LOCAL", "").strip()
-            if not db_local:
-                db_local = cls.default_local_db_path_for(country_code)
-            if not storage_local:
-                storage_local = cls.default_local_storage_path_for(country_code),
+            storage_local=storage_local,
             storage_cloud=os.getenv("LAWS_STORAGE_CLOUD", "").strip(),
             delta_poll_hours=int(os.getenv("LAWS_DELTA_POLL_HOURS", "3")),
             initial_import_from=_parse_iso_date(os.getenv("LAWS_INITIAL_IMPORT_FROM", "2025-01-01")),

--- a/tests/test_laws_collector.py
+++ b/tests/test_laws_collector.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
+from datetime import date
 from pathlib import Path
 
-from datetime import date
-
-from services.laws_collector import LawsCollectorConfig, SlovLexImportPlanner, SlovakLawsCollectorService, SqliteLawStore
-from services.laws_collector.source_fixtures import baseline_snapshots, delta_snapshots
 from services.laws_collector import (
+    LawsCollectorConfig,
+    SlovLexImportPlanner,
+    SlovakLawsCollectorService,
+    SqliteLawStore,
     get_country_laws_collector_definition,
 )
-from services.laws_collector.slovak_laws_collector import SlovakLawsCollectorService
 from services.laws_collector.slovak_source_fixtures import baseline_snapshots, delta_snapshots
 
 
@@ -128,6 +128,8 @@ def test_slovlex_import_planner_starts_with_2025_then_unblocks_1946_history(tmp_
     assert blocked_plan.windows[1].end_date.isoformat() == "2024-12-31"
     assert blocked_plan.windows[1].blocked_by == "initial_2025_to_today"
     assert unblocked_plan.windows[1].blocked_by is None
+
+
 def test_country_definition_resolves_slovak_collector_and_db_name() -> None:
     definition = get_country_laws_collector_definition("sk")
 
@@ -145,6 +147,8 @@ def test_country_db_name_uses_laws_prefix_for_future_countries() -> None:
         storage_local="",
         storage_cloud="",
         delta_poll_hours=3,
+        initial_import_from=date(2025, 1, 1),
+        historical_import_from=date(1946, 1, 1),
     )
 
     assert config.country_db_name == "laws_cz"


### PR DESCRIPTION
## Summary
- repair the merged `LawsCollectorConfig.from_env()` implementation that introduced the CI syntax error
- clean up the laws collector tests so they import the current country-specific fixtures and construct config objects with the required date fields
- realign package versions and refresh the laws collector docs/demo to match the current ACA Job architecture and default path behavior

## Verification
- `.\\.conda\\python.exe -m pytest`
- `.\\.conda\\python.exe -m compileall src tests`
- `.\\.conda\\python.exe examples/laws_collector_minimal_demo.py`

## GitHub failures addressed
- `core_build` run `23746824075`
- `Laws Collector Build and Deploy` run `23746824070`
