### PR TITLE
Implement sequential Slovak laws collector progress

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,9 +116,15 @@ LAWS_DB_BACKEND=sqlite
 # SQLite default stays `sk_laws.sqlite3` for Slovakia. Future countries default to `<country>_laws.sqlite3`.
 LAWS_DB_LOCAL=./databases/laws-collector/sk_laws.sqlite3
 LAWS_DELTA_POLL_HOURS=3
-# SlovLex import sequencing: import the current window first, then open the historical backfill.
-LAWS_INITIAL_IMPORT_FROM=2025-01-01
-LAWS_HISTORICAL_IMPORT_FROM=1946-01-01
+# Slovak Slov-Lex sequential import always starts at law `1/1993`.
+# Progress is persisted in the laws database, including:
+# - last collector run timestamp
+# - last processed law (for example `234/2026`)
+# - next law number/year probe target
+# Worker options:
+# LAWS_WORKER_FIXTURE=live   # baseline | delta | live
+# LAWS_WORKER_POLL_SECONDS=3600
+# LAWS_WORKER_MAX_CYCLES=0
 # Optional fallback when the laws database has no imported records yet.
 # Provider APIs do not expose a reliable legal knowledge cutoff automatically,
 # so set this manually to the model/legal corpus cutoff you want the system to

--- a/README.md
+++ b/README.md
@@ -485,12 +485,34 @@ The laws collector package lives in `src/services/laws_collector`.
 It now selects a country-specific implementation by `LAWS_COUNTRY`.
 Only `slovak_laws_collector` is implemented today, and it keeps using PostgreSQL database `laws_sk`.
 For Slovak records, the collector persists law year/number and also stores an optional parent law year/number when the imported act is an amendment of another law.
+The Slovak sequential crawl now starts hardcoded at `1/1993`, persists the last collector run timestamp, and remembers the last processed law plus the next `number/year` probe target.
 
 Quick start:
 
 ```powershell
 conda activate .\.conda
 python examples/laws_collector_minimal_demo.py
+```
+
+Inspect the persisted sequential import state:
+
+```powershell
+conda activate .\.conda
+python -m services.laws_collector --plan-import
+```
+
+Run a live Slov-Lex sequential probe loop:
+
+```powershell
+conda activate .\.conda
+python -m services.laws_collector --run-sequential-import --max-probes 25
+```
+
+Local PostgreSQL debug example:
+
+```powershell
+conda activate .\.conda
+python examples/laws_collector_postgres_debug_demo.py
 ```
 
 For database, scheduling, and Azure migration guidance, see `docs/LAWS_COLLECTOR.md`.

--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -154,6 +154,8 @@ If the database is unreachable or misconfigured, the endpoint returns `503` with
 - `core_version`: core system version from installed `aijurisdictionagents` package or local `src/aijurisdictionagents/__init__.py` during monorepo development.
 - `last_law_update_date`: latest law-ingestion timestamp available to the system from the laws database. This reflects the newest law content collected by the law processor, even when the underlying LLM was trained earlier.
 - `last_law_update_source`: whether that timestamp comes from country-specific or global `law_documents` data.
+- `last_collector_run_at`: latest sequential laws collector run timestamp stored in `collector_progress`.
+- `last_processed_law`: latest successfully processed law identifier in `number/year` format, for example `234/2026`.
 - `model_knowledge_cutoff_date`: cached fallback date used when `last_law_update_date` is not available yet.
 - `model_knowledge_cutoff_source`: source of that fallback date, currently the cached `MODEL_KNOWLEDGE_CUTOFF_DATE` value.
 - `law_reference_links`: recent official law links available in the system knowledge store.
@@ -178,6 +180,8 @@ Example:
   "core_version": "0.1.0",
   "last_law_update_date": "2026-03-20T00:00:00Z",
   "last_law_update_source": "law_documents_global",
+  "last_collector_run_at": "2026-03-30T12:30:00Z",
+  "last_processed_law": "234/2026",
   "model_knowledge_cutoff_date": "2020-12-31",
   "model_knowledge_cutoff_source": "model_knowledge_cutoff_cache",
   "law_reference_links": [

--- a/api/aijuristiction-api/app/chat/result_metadata.py
+++ b/api/aijuristiction-api/app/chat/result_metadata.py
@@ -89,6 +89,8 @@ class LawKnowledgeSnapshot:
     last_law_update_source: str
     model_knowledge_cutoff_date: str | None
     model_knowledge_cutoff_source: str
+    last_collector_run_at: str | None = None
+    last_processed_law: str | None = None
     reference_links: tuple[str, ...] = ()
 
 
@@ -154,6 +156,8 @@ def build_session_result_metadata(
             ),
             "last_law_update_date": knowledge_snapshot.last_law_update_date,
             "last_law_update_source": knowledge_snapshot.last_law_update_source,
+            "last_collector_run_at": knowledge_snapshot.last_collector_run_at,
+            "last_processed_law": knowledge_snapshot.last_processed_law,
             "model_knowledge_cutoff_date": knowledge_snapshot.model_knowledge_cutoff_date,
             "model_knowledge_cutoff_source": knowledge_snapshot.model_knowledge_cutoff_source,
             "law_reference_links": list(knowledge_snapshot.reference_links),
@@ -245,9 +249,15 @@ def get_law_knowledge_snapshot(country_code: str | None) -> LawKnowledgeSnapshot
                     ).fetchone()
                 else:
                     row = conn.execute(_law_snapshot_sqlite_query(filtered=False)).fetchone()
+                progress_row = _collector_progress_sqlite_row(conn=conn, country_code=normalized_country)
         except sqlite3.Error:
             return _law_snapshot_without_db(model_cutoff=model_cutoff)
-        snapshot = _law_snapshot_from_row(row, scope=scope, model_cutoff=model_cutoff)
+        snapshot = _law_snapshot_from_row(
+            row,
+            scope=scope,
+            model_cutoff=model_cutoff,
+            progress_row=progress_row,
+        )
         if snapshot.last_law_update_date is not None:
             return snapshot
         return _law_snapshot_without_db(model_cutoff=model_cutoff)
@@ -264,9 +274,15 @@ def get_law_knowledge_snapshot(country_code: str | None) -> LawKnowledgeSnapshot
                     ).fetchone()
                 else:
                     row = conn.execute(_law_snapshot_postgres_query(filtered=False)).fetchone()
+                progress_row = _collector_progress_postgres_row(conn=conn, country_code=normalized_country)
         except Exception:
             return _law_snapshot_without_db(model_cutoff=model_cutoff)
-        snapshot = _law_snapshot_from_row(row, scope=scope, model_cutoff=model_cutoff)
+        snapshot = _law_snapshot_from_row(
+            row,
+            scope=scope,
+            model_cutoff=model_cutoff,
+            progress_row=progress_row,
+        )
         if snapshot.last_law_update_date is not None:
             return snapshot
         return _law_snapshot_without_db(model_cutoff=model_cutoff)
@@ -311,10 +327,14 @@ def _law_snapshot_from_row(
     *,
     scope: str,
     model_cutoff: tuple[str | None, str],
+    progress_row: Sequence[Any] | None,
 ) -> LawKnowledgeSnapshot:
+    collector_run_at, last_processed_law = _collector_progress_values(progress_row)
     if row is None:
         return _law_snapshot_without_db(
             model_cutoff=model_cutoff,
+            last_collector_run_at=collector_run_at,
+            last_processed_law=last_processed_law,
             reference_links=(),
         )
     latest_update = row[0]
@@ -323,6 +343,8 @@ def _law_snapshot_from_row(
     if latest_update is None:
         return _law_snapshot_without_db(
             model_cutoff=model_cutoff,
+            last_collector_run_at=collector_run_at,
+            last_processed_law=last_processed_law,
             reference_links=links,
         )
     return LawKnowledgeSnapshot(
@@ -330,6 +352,8 @@ def _law_snapshot_from_row(
         last_law_update_source=f"law_documents_{scope}",
         model_knowledge_cutoff_date=model_cutoff[0],
         model_knowledge_cutoff_source=model_cutoff[1],
+        last_collector_run_at=collector_run_at,
+        last_processed_law=last_processed_law,
         reference_links=links,
     )
 
@@ -349,6 +373,8 @@ def _parse_reference_links(raw_links: Any) -> tuple[str, ...]:
 def _law_snapshot_without_db(
     *,
     model_cutoff: tuple[str | None, str],
+    last_collector_run_at: str | None = None,
+    last_processed_law: str | None = None,
     reference_links: tuple[str, ...] = (),
 ) -> LawKnowledgeSnapshot:
     return LawKnowledgeSnapshot(
@@ -356,6 +382,8 @@ def _law_snapshot_without_db(
         last_law_update_source="unavailable",
         model_knowledge_cutoff_date=model_cutoff[0],
         model_knowledge_cutoff_source=model_cutoff[1],
+        last_collector_run_at=last_collector_run_at,
+        last_processed_law=last_processed_law,
         reference_links=reference_links,
     )
 
@@ -424,3 +452,74 @@ def _resolve_repo_path(value: str) -> Path:
     if candidate.is_absolute():
         return candidate
     return _REPO_ROOT / candidate
+
+
+def _collector_progress_sqlite_row(
+    *,
+    conn: sqlite3.Connection,
+    country_code: str,
+) -> Sequence[Any] | None:
+    exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'collector_progress'"
+    ).fetchone()
+    if exists is None:
+        return None
+    if country_code:
+        return conn.execute(
+            """
+            SELECT last_collector_run_at, last_processed_law_year, last_processed_law_number
+            FROM collector_progress
+            WHERE UPPER(country_code) = ?
+            ORDER BY updated_at DESC
+            LIMIT 1
+            """,
+            (country_code,),
+        ).fetchone()
+    return conn.execute(
+        """
+        SELECT last_collector_run_at, last_processed_law_year, last_processed_law_number
+        FROM collector_progress
+        ORDER BY updated_at DESC
+        LIMIT 1
+        """
+    ).fetchone()
+
+
+def _collector_progress_postgres_row(
+    *,
+    conn: Any,
+    country_code: str,
+) -> Sequence[Any] | None:
+    relation = conn.execute("SELECT to_regclass(%s)", ("public.collector_progress",)).fetchone()
+    if not relation or relation[0] is None:
+        return None
+    if country_code:
+        return conn.execute(
+            """
+            SELECT last_collector_run_at, last_processed_law_year, last_processed_law_number
+            FROM collector_progress
+            WHERE UPPER(country_code) = %s
+            ORDER BY updated_at DESC
+            LIMIT 1
+            """,
+            (country_code,),
+        ).fetchone()
+    return conn.execute(
+        """
+        SELECT last_collector_run_at, last_processed_law_year, last_processed_law_number
+        FROM collector_progress
+        ORDER BY updated_at DESC
+        LIMIT 1
+        """
+    ).fetchone()
+
+
+def _collector_progress_values(progress_row: Sequence[Any] | None) -> tuple[str | None, str | None]:
+    if progress_row is None:
+        return None, None
+    last_collector_run_at = str(progress_row[0]) if progress_row[0] is not None else None
+    year = progress_row[1] if len(progress_row) > 1 else None
+    number = progress_row[2] if len(progress_row) > 2 else None
+    if year is None or number is None:
+        return last_collector_run_at, None
+    return last_collector_run_at, f"{int(number)}/{int(year)}"

--- a/api/aijuristiction-api/app/main.py
+++ b/api/aijuristiction-api/app/main.py
@@ -110,7 +110,8 @@ async def startup_log() -> None:
     logger.info(
         (
             "API Starting | api_version=%s | core_version=%s | log_level=%s "
-            "| llm_provider=%s | db_option=%s | document_processor=%s | last_law_update_date=%s | law_source=%s"
+            "| llm_provider=%s | db_option=%s | document_processor=%s | last_law_update_date=%s "
+            "| law_source=%s | last_collector_run_at=%s | last_processed_law=%s"
         ),
         app.version,
         get_core_version(),
@@ -120,6 +121,8 @@ async def startup_log() -> None:
         DOCUMENT_PROCESSOR_MODE,
         law_snapshot.last_law_update_date,
         law_snapshot.last_law_update_source,
+        law_snapshot.last_collector_run_at,
+        law_snapshot.last_processed_law,
     )
 
 
@@ -218,6 +221,8 @@ def version() -> JSONResponse:
             "core_version": get_core_version(),
             "last_law_update_date": law_snapshot.last_law_update_date,
             "last_law_update_source": law_snapshot.last_law_update_source,
+            "last_collector_run_at": law_snapshot.last_collector_run_at,
+            "last_processed_law": law_snapshot.last_processed_law,
             "model_knowledge_cutoff_date": law_snapshot.model_knowledge_cutoff_date,
             "model_knowledge_cutoff_source": law_snapshot.model_knowledge_cutoff_source,
             "law_reference_links": list(law_snapshot.reference_links),

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260324"
+version = "1.0.260325"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -761,6 +761,17 @@ def test_direct_reply_result_uses_latest_law_store_timestamp(monkeypatch, tmp_pa
         )
         conn.execute(
             """
+            CREATE TABLE collector_progress (
+                country_code TEXT PRIMARY KEY,
+                last_collector_run_at TEXT,
+                last_processed_law_year INTEGER,
+                last_processed_law_number INTEGER,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
             INSERT INTO law_documents(document_id, country_code, last_stored_at, source_url)
             VALUES ('doc-1', 'SK', '2026-02-10T12:30:00Z', 'https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/2026/2/')
             """
@@ -769,6 +780,14 @@ def test_direct_reply_result_uses_latest_law_store_timestamp(monkeypatch, tmp_pa
             """
             INSERT INTO law_documents(document_id, country_code, last_stored_at, source_url)
             VALUES ('doc-2', 'SK', '2026-03-11T08:15:00Z', 'https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/2026/11/')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO collector_progress(
+                country_code, last_collector_run_at, last_processed_law_year, last_processed_law_number, updated_at
+            )
+            VALUES ('SK', '2026-03-30T14:00:00Z', 2026, 234, '2026-03-30T14:00:00Z')
             """
         )
         conn.commit()
@@ -803,6 +822,8 @@ def test_direct_reply_result_uses_latest_law_store_timestamp(monkeypatch, tmp_pa
     assert result.metadata["knowledge_last_updated_at"] == "2026-03-11T08:15:00Z"
     assert result.metadata["last_law_update_date"] == "2026-03-11T08:15:00Z"
     assert result.metadata["last_law_update_source"] == "law_documents_country"
+    assert result.metadata["last_collector_run_at"] == "2026-03-30T14:00:00Z"
+    assert result.metadata["last_processed_law"] == "234/2026"
     assert result.metadata["model_knowledge_cutoff_date"] == "2020-12-31"
     assert result.metadata["model_knowledge_cutoff_source"] == "model_knowledge_cutoff_cache"
     assert result.metadata["law_reference_links"] == [
@@ -827,6 +848,8 @@ def test_law_snapshot_falls_back_to_model_cutoff_and_writes_cache(monkeypatch, t
 
     assert snapshot.last_law_update_date is None
     assert snapshot.last_law_update_source == "unavailable"
+    assert snapshot.last_collector_run_at is None
+    assert snapshot.last_processed_law is None
     assert snapshot.model_knowledge_cutoff_date == "2024-12-31"
     assert snapshot.model_knowledge_cutoff_source == "model_knowledge_cutoff_cache"
     assert snapshot.reference_links == ()
@@ -854,6 +877,8 @@ def test_law_snapshot_reuses_cached_model_cutoff_without_expiration(monkeypatch,
     second_snapshot = get_law_knowledge_snapshot("SK")
 
     assert second_snapshot.last_law_update_date is None
+    assert second_snapshot.last_collector_run_at is None
+    assert second_snapshot.last_processed_law is None
     assert second_snapshot.model_knowledge_cutoff_date == "2024-12-31"
     assert second_snapshot.model_knowledge_cutoff_source == "model_knowledge_cutoff_cache"
 

--- a/api/aijuristiction-api/tests/test_health.py
+++ b/api/aijuristiction-api/tests/test_health.py
@@ -57,6 +57,8 @@ def test_version_endpoint(monkeypatch) -> None:
         lambda _country: SimpleNamespace(
             last_law_update_date="2026-03-20T00:00:00Z",
             last_law_update_source="law_documents_global",
+            last_collector_run_at="2026-03-30T12:30:00Z",
+            last_processed_law="234/2026",
             model_knowledge_cutoff_date="2020-12-31",
             model_knowledge_cutoff_source="model_knowledge_cutoff_cache",
             reference_links=(
@@ -73,6 +75,8 @@ def test_version_endpoint(monkeypatch) -> None:
     assert isinstance(payload["core_version"], str)
     assert payload["last_law_update_date"] == "2026-03-20T00:00:00Z"
     assert payload["last_law_update_source"] == "law_documents_global"
+    assert payload["last_collector_run_at"] == "2026-03-30T12:30:00Z"
+    assert payload["last_processed_law"] == "234/2026"
     assert payload["model_knowledge_cutoff_date"] == "2020-12-31"
     assert payload["model_knowledge_cutoff_source"] == "model_knowledge_cutoff_cache"
     assert payload["law_reference_links"] == [

--- a/databases/migrations/laws/0002_add_collector_progress.sql
+++ b/databases/migrations/laws/0002_add_collector_progress.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS collector_progress (
+    country_code TEXT PRIMARY KEY,
+    source_system TEXT NOT NULL,
+    last_collector_run_at TIMESTAMPTZ,
+    last_processed_at TIMESTAMPTZ,
+    last_processed_law_year INTEGER,
+    last_processed_law_number INTEGER,
+    next_probe_law_year INTEGER NOT NULL,
+    next_probe_law_number INTEGER NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);

--- a/docs/LAWS_COLLECTOR.md
+++ b/docs/LAWS_COLLECTOR.md
@@ -202,6 +202,33 @@ python -m services.laws_collector --fixture baseline
 python -m services.laws_collector --fixture delta
 ```
 
+## Sequential Slov-Lex process
+
+The Slovak collector now keeps a persisted sequential crawl state in `collector_progress`.
+
+Rules:
+
+- the starting year is fixed to `1993`
+- the first target is `1/1993`
+- within a year the next probe is `number + 1`
+- when a missing law is hit in a past year, the collector jumps to `1/<next year>`
+- when a missing law is hit in the current year, the run stops and keeps that missing law as the next probe target
+- the database stores the latest collector run timestamp and the last successfully processed law like `234/2026`
+
+Inspect the persisted state:
+
+```powershell
+conda activate .\.conda
+python -m services.laws_collector --plan-import
+```
+
+Run a live sequential Slov-Lex probe loop:
+
+```powershell
+conda activate .\.conda
+python -m services.laws_collector --run-sequential-import --max-probes 25
+```
+
 
 ## Live SlovLex probe test (year/number)
 
@@ -229,10 +256,10 @@ Add these to `.env` when you start wiring the service into real runs:
 - `LAWS_DB_LOCAL=./databases/laws-collector/sk_laws.sqlite3`
 - `LAWS_STORAGE_LOCAL=./storage/laws/sk`
 - `LAWS_DELTA_POLL_HOURS=3`
-- `LAWS_INITIAL_IMPORT_FROM=2025-01-01`
-- `LAWS_HISTORICAL_IMPORT_FROM=1946-01-01`
 
 `LAWS_COUNTRY` selects the country-specific collector implementation. The current implementation supports only `SK`, so the service still defaults to `SK` when the variable is unset.
+
+For Slovakia, the sequential Slov-Lex crawl always starts from `1/1993`. That starting point is no longer environment-configurable.
 
 For PostgreSQL naming, keep the database mapping country-specific:
 
@@ -302,6 +329,13 @@ Start the local worker loop with the new project skill:
 
 This runs the collector worker (`services.laws_collector.worker`) with local SQLite defaults and is useful for repeatable smoke tests.
 
+For live Slov-Lex sequential probing, set:
+
+```powershell
+$env:LAWS_WORKER_FIXTURE = "live"
+./skills/laws-collector/scripts/start_laws_collector.ps1 -Fixture live -MaxCycles 1
+```
+
 ## Azure Container App deployment (laws-collector)
 
 Deployment assets for a dedicated Azure Container App named `laws-collector` are now included:
@@ -315,22 +349,28 @@ Deployment assets for a dedicated Azure Container App named `laws-collector` are
 The deploy script builds the image in ACR and deploys it to Azure Container Apps with PostgreSQL env configuration.
 
 
-## SlovLex import order for Slovakia
+## Local PostgreSQL debugging
 
-The collector now plans Slovakia imports in two explicit windows:
+Start the shared local PostgreSQL Docker container:
 
-1. `2025-01-01` through the current day.
-2. `1946-01-01` through `2024-12-31`, but only after the first window is complete.
-
-The country-specific database naming stays aligned with the existing provisioning flow:
-
-- SQLite default: `./databases/laws-collector/sk_laws.sqlite3`
-- PostgreSQL database name: `laws_sk`
-
-Preview the planned windows with:
-
-```bash
-PYTHONPATH=src python -m services.laws_collector --plan-import
-PYTHONPATH=src python -m services.laws_collector --plan-import --initial-window-complete
+```powershell
+./skills/start-postgress/scripts/start_postgress.ps1 -SkipSchemaUpdate
 ```
-The shared `infra_deploy` workflow now also provisions the `laws_sk` PostgreSQL database and a placeholder private Container App for `laws-collector`, which the dedicated laws collector workflow later updates with the real image.
+
+This requires the local Docker daemon to be running.
+
+Provision the dedicated laws schema locally:
+
+```powershell
+.\.conda\python.exe databases/scripts/provision_country_laws_db.py --admin-uri postgresql://postgres:postgres@127.0.0.1:5432/postgres --country SK
+$env:DB_OPTION = "postgres"
+$env:DB_CLOUD = "postgresql://postgres:postgres@127.0.0.1:5432/laws_sk"
+.\.conda\python.exe databases/scripts/apply_db_migrations.py --project laws
+```
+
+Then run the PostgreSQL debug example:
+
+```powershell
+$env:LAWS_DB_CLOUD = "postgresql://postgres:postgres@127.0.0.1:5432/laws_sk"
+.\.conda\python.exe examples/laws_collector_postgres_debug_demo.py
+```

--- a/examples/laws_collector_minimal_demo.py
+++ b/examples/laws_collector_minimal_demo.py
@@ -4,9 +4,12 @@ from datetime import date
 from pathlib import Path
 import tempfile
 
-from services.laws_collector import LawsCollectorConfig, SlovLexImportPlanner, SlovakLawsCollectorService, SqliteLawStore
-from services.laws_collector.source_fixtures import baseline_snapshots, delta_snapshots
-from services.laws_collector import  get_country_laws_collector_definition
+from services.laws_collector import (
+    LawsCollectorConfig,
+    SlovLexImportPlanner,
+    SqliteLawStore,
+    get_country_laws_collector_definition,
+)
 
 
 def main() -> None:
@@ -20,37 +23,45 @@ def main() -> None:
             storage_local="",
             storage_cloud="",
             delta_poll_hours=3,
-            initial_import_from=date(2025, 1, 1),
-            historical_import_from=date(1946, 1, 1),
+            initial_import_from=date(1993, 1, 1),
+            historical_import_from=date(1993, 1, 1),
         )
         collector_definition = get_country_laws_collector_definition(config.country_code)
         store = SqliteLawStore.from_config(config)
         store.initialize()
-        service = SlovakLawsCollectorService(config=config, store=store)
+        service = collector_definition.create_service(config=config, store=store)
         planner = SlovLexImportPlanner(config=config)
 
-        baseline_snapshots = collector_definition.baseline_snapshots()
-        delta_snapshots = collector_definition.delta_snapshots()
-        baseline = service.sync(baseline_snapshots)
-        delta = service.sync(delta_snapshots)
-        plan = service.plan_updates(known_snapshots=baseline_snapshots, latest_snapshots=delta_snapshots)
+        baseline = collector_definition.baseline_snapshots()
+        delta = collector_definition.delta_snapshots()
+        baseline_summary = service.sync(baseline)
+        delta_summary = service.sync(delta)
+        update_plan = service.plan_updates(known_snapshots=baseline, latest_snapshots=delta)
+        progress = store.get_or_create_collector_progress(
+            country_code=config.country_code,
+            source_system="slov-lex",
+            initial_year=planner.initial_year,
+        )
+        import_plan = planner.build_plan(progress=progress, today=date(2026, 3, 30))
         counts = store.get_counts()
         overview = store.list_document_overview()
 
-        print("Country DB name:", config.country_db_name)
-        print("Import plan:", planner.build_plan(initial_window_complete=False))
         print("Collector:", collector_definition.collector_name)
         print("Country:", config.country_code)
         print("Cloud DB name:", collector_definition.cloud_database_name)
-        print("Baseline sync:", baseline)
-        print("Delta sync:", delta)
-        print("Planned updates:", plan.items_with_updates)
+        print("Baseline sync:", baseline_summary)
+        print("Delta sync:", delta_summary)
+        print("Planned updates:", update_plan.items_with_updates)
+        print("Import initial year:", import_plan.initial_year)
+        print("Next law to check:", import_plan.next_target.law_id)
+        print("Next law URL:", import_plan.next_target.url)
+        print("Last processed law:", import_plan.last_processed_law or "")
+        print("Last collector run:", import_plan.last_collector_run_at or "")
         print("Documents in DB:", counts.documents)
         print("Versions in DB:", counts.versions)
         print("Provisions in DB:", counts.provisions)
         print("Update events in DB:", counts.update_events)
         print("First document:", overview[0])
-        print("Amendment sample parent law:", (overview[2].law_year, overview[2].law_number), "->", (overview[2].parent_law_year, overview[2].parent_law_number))
         print("SQLite path:", store.db_path)
 
 

--- a/examples/laws_collector_postgres_debug_demo.py
+++ b/examples/laws_collector_postgres_debug_demo.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import date
+import os
+
+from services.laws_collector import LawsCollectorConfig, PostgresLawStore, SlovLexImportPlanner
+from aijurisdictionagents.db_migrations import apply_sql_migrations
+
+
+def main() -> None:
+    db_cloud = os.getenv(
+        "LAWS_DB_CLOUD",
+        "postgresql://postgres:postgres@127.0.0.1:5432/laws_sk",
+    ).strip()
+    config = LawsCollectorConfig(
+        country_code="SK",
+        db_backend="postgres",
+        db_local="",
+        db_cloud=db_cloud,
+        storage_local="",
+        storage_cloud="",
+        delta_poll_hours=3,
+        initial_import_from=date(1993, 1, 1),
+        historical_import_from=date(1993, 1, 1),
+    )
+    apply_sql_migrations(
+        project="laws",
+        db_option="postgres",
+        target=db_cloud,
+        dry_run=False,
+    )
+    store = PostgresLawStore.from_config(config)
+    planner = SlovLexImportPlanner(config=config)
+    progress = store.get_or_create_collector_progress(
+        country_code=config.country_code,
+        source_system="slov-lex",
+        initial_year=planner.initial_year,
+    )
+    plan = planner.build_plan(progress=progress)
+
+    print("Backend:", config.db_backend)
+    print("Database:", config.country_db_name)
+    print("Connection:", config.db_cloud)
+    print("Initial year:", plan.initial_year)
+    print("Last collector run:", plan.last_collector_run_at or "")
+    print("Last processed law:", plan.last_processed_law or "")
+    print("Next law to check:", plan.next_target.law_id)
+    print("Next law URL:", plan.next_target.url)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aijurisdictionagents"
-version = "1.0.260325"
+version = "1.0.260329"
 description = "Multi-agent legal discussion scaffold."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260328"
+__version__ = "1.0.260329"

--- a/src/services/laws_collector/__init__.py
+++ b/src/services/laws_collector/__init__.py
@@ -2,15 +2,17 @@
 
 from .country_registry import CountryLawsCollectorDefinition, get_country_laws_collector_definition
 from .config import LawsCollectorConfig
-from .domain import SyncSummary, UpdateCheckPlan
-from .import_planner import ImportPlan, ImportWindow, SlovLexImportPlanner
+from .domain import CollectorProgress, LawSnapshot, SyncSummary, UpdateCheckPlan
+from .import_planner import ImportPlan, ImportTarget, SlovLexImportPlanner
 from .postgres_store import PostgresLawStore
 from .service import LawsCollectorService
 from .slovak_laws_collector import SlovakLawsCollectorService
+from .slovlex_process import SequentialImportSummary, SlovLexProbeResult, SlovLexSequentialImportRunner
 from .sqlite_store import SqliteLawStore
 
 __all__ = [
     "CountryLawsCollectorDefinition",
+    "CollectorProgress",
     "LawsCollectorConfig",
     "LawSnapshot",
     "LawsCollectorService",
@@ -20,7 +22,10 @@ __all__ = [
     "SyncSummary",
     "UpdateCheckPlan",
     "ImportPlan",
-    "ImportWindow",
+    "ImportTarget",
     "SlovLexImportPlanner",
+    "SequentialImportSummary",
+    "SlovLexProbeResult",
+    "SlovLexSequentialImportRunner",
     "get_country_laws_collector_definition",
 ]

--- a/src/services/laws_collector/cli.py
+++ b/src/services/laws_collector/cli.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import argparse
-from datetime import date
 
 from .country_registry import get_country_laws_collector_definition
 from .config import LawsCollectorConfig
 from .import_planner import SlovLexImportPlanner
 from .postgres_store import PostgresLawStore
+from .slovlex_process import SlovLexSequentialImportRunner
 from .sqlite_store import SqliteLawStore
 
 
@@ -26,12 +26,24 @@ def main() -> None:
     parser.add_argument(
         "--plan-import",
         action="store_true",
-        help="Print the SlovLex import window plan for the configured country.",
+        help="Print the persisted SlovLex sequential import plan for the configured country.",
     )
     parser.add_argument(
-        "--initial-window-complete",
+        "--run-sequential-import",
         action="store_true",
-        help="Mark the 2025-to-today window as completed when printing the import plan.",
+        help="Probe SlovLex sequentially by law number/year and persist collector progress.",
+    )
+    parser.add_argument(
+        "--max-probes",
+        type=int,
+        default=25,
+        help="Maximum SlovLex sequential probes to execute in one run.",
+    )
+    parser.add_argument(
+        "--probe-timeout-seconds",
+        type=float,
+        default=12.0,
+        help="Timeout for each SlovLex HTTP probe.",
     )
     args = parser.parse_args()
 
@@ -46,14 +58,41 @@ def main() -> None:
 
     if args.plan_import:
         planner = SlovLexImportPlanner(config=config)
-        plan = planner.build_plan(today=date.today(), initial_window_complete=args.initial_window_complete)
+        progress = store.get_or_create_collector_progress(
+            country_code=config.country_code,
+            source_system="slov-lex",
+            initial_year=planner.initial_year,
+        )
+        plan = planner.build_plan(progress=progress)
         print("country:", config.country_code)
         print("database_name:", config.country_db_name)
-        for index, window in enumerate(plan.windows, start=1):
-            print(f"window_{index}_stage:", window.stage)
-            print(f"window_{index}_start:", window.start_date.isoformat())
-            print(f"window_{index}_end:", window.end_date.isoformat())
-            print(f"window_{index}_blocked_by:", window.blocked_by or "")
+        print("initial_year:", plan.initial_year)
+        print("current_year:", plan.current_year)
+        print("last_collector_run_at:", plan.last_collector_run_at or "")
+        print("last_processed_at:", plan.last_processed_at or "")
+        print("last_processed_law:", plan.last_processed_law or "")
+        print("next_law_to_check:", plan.next_target.law_id)
+        print("next_law_url:", plan.next_target.url)
+        print("stop_when_missing_current_year:", str(plan.stop_when_missing_current_year).lower())
+        return
+
+    if args.run_sequential_import:
+        runner = SlovLexSequentialImportRunner(config=config, store=store)
+        summary = runner.run(
+            max_probes=args.max_probes,
+            timeout_seconds=args.probe_timeout_seconds,
+        )
+        print("country:", config.country_code)
+        print("database_name:", config.country_db_name)
+        print("probes:", summary.probes)
+        print("laws_found:", summary.laws_found)
+        print("years_advanced:", summary.years_advanced)
+        print("stopped_on_current_year_gap:", str(summary.stopped_on_current_year_gap).lower())
+        print("last_checked_law:", summary.last_checked_law or "")
+        print("last_processed_law:", summary.last_processed_law or "")
+        print("next_law_to_check:", summary.next_law_to_check)
+        print("last_collector_run_at:", summary.last_collector_run_at or "")
+        print("first_found_url:", summary.first_found_url or "")
         return
 
     if args.check_updates:

--- a/src/services/laws_collector/config.py
+++ b/src/services/laws_collector/config.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
+_SLOVAK_INITIAL_IMPORT_DATE = date(1993, 1, 1)
 
 
 @dataclass(frozen=True)
@@ -23,37 +24,24 @@ class LawsCollectorConfig:
     @classmethod
     def from_env(cls) -> "LawsCollectorConfig":
         country_code = os.getenv("LAWS_COUNTRY", "SK").strip().upper()
-        default_sqlite_path = f"./databases/laws-collector/{country_code.lower()}_laws.sqlite3"
-        
-        return cls(
-            country_code=country_code,
-            db_backend=os.getenv("LAWS_DB_BACKEND", "sqlite").strip().lower(),
-            db_local=os.getenv("LAWS_DB_LOCAL", default_sqlite_path).strip(),
-            db_cloud=os.getenv("LAWS_DB_CLOUD", "").strip(),
-            storage_local=os.getenv("LAWS_STORAGE_LOCAL", f"./storage/laws/{country_code.lower()}").strip(),
-            db_local = os.getenv("LAWS_DB_LOCAL", "").strip()
-            storage_local = os.getenv("LAWS_STORAGE_LOCAL", "").strip()
-            if not db_local:
-                db_local = cls.default_local_db_path_for(country_code)
-            if not storage_local:
-                storage_local = cls.default_local_storage_path_for(country_code)
+        db_local = os.getenv("LAWS_DB_LOCAL", "").strip()
+        storage_local = os.getenv("LAWS_STORAGE_LOCAL", "").strip()
+
+        if not db_local:
+            db_local = cls.default_local_db_path_for(country_code)
+        if not storage_local:
+            storage_local = cls.default_local_storage_path_for(country_code)
 
         return cls(
             country_code=country_code,
             db_backend=os.getenv("LAWS_DB_BACKEND", "sqlite").strip().lower(),
-            db_local=os.getenv("LAWS_DB_LOCAL", default_sqlite_path).strip(),
+            db_local=db_local,
             db_cloud=os.getenv("LAWS_DB_CLOUD", "").strip(),
-            storage_local=os.getenv("LAWS_STORAGE_LOCAL", f"./storage/laws/{country_code.lower()}").strip(),
-            db_local = os.getenv("LAWS_DB_LOCAL", "").strip()
-            storage_local = os.getenv("LAWS_STORAGE_LOCAL", "").strip()
-            if not db_local:
-                db_local = cls.default_local_db_path_for(country_code)
-            if not storage_local:
-                storage_local = cls.default_local_storage_path_for(country_code),
+            storage_local=storage_local,
             storage_cloud=os.getenv("LAWS_STORAGE_CLOUD", "").strip(),
             delta_poll_hours=int(os.getenv("LAWS_DELTA_POLL_HOURS", "3")),
-            initial_import_from=_parse_iso_date(os.getenv("LAWS_INITIAL_IMPORT_FROM", "2025-01-01")),
-            historical_import_from=_parse_iso_date(os.getenv("LAWS_HISTORICAL_IMPORT_FROM", "1946-01-01")),
+            initial_import_from=_SLOVAK_INITIAL_IMPORT_DATE,
+            historical_import_from=_SLOVAK_INITIAL_IMPORT_DATE,
         )
 
     @staticmethod
@@ -77,8 +65,11 @@ class LawsCollectorConfig:
             raise ValueError("LAWS_DB_CLOUD must be set for postgres backend")
         if self.delta_poll_hours < 1:
             raise ValueError("LAWS_DELTA_POLL_HOURS must be >= 1")
-        if self.historical_import_from > self.initial_import_from:
-            raise ValueError("LAWS_HISTORICAL_IMPORT_FROM must be on or before LAWS_INITIAL_IMPORT_FROM")
+        if self.country_code == "SK":
+            if self.initial_import_from != _SLOVAK_INITIAL_IMPORT_DATE:
+                raise ValueError("Slovak laws collector initial import date is fixed at 1993-01-01")
+            if self.historical_import_from != _SLOVAK_INITIAL_IMPORT_DATE:
+                raise ValueError("Slovak laws collector historical import date is fixed at 1993-01-01")
 
     @property
     def db_path(self) -> Path:
@@ -93,17 +84,8 @@ class LawsCollectorConfig:
         return f"laws_{self.country_code.lower()}"
 
 
-
 def _resolve_repo_path(value: str) -> Path:
     candidate = Path(value)
     if candidate.is_absolute():
         return candidate
     return _REPO_ROOT / candidate
-
-
-
-def _parse_iso_date(value: str) -> date:
-    try:
-        return date.fromisoformat(value.strip())
-    except ValueError as exc:
-        raise ValueError(f"Invalid ISO date: {value}") from exc

--- a/src/services/laws_collector/domain.py
+++ b/src/services/laws_collector/domain.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from hashlib import sha256
 import json
 
@@ -101,6 +101,37 @@ class SyncSummary:
 
 
 @dataclass(frozen=True)
+class CollectorProgress:
+    country_code: str
+    source_system: str
+    last_collector_run_at: str | None
+    last_processed_at: str | None
+    last_processed_law_year: int | None
+    last_processed_law_number: int | None
+    next_probe_law_year: int
+    next_probe_law_number: int
+
+    @property
+    def last_processed_law(self) -> str | None:
+        if self.last_processed_law_year is None or self.last_processed_law_number is None:
+            return None
+        return format_law_identifier(
+            year=self.last_processed_law_year,
+            number=self.last_processed_law_number,
+        )
+
+    @property
+    def next_probe_law(self) -> str:
+        return format_law_identifier(
+            year=self.next_probe_law_year,
+            number=self.next_probe_law_number,
+        )
+
+    def evolve(self, **changes: object) -> "CollectorProgress":
+        return replace(self, **changes)
+
+
+@dataclass(frozen=True)
 class UpdateCheckItem:
     document_key: str
     country_code: str
@@ -117,3 +148,7 @@ class UpdateCheckPlan:
     checked_items: int
     items_with_updates: int
     items: tuple[UpdateCheckItem, ...]
+
+
+def format_law_identifier(*, year: int, number: int) -> str:
+    return f"{number}/{year}"

--- a/src/services/laws_collector/import_planner.py
+++ b/src/services/laws_collector/import_planner.py
@@ -1,50 +1,123 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date, timedelta
+from datetime import date
 
 from .config import LawsCollectorConfig
+from .domain import CollectorProgress
+
+SLOVAK_INITIAL_IMPORT_YEAR = 1993
 
 
 @dataclass(frozen=True)
-class ImportWindow:
-    stage: str
-    start_date: date
-    end_date: date
-    blocked_by: str | None = None
+class ImportTarget:
+    year: int
+    number: int
+
+    @property
+    def law_id(self) -> str:
+        return f"{self.number}/{self.year}"
+
+    @property
+    def url(self) -> str:
+        return f"https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/{self.year}/{self.number}/"
 
 
 @dataclass(frozen=True)
 class ImportPlan:
-    windows: tuple[ImportWindow, ...]
-
-    @property
-    def active_window(self) -> ImportWindow | None:
-        for window in self.windows:
-            if window.blocked_by is None:
-                return window
-        return None
+    current_year: int
+    initial_year: int
+    last_collector_run_at: str | None
+    last_processed_at: str | None
+    last_processed_law: str | None
+    next_target: ImportTarget
+    stop_when_missing_current_year: bool
 
 
 class SlovLexImportPlanner:
-    """Plans SlovLex import windows for Slovakia backfills."""
+    """Plans sequential Slov-Lex probing by law number/year for Slovakia."""
 
     def __init__(self, *, config: LawsCollectorConfig) -> None:
         self.config = config
 
-    def build_plan(self, *, today: date | None = None, initial_window_complete: bool = False) -> ImportPlan:
-        current_day = today or date.today()
-        initial_window = ImportWindow(
-            stage="initial_2025_to_today",
-            start_date=self.config.initial_import_from,
-            end_date=current_day,
+    @property
+    def initial_year(self) -> int:
+        return SLOVAK_INITIAL_IMPORT_YEAR
+
+    def initial_progress(self) -> CollectorProgress:
+        return CollectorProgress(
+            country_code=self.config.country_code,
+            source_system="slov-lex",
+            last_collector_run_at=None,
+            last_processed_at=None,
+            last_processed_law_year=None,
+            last_processed_law_number=None,
+            next_probe_law_year=self.initial_year,
+            next_probe_law_number=1,
         )
 
-        historical_end = self.config.initial_import_from - timedelta(days=1)
-        historical_window = ImportWindow(
-            stage="historical_1946_to_2024",
-            start_date=self.config.historical_import_from,
-            end_date=historical_end,
-            blocked_by=None if initial_window_complete else initial_window.stage,
+    def build_plan(
+        self,
+        *,
+        progress: CollectorProgress | None = None,
+        today: date | None = None,
+    ) -> ImportPlan:
+        current_day = today or date.today()
+        state = progress or self.initial_progress()
+        next_target = ImportTarget(
+            year=state.next_probe_law_year,
+            number=state.next_probe_law_number,
         )
-        return ImportPlan(windows=(initial_window, historical_window))
+        return ImportPlan(
+            current_year=current_day.year,
+            initial_year=self.initial_year,
+            last_collector_run_at=state.last_collector_run_at,
+            last_processed_at=state.last_processed_at,
+            last_processed_law=state.last_processed_law,
+            next_target=next_target,
+            stop_when_missing_current_year=next_target.year >= current_day.year,
+        )
+
+    def mark_processed(
+        self,
+        progress: CollectorProgress,
+        *,
+        target: ImportTarget,
+        processed_at: str,
+    ) -> CollectorProgress:
+        return progress.evolve(
+            last_collector_run_at=processed_at,
+            last_processed_at=processed_at,
+            last_processed_law_year=target.year,
+            last_processed_law_number=target.number,
+            next_probe_law_year=target.year,
+            next_probe_law_number=target.number + 1,
+        )
+
+    def mark_missing(
+        self,
+        progress: CollectorProgress,
+        *,
+        target: ImportTarget,
+        observed_at: str,
+        today: date | None = None,
+    ) -> tuple[CollectorProgress, bool]:
+        current_year = (today or date.today()).year
+        if target.year < current_year:
+            return (
+                progress.evolve(
+                    last_collector_run_at=observed_at,
+                    next_probe_law_year=target.year + 1,
+                    next_probe_law_number=1,
+                ),
+                False,
+            )
+
+        return (
+            progress.evolve(
+                last_collector_run_at=observed_at,
+                next_probe_law_year=target.year,
+                next_probe_law_number=target.number,
+            ),
+            True,
+        )

--- a/src/services/laws_collector/postgres_store.py
+++ b/src/services/laws_collector/postgres_store.py
@@ -9,7 +9,7 @@ import psycopg
 from psycopg.rows import dict_row
 
 from .config import LawsCollectorConfig
-from .domain import LawSnapshot, ProvisionRecord, StoredVersion
+from .domain import CollectorProgress, LawSnapshot, ProvisionRecord, StoredVersion
 
 
 @dataclass(frozen=True)
@@ -324,6 +324,88 @@ class PostgresLawStore:
             )
             conn.commit()
 
+    def get_or_create_collector_progress(
+        self,
+        *,
+        country_code: str,
+        source_system: str,
+        initial_year: int,
+    ) -> CollectorProgress:
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT country_code, source_system, last_collector_run_at, last_processed_at,
+                       last_processed_law_year, last_processed_law_number,
+                       next_probe_law_year, next_probe_law_number
+                FROM collector_progress
+                WHERE country_code = %(country_code)s
+                """,
+                {"country_code": country_code},
+            ).fetchone()
+            if row is not None:
+                return _collector_progress_from_row(row)
+
+            now = _now_iso()
+            conn.execute(
+                """
+                INSERT INTO collector_progress(
+                    country_code, source_system, last_collector_run_at, last_processed_at,
+                    last_processed_law_year, last_processed_law_number,
+                    next_probe_law_year, next_probe_law_number, created_at, updated_at
+                ) VALUES (
+                    %(country_code)s, %(source_system)s, NULL, NULL, NULL, NULL,
+                    %(next_probe_law_year)s, %(next_probe_law_number)s, %(now)s, %(now)s
+                )
+                """,
+                {
+                    "country_code": country_code,
+                    "source_system": source_system,
+                    "next_probe_law_year": initial_year,
+                    "next_probe_law_number": 1,
+                    "now": now,
+                },
+            )
+            conn.commit()
+            return CollectorProgress(
+                country_code=country_code,
+                source_system=source_system,
+                last_collector_run_at=None,
+                last_processed_at=None,
+                last_processed_law_year=None,
+                last_processed_law_number=None,
+                next_probe_law_year=initial_year,
+                next_probe_law_number=1,
+            )
+
+    def save_collector_progress(self, progress: CollectorProgress) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE collector_progress
+                SET source_system = %(source_system)s,
+                    last_collector_run_at = %(last_collector_run_at)s,
+                    last_processed_at = %(last_processed_at)s,
+                    last_processed_law_year = %(last_processed_law_year)s,
+                    last_processed_law_number = %(last_processed_law_number)s,
+                    next_probe_law_year = %(next_probe_law_year)s,
+                    next_probe_law_number = %(next_probe_law_number)s,
+                    updated_at = %(updated_at)s
+                WHERE country_code = %(country_code)s
+                """,
+                {
+                    "source_system": progress.source_system,
+                    "last_collector_run_at": progress.last_collector_run_at,
+                    "last_processed_at": progress.last_processed_at,
+                    "last_processed_law_year": progress.last_processed_law_year,
+                    "last_processed_law_number": progress.last_processed_law_number,
+                    "next_probe_law_year": progress.next_probe_law_year,
+                    "next_probe_law_number": progress.next_probe_law_number,
+                    "updated_at": _now_iso(),
+                    "country_code": progress.country_code,
+                },
+            )
+            conn.commit()
+
     def get_counts(self) -> CollectorCounts:
         with self._connect() as conn:
             return CollectorCounts(
@@ -344,3 +426,22 @@ def _count(conn: psycopg.Connection, table_name: str) -> int:
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _collector_progress_from_row(row: dict[str, object]) -> CollectorProgress:
+    return CollectorProgress(
+        country_code=str(row["country_code"]),
+        source_system=str(row["source_system"]),
+        last_collector_run_at=(str(row["last_collector_run_at"]) if row["last_collector_run_at"] else None),
+        last_processed_at=(str(row["last_processed_at"]) if row["last_processed_at"] else None),
+        last_processed_law_year=(
+            int(row["last_processed_law_year"]) if row["last_processed_law_year"] is not None else None
+        ),
+        last_processed_law_number=(
+            int(row["last_processed_law_number"])
+            if row["last_processed_law_number"] is not None
+            else None
+        ),
+        next_probe_law_year=int(row["next_probe_law_year"]),
+        next_probe_law_number=int(row["next_probe_law_number"]),
+    )

--- a/src/services/laws_collector/slovlex_process.py
+++ b/src/services/laws_collector/slovlex_process.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Protocol
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from .config import LawsCollectorConfig
+from .domain import CollectorProgress
+from .import_planner import ImportTarget, SlovLexImportPlanner
+
+
+class CollectorProgressStore(Protocol):
+    def get_or_create_collector_progress(
+        self,
+        *,
+        country_code: str,
+        source_system: str,
+        initial_year: int,
+    ) -> CollectorProgress: ...
+
+    def save_collector_progress(self, progress: CollectorProgress) -> None: ...
+
+
+@dataclass(frozen=True)
+class SlovLexProbeResult:
+    target: ImportTarget
+    exists: bool
+    status_code: int | None
+    url: str
+
+
+@dataclass(frozen=True)
+class SequentialImportSummary:
+    probes: int
+    laws_found: int
+    years_advanced: int
+    stopped_on_current_year_gap: bool
+    last_checked_law: str | None
+    last_processed_law: str | None
+    next_law_to_check: str
+    last_collector_run_at: str | None
+    first_found_url: str | None = None
+
+
+class SlovLexSequentialImportRunner:
+    def __init__(
+        self,
+        *,
+        config: LawsCollectorConfig,
+        store: CollectorProgressStore,
+        planner: SlovLexImportPlanner | None = None,
+    ) -> None:
+        self.config = config
+        self.store = store
+        self.planner = planner or SlovLexImportPlanner(config=config)
+
+    def get_progress(self) -> CollectorProgress:
+        return self.store.get_or_create_collector_progress(
+            country_code=self.config.country_code,
+            source_system="slov-lex",
+            initial_year=self.planner.initial_year,
+        )
+
+    def run(
+        self,
+        *,
+        max_probes: int = 25,
+        today: date | None = None,
+        timeout_seconds: float = 12.0,
+    ) -> SequentialImportSummary:
+        if max_probes < 1:
+            raise ValueError("max_probes must be >= 1")
+
+        current_day = today or date.today()
+        progress = self.get_progress()
+        probes = 0
+        laws_found = 0
+        years_advanced = 0
+        stopped_on_current_year_gap = False
+        last_checked_law: str | None = None
+        first_found_url: str | None = None
+
+        while probes < max_probes:
+            plan = self.planner.build_plan(progress=progress, today=current_day)
+            target = plan.next_target
+            probe = self._probe_target(target=target, timeout_seconds=timeout_seconds)
+            probes += 1
+            last_checked_law = target.law_id
+            observed_at = _now_iso()
+
+            if probe.exists:
+                progress = self.planner.mark_processed(
+                    progress,
+                    target=target,
+                    processed_at=observed_at,
+                )
+                self.store.save_collector_progress(progress)
+                laws_found += 1
+                if first_found_url is None:
+                    first_found_url = probe.url
+                continue
+
+            previous_year = progress.next_probe_law_year
+            progress, stopped_on_current_year_gap = self.planner.mark_missing(
+                progress,
+                target=target,
+                observed_at=observed_at,
+                today=current_day,
+            )
+            self.store.save_collector_progress(progress)
+            if progress.next_probe_law_year != previous_year:
+                years_advanced += 1
+            if stopped_on_current_year_gap:
+                break
+
+        final_plan = self.planner.build_plan(progress=progress, today=current_day)
+        return SequentialImportSummary(
+            probes=probes,
+            laws_found=laws_found,
+            years_advanced=years_advanced,
+            stopped_on_current_year_gap=stopped_on_current_year_gap,
+            last_checked_law=last_checked_law,
+            last_processed_law=progress.last_processed_law,
+            next_law_to_check=final_plan.next_target.law_id,
+            last_collector_run_at=progress.last_collector_run_at,
+            first_found_url=first_found_url,
+        )
+
+    def _probe_target(self, *, target: ImportTarget, timeout_seconds: float) -> SlovLexProbeResult:
+        request = Request(
+            target.url,
+            headers={"User-Agent": "aijurisdictionagents-slovlex-runner/1.0"},
+        )
+        try:
+            with urlopen(request, timeout=timeout_seconds) as response:  # noqa: S310 - controlled HTTPS URL
+                status_code = int(getattr(response, "status", 200))
+                return SlovLexProbeResult(
+                    target=target,
+                    exists=status_code == 200,
+                    status_code=status_code,
+                    url=target.url,
+                )
+        except HTTPError as exc:
+            return SlovLexProbeResult(
+                target=target,
+                exists=False,
+                status_code=exc.code,
+                url=target.url,
+            )
+        except URLError as exc:
+            raise RuntimeError(f"SlovLex probe failed for {target.url}: {exc}") from exc
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/src/services/laws_collector/sqlite_store.py
+++ b/src/services/laws_collector/sqlite_store.py
@@ -8,7 +8,7 @@ import sqlite3
 import uuid
 
 from .config import LawsCollectorConfig
-from .domain import LawSnapshot, ProvisionRecord, StoredVersion
+from .domain import CollectorProgress, LawSnapshot, ProvisionRecord, StoredVersion
 
 
 @dataclass(frozen=True)
@@ -148,6 +148,19 @@ class SqliteLawStore:
                     created_at TEXT NOT NULL,
                     FOREIGN KEY(document_id) REFERENCES law_documents(document_id) ON DELETE CASCADE,
                     FOREIGN KEY(version_id) REFERENCES law_versions(version_id) ON DELETE SET NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS collector_progress (
+                    country_code TEXT PRIMARY KEY,
+                    source_system TEXT NOT NULL,
+                    last_collector_run_at TEXT,
+                    last_processed_at TEXT,
+                    last_processed_law_year INTEGER,
+                    last_processed_law_number INTEGER,
+                    next_probe_law_year INTEGER NOT NULL,
+                    next_probe_law_number INTEGER NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
                 );
                 """
             )
@@ -467,6 +480,74 @@ class SqliteLawStore:
                 ),
             )
 
+    def get_or_create_collector_progress(
+        self,
+        *,
+        country_code: str,
+        source_system: str,
+        initial_year: int,
+    ) -> CollectorProgress:
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT country_code, source_system, last_collector_run_at, last_processed_at,
+                       last_processed_law_year, last_processed_law_number,
+                       next_probe_law_year, next_probe_law_number
+                FROM collector_progress
+                WHERE country_code = ?
+                """,
+                (country_code,),
+            ).fetchone()
+            if row is not None:
+                return _collector_progress_from_row(row)
+
+            now = _now_iso()
+            conn.execute(
+                """
+                INSERT INTO collector_progress(
+                    country_code, source_system, last_collector_run_at, last_processed_at,
+                    last_processed_law_year, last_processed_law_number,
+                    next_probe_law_year, next_probe_law_number, created_at, updated_at
+                )
+                VALUES (?, ?, NULL, NULL, NULL, NULL, ?, ?, ?, ?)
+                """,
+                (country_code, source_system, initial_year, 1, now, now),
+            )
+            return CollectorProgress(
+                country_code=country_code,
+                source_system=source_system,
+                last_collector_run_at=None,
+                last_processed_at=None,
+                last_processed_law_year=None,
+                last_processed_law_number=None,
+                next_probe_law_year=initial_year,
+                next_probe_law_number=1,
+            )
+
+    def save_collector_progress(self, progress: CollectorProgress) -> None:
+        now = _now_iso()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE collector_progress
+                SET source_system = ?, last_collector_run_at = ?, last_processed_at = ?,
+                    last_processed_law_year = ?, last_processed_law_number = ?,
+                    next_probe_law_year = ?, next_probe_law_number = ?, updated_at = ?
+                WHERE country_code = ?
+                """,
+                (
+                    progress.source_system,
+                    progress.last_collector_run_at,
+                    progress.last_processed_at,
+                    progress.last_processed_law_year,
+                    progress.last_processed_law_number,
+                    progress.next_probe_law_year,
+                    progress.next_probe_law_number,
+                    now,
+                    progress.country_code,
+                ),
+            )
+
     def get_counts(self) -> CollectorCounts:
         with self._connect() as conn:
             return CollectorCounts(
@@ -523,3 +604,22 @@ def _count(conn: sqlite3.Connection, table_name: str) -> int:
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _collector_progress_from_row(row: sqlite3.Row) -> CollectorProgress:
+    return CollectorProgress(
+        country_code=str(row["country_code"]),
+        source_system=str(row["source_system"]),
+        last_collector_run_at=(str(row["last_collector_run_at"]) if row["last_collector_run_at"] else None),
+        last_processed_at=(str(row["last_processed_at"]) if row["last_processed_at"] else None),
+        last_processed_law_year=(
+            int(row["last_processed_law_year"]) if row["last_processed_law_year"] is not None else None
+        ),
+        last_processed_law_number=(
+            int(row["last_processed_law_number"])
+            if row["last_processed_law_number"] is not None
+            else None
+        ),
+        next_probe_law_year=int(row["next_probe_law_year"]),
+        next_probe_law_number=int(row["next_probe_law_number"]),
+    )

--- a/src/services/laws_collector/worker.py
+++ b/src/services/laws_collector/worker.py
@@ -7,6 +7,7 @@ import time
 from .country_registry import get_country_laws_collector_definition
 from .config import LawsCollectorConfig
 from .postgres_store import PostgresLawStore
+from .slovlex_process import SlovLexSequentialImportRunner
 from .sqlite_store import SqliteLawStore
 
 
@@ -19,8 +20,8 @@ class WorkerOptions:
     @classmethod
     def from_env(cls) -> "WorkerOptions":
         fixture = os.getenv("LAWS_WORKER_FIXTURE", "baseline").strip().lower()
-        if fixture not in {"baseline", "delta"}:
-            raise ValueError("LAWS_WORKER_FIXTURE must be baseline or delta")
+        if fixture not in {"baseline", "delta", "live"}:
+            raise ValueError("LAWS_WORKER_FIXTURE must be baseline, delta, or live")
 
         poll_seconds = int(os.getenv("LAWS_WORKER_POLL_SECONDS", "3600"))
         if poll_seconds < 1:
@@ -45,20 +46,31 @@ def run_worker() -> None:
 
     while True:
         cycle += 1
-        snapshots = (
-            collector_definition.baseline_snapshots()
-            if options.fixture == "baseline"
-            else collector_definition.delta_snapshots()
-        )
-        summary = service.sync(snapshots)
-
-        print(
-            f"[laws-collector] collector={collector_definition.collector_name} "
-            f"country={config.country_code} cycle={cycle} fixture={options.fixture} "
-            f"processed={summary.processed} new_documents={summary.new_documents} "
-            f"new_versions={summary.new_versions} metadata_updates={summary.metadata_updates} "
-            f"skipped={summary.skipped}"
-        )
+        if options.fixture == "live":
+            summary = SlovLexSequentialImportRunner(config=config, store=store).run(max_probes=25)
+            print(
+                f"[laws-collector] collector={collector_definition.collector_name} "
+                f"country={config.country_code} cycle={cycle} fixture=live "
+                f"probes={summary.probes} laws_found={summary.laws_found} "
+                f"years_advanced={summary.years_advanced} "
+                f"stopped_on_current_year_gap={str(summary.stopped_on_current_year_gap).lower()} "
+                f"last_processed_law={summary.last_processed_law or ''} "
+                f"next_law_to_check={summary.next_law_to_check}"
+            )
+        else:
+            snapshots = (
+                collector_definition.baseline_snapshots()
+                if options.fixture == "baseline"
+                else collector_definition.delta_snapshots()
+            )
+            summary = service.sync(snapshots)
+            print(
+                f"[laws-collector] collector={collector_definition.collector_name} "
+                f"country={config.country_code} cycle={cycle} fixture={options.fixture} "
+                f"processed={summary.processed} new_documents={summary.new_documents} "
+                f"new_versions={summary.new_versions} metadata_updates={summary.metadata_updates} "
+                f"skipped={summary.skipped}"
+            )
 
         if options.max_cycles > 0 and cycle >= options.max_cycles:
             print("[laws-collector] worker stopped after max cycles")

--- a/tests/test_laws_collector.py
+++ b/tests/test_laws_collector.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
+from datetime import date
 from pathlib import Path
 
-from datetime import date
-
-from services.laws_collector import LawsCollectorConfig, SlovLexImportPlanner, SlovakLawsCollectorService, SqliteLawStore
-from services.laws_collector.source_fixtures import baseline_snapshots, delta_snapshots
 from services.laws_collector import (
+    LawsCollectorConfig,
+    SlovLexImportPlanner,
+    SlovLexSequentialImportRunner,
+    SlovakLawsCollectorService,
+    SqliteLawStore,
     get_country_laws_collector_definition,
 )
-from services.laws_collector.slovak_laws_collector import SlovakLawsCollectorService
+from services.laws_collector.import_planner import ImportTarget
 from services.laws_collector.slovak_source_fixtures import baseline_snapshots, delta_snapshots
 
 
@@ -22,8 +24,8 @@ def _build_service(tmp_path: Path) -> tuple[SqliteLawStore, SlovakLawsCollectorS
         storage_local="",
         storage_cloud="",
         delta_poll_hours=3,
-        initial_import_from=date(2025, 1, 1),
-        historical_import_from=date(1946, 1, 1),
+        initial_import_from=date(1993, 1, 1),
+        historical_import_from=date(1993, 1, 1),
     )
     store = SqliteLawStore.from_config(config)
     store.initialize()
@@ -90,11 +92,12 @@ def test_laws_collector_config_resolves_relative_db_from_repo_root(monkeypatch) 
     assert config.db_path.parent.parent.name == "databases"
     assert config.db_path.parent.parent.parent == Path(__file__).resolve().parents[1]
     assert config.country_db_name == "laws_sk"
-
+    assert config.initial_import_from == date(1993, 1, 1)
+    assert config.historical_import_from == date(1993, 1, 1)
 
 
 def test_laws_collector_update_plan_detects_changes(tmp_path: Path) -> None:
-    store, service = _build_service(tmp_path)
+    _, service = _build_service(tmp_path)
 
     plan = service.plan_updates(known_snapshots=baseline_snapshots(), latest_snapshots=delta_snapshots())
 
@@ -113,21 +116,147 @@ def test_laws_collector_config_defaults_to_country_specific_sqlite_db(monkeypatc
     assert config.country_db_name == "laws_sk"
 
 
-def test_slovlex_import_planner_starts_with_2025_then_unblocks_1946_history(tmp_path: Path) -> None:
+def test_slovlex_import_planner_starts_from_1_1993_without_progress(tmp_path: Path) -> None:
     store, service = _build_service(tmp_path)
     planner = SlovLexImportPlanner(config=service.config)
+    progress = store.get_or_create_collector_progress(
+        country_code="SK",
+        source_system="slov-lex",
+        initial_year=planner.initial_year,
+    )
 
-    blocked_plan = planner.build_plan(today=date(2026, 3, 23), initial_window_complete=False)
-    unblocked_plan = planner.build_plan(today=date(2026, 3, 23), initial_window_complete=True)
+    plan = planner.build_plan(progress=progress, today=date(2026, 3, 30))
 
-    assert blocked_plan.windows[0].stage == "initial_2025_to_today"
-    assert blocked_plan.windows[0].start_date.isoformat() == "2025-01-01"
-    assert blocked_plan.windows[0].end_date.isoformat() == "2026-03-23"
-    assert blocked_plan.windows[1].stage == "historical_1946_to_2024"
-    assert blocked_plan.windows[1].start_date.isoformat() == "1946-01-01"
-    assert blocked_plan.windows[1].end_date.isoformat() == "2024-12-31"
-    assert blocked_plan.windows[1].blocked_by == "initial_2025_to_today"
-    assert unblocked_plan.windows[1].blocked_by is None
+    assert plan.initial_year == 1993
+    assert plan.next_target == ImportTarget(year=1993, number=1)
+    assert plan.last_processed_law is None
+    assert plan.stop_when_missing_current_year is False
+
+
+def test_slovlex_import_planner_persists_next_law_after_processed_probe(tmp_path: Path) -> None:
+    store, service = _build_service(tmp_path)
+    planner = SlovLexImportPlanner(config=service.config)
+    progress = store.get_or_create_collector_progress(
+        country_code="SK",
+        source_system="slov-lex",
+        initial_year=planner.initial_year,
+    )
+
+    updated = planner.mark_processed(
+        progress,
+        target=ImportTarget(year=1993, number=1),
+        processed_at="2026-03-30T12:00:00Z",
+    )
+    store.save_collector_progress(updated)
+    reloaded = store.get_or_create_collector_progress(
+        country_code="SK",
+        source_system="slov-lex",
+        initial_year=planner.initial_year,
+    )
+
+    assert reloaded.last_processed_law == "1/1993"
+    assert reloaded.next_probe_law == "2/1993"
+    assert reloaded.last_collector_run_at == "2026-03-30T12:00:00Z"
+
+
+def test_slovlex_import_planner_jumps_to_next_year_on_missing_past_year(tmp_path: Path) -> None:
+    _, service = _build_service(tmp_path)
+    planner = SlovLexImportPlanner(config=service.config)
+    progress = planner.initial_progress().evolve(
+        last_processed_at="2026-03-30T12:00:00Z",
+        last_processed_law_year=1993,
+        last_processed_law_number=234,
+        next_probe_law_year=1993,
+        next_probe_law_number=235,
+    )
+
+    updated, stopped = planner.mark_missing(
+        progress,
+        target=ImportTarget(year=1993, number=235),
+        observed_at="2026-03-30T13:00:00Z",
+        today=date(2026, 3, 30),
+    )
+
+    assert stopped is False
+    assert updated.next_probe_law == "1/1994"
+    assert updated.last_processed_law == "234/1993"
+    assert updated.last_collector_run_at == "2026-03-30T13:00:00Z"
+
+
+def test_slovlex_import_planner_stops_on_missing_current_year_and_retries_same_law(tmp_path: Path) -> None:
+    _, service = _build_service(tmp_path)
+    planner = SlovLexImportPlanner(config=service.config)
+    progress = planner.initial_progress().evolve(
+        last_processed_at="2026-03-30T12:00:00Z",
+        last_processed_law_year=2026,
+        last_processed_law_number=234,
+        next_probe_law_year=2026,
+        next_probe_law_number=235,
+    )
+
+    updated, stopped = planner.mark_missing(
+        progress,
+        target=ImportTarget(year=2026, number=235),
+        observed_at="2026-03-30T13:00:00Z",
+        today=date(2026, 3, 30),
+    )
+
+    assert stopped is True
+    assert updated.next_probe_law == "235/2026"
+    assert updated.last_processed_law == "234/2026"
+    assert updated.last_collector_run_at == "2026-03-30T13:00:00Z"
+
+
+def test_slovlex_sequential_import_runner_updates_progress_until_current_year_gap(tmp_path: Path) -> None:
+    store, service = _build_service(tmp_path)
+    runner = SlovLexSequentialImportRunner(config=service.config, store=store)
+
+    def fake_probe(*, target: ImportTarget, timeout_seconds: float) -> object:
+        outcomes = {
+            (1993, 1): True,
+            (1993, 2): False,
+            (1994, 1): True,
+            (1994, 2): False,
+        }
+        exists = outcomes[(target.year, target.number)]
+        return type(
+            "Probe",
+            (),
+            {
+                "target": target,
+                "exists": exists,
+                "status_code": 200 if exists else 404,
+                "url": target.url,
+            },
+        )()
+
+    progress = store.get_or_create_collector_progress(
+        country_code="SK",
+        source_system="slov-lex",
+        initial_year=1993,
+    )
+    progress = progress.evolve(
+        next_probe_law_year=1993,
+        next_probe_law_number=1,
+    )
+    store.save_collector_progress(progress)
+    runner._probe_target = fake_probe  # type: ignore[method-assign]
+
+    summary = runner.run(max_probes=4, today=date(1994, 3, 30))
+    reloaded = store.get_or_create_collector_progress(
+        country_code="SK",
+        source_system="slov-lex",
+        initial_year=1993,
+    )
+
+    assert summary.probes == 4
+    assert summary.laws_found == 2
+    assert summary.years_advanced == 1
+    assert summary.stopped_on_current_year_gap is True
+    assert summary.next_law_to_check == "2/1994"
+    assert reloaded.next_probe_law == "2/1994"
+
+
 def test_country_definition_resolves_slovak_collector_and_db_name() -> None:
     definition = get_country_laws_collector_definition("sk")
 
@@ -145,6 +274,8 @@ def test_country_db_name_uses_laws_prefix_for_future_countries() -> None:
         storage_local="",
         storage_cloud="",
         delta_poll_hours=3,
+        initial_import_from=date(1993, 1, 1),
+        historical_import_from=date(1993, 1, 1),
     )
 
     assert config.country_db_name == "laws_cz"


### PR DESCRIPTION
## Summary
- replace the old Slovakia date-window import planner with persisted sequential `number/year` progress starting at `1/1993`
- add `collector_progress` storage for SQLite and PostgreSQL plus a live Slov-Lex probe runner, CLI support, worker `live` mode, and local PostgreSQL debug example/docs
- surface collector progress in the API `/version` metadata as `last_collector_run_at` and `last_processed_law`

## Verification
- `.\\.conda\\python.exe -m pytest`
- `.\\.conda\\python.exe examples/laws_collector_minimal_demo.py`
- `.\\.conda\\python.exe -m services.laws_collector --plan-import`
- `.\\.conda\\python.exe -m services.laws_collector --run-sequential-import --max-probes 1 --probe-timeout-seconds 5`

## Notes
- Local PostgreSQL code path is implemented and documented, but I could not run the Docker-backed verification on this machine because the Docker Desktop Linux engine pipe was unavailable (`//./pipe/dockerDesktopLinuxEngine`).
