### PR TITLE
Fix strict mypy typing for law snapshot DB row reads

### DIFF
--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -521,6 +521,7 @@ ruff check . && mypy app && pytest -q
 
 Typing note: keep `UserResponseProvider` and `MessageCallback` imports in `app/chat/core_runtime.py`
 inside the `TYPE_CHECKING` block so both `ruff` and `mypy --strict` stay green.
+Database cursor reads in `app/chat/result_metadata.py` intentionally go through typed helper wrappers so strict `mypy` does not treat `fetchone()` results as implicit `Any`.
 
 Telemetry processor selection (OTLP vs console) is covered by unit tests in `tests/test_telemetry.py`.
 

--- a/api/aijuristiction-api/app/chat/result_metadata.py
+++ b/api/aijuristiction-api/app/chat/result_metadata.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import re
 import sqlite3
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any, Sequence, cast
 
 from app.chat.models import Message, MessageRole, Session
 from app.versioning import get_api_version, get_core_version
@@ -239,12 +239,16 @@ def get_law_knowledge_snapshot(country_code: str | None) -> LawKnowledgeSnapshot
         try:
             with sqlite3.connect(db_path) as conn:
                 if normalized_country:
-                    row = conn.execute(
-                        _law_snapshot_sqlite_query(filtered=True),
-                        (normalized_country,),
-                    ).fetchone()
+                    row = _fetchone_sqlite(
+                        conn=conn,
+                        query=_law_snapshot_sqlite_query(filtered=True),
+                        params=(normalized_country,),
+                    )
                 else:
-                    row = conn.execute(_law_snapshot_sqlite_query(filtered=False)).fetchone()
+                    row = _fetchone_sqlite(
+                        conn=conn,
+                        query=_law_snapshot_sqlite_query(filtered=False),
+                    )
         except sqlite3.Error:
             return _law_snapshot_without_db(model_cutoff=model_cutoff)
         snapshot = _law_snapshot_from_row(row, scope=scope, model_cutoff=model_cutoff)
@@ -258,12 +262,16 @@ def get_law_knowledge_snapshot(country_code: str | None) -> LawKnowledgeSnapshot
 
             with psycopg.connect(db_cloud) as conn:
                 if normalized_country:
-                    row = conn.execute(
-                        _law_snapshot_postgres_query(filtered=True),
-                        (normalized_country,),
-                    ).fetchone()
+                    row = _fetchone_postgres(
+                        conn=conn,
+                        query=_law_snapshot_postgres_query(filtered=True),
+                        params=(normalized_country,),
+                    )
                 else:
-                    row = conn.execute(_law_snapshot_postgres_query(filtered=False)).fetchone()
+                    row = _fetchone_postgres(
+                        conn=conn,
+                        query=_law_snapshot_postgres_query(filtered=False),
+                    )
         except Exception:
             return _law_snapshot_without_db(model_cutoff=model_cutoff)
         snapshot = _law_snapshot_from_row(row, scope=scope, model_cutoff=model_cutoff)
@@ -272,6 +280,24 @@ def get_law_knowledge_snapshot(country_code: str | None) -> LawKnowledgeSnapshot
         return _law_snapshot_without_db(model_cutoff=model_cutoff)
 
     return _law_snapshot_without_db(model_cutoff=model_cutoff)
+
+
+def _fetchone_sqlite(
+    *,
+    conn: sqlite3.Connection,
+    query: str,
+    params: Sequence[Any] = (),
+) -> Sequence[Any] | None:
+    return cast(Sequence[Any] | None, conn.execute(query, params).fetchone())
+
+
+def _fetchone_postgres(
+    *,
+    conn: Any,
+    query: str,
+    params: Sequence[Any] = (),
+) -> Sequence[Any] | None:
+    return cast(Sequence[Any] | None, conn.execute(query, params).fetchone())
 
 
 def _law_snapshot_sqlite_query(*, filtered: bool) -> str:

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260324"
+version = "1.0.260325"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
### Motivation
- Resolve `mypy` `no-any-return` errors coming from `fetchone()` results used by `_law_snapshot_from_row` in `app/chat/result_metadata.py` by ensuring returned DB rows are typed as `Sequence[Any] | None`.
- Keep the API package revision aligned with the repository versioning rule for changes under `api/aijuristiction-api`.

### Description
- Added typed helper wrappers ` _fetchone_sqlite` and `_fetchone_postgres` that `cast(...)` cursor results to `Sequence[Any] | None` and replaced direct `.fetchone()` uses with these wrappers in `api/aijuristiction-api/app/chat/result_metadata.py`.
- Imported `cast` from `typing` to support explicit casting and updated the module imports accordingly.
- Documented the typed cursor-wrapper pattern in `api/aijuristiction-api/README.md` to explain why DB reads route through helpers for strict `mypy` checks.
- Bumped the API package revision in `api/aijuristiction-api/pyproject.toml` from `1.0.260324` to `1.0.260325`.

### Testing
- Ran `cd api/aijuristiction-api && mypy app` and it completed successfully with no issues reported.
- Ran `cd api/aijuristiction-api && pytest -q tests/test_chat.py -k law_snapshot` and the targeted tests passed.
- Executed `python examples/minimal_demo.py` and the example scenario ran to completion (produced expected example output).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce28c02ad48332861760c215b1937e)