### PR TITLE
Improve laws collector ZIP import state handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,7 @@ SYSTEM_EMBEDDING_MODEL=all-MiniLM-L6-v2
 # AZURE_LAWS_COLLECTOR_CONTAINER_APP_NAME=laws-collector
 # AZURE_LAWS_COLLECTOR_CRON_EXPRESSION=0 0 * * *
 # AZURE_LAWS_COLLECTOR_MAX_PROBES=1
+# AZURE_LAWS_STORAGE_CONTAINER_NAME=laws-collection-sk
 # LAWS_COLLECTOR_MAX_RUNNING_TIME=60
 # AZURE_POSTGRES_SERVER_NAME=db-juris-dev
 # AZURE_POSTGRES_DATABASE_NAME=aijurisdiction
@@ -128,14 +129,14 @@ STORE_LOCAL=./runs/storage/api/files
 # LAWS_COUNTRY=SK
 LAWS_COLLECTOR_IMPORT=zip
 # `zip` is the default Slovak import path:
-# - first bootstrap from the full Slov-Lex archive under `./archivelaws/slovakia`
+# - first bootstrap from the full Slov-Lex archive under `./archivelaws/laws-collection-sk`
 # - then continue from monthly `exportZmeny.zip` deltas with resume support
 # Set `one_law_url` to keep the older sequential per-law probe importer.
 LAWS_DB_BACKEND=sqlite
 # SQLite default stays `sk_laws.sqlite3` for Slovakia. Future countries default to `<country>_laws.sqlite3`.
 LAWS_DB_LOCAL=./runs/storage/laws-collector/sqlite/sk_laws.sqlite3
 LAWS_DELTA_POLL_HOURS=3
-# `zip` mode persists archive/monthly import cursors in the laws database and downloads Slov-Lex bundles into `./archivelaws/slovakia`.
+# `zip` mode persists archive/monthly import cursors in the laws database and downloads Slov-Lex bundles into `./archivelaws/laws-collection-sk`.
 # `one_law_url` keeps the older sequential probe state in `collector_progress` starting from law `1/1993`.
 # Worker options:
 # LAWS_WORKER_FIXTURE=live   # baseline | delta | live
@@ -155,4 +156,7 @@ LAWS_DELTA_POLL_HOURS=3
 # Future cloud settings
 # PostgreSQL database naming is `laws_sk` for Slovakia and `laws_<country>` for future countries.
 # LAWS_DB_CLOUD=postgresql://user:password@host:5432/laws_sk
-# LAWS_STORAGE_CLOUD=https://<storage-account>.blob.core.windows.net/law-corpus
+# For Azure laws collector jobs, this can be omitted and the deploy will derive:
+# https://<AZURE_STORAGE_ACCOUNT_NAME>.blob.core.windows.net/laws-collection-sk
+# unless you explicitly override `AZURE_LAWS_STORAGE_CONTAINER_NAME`.
+# LAWS_STORAGE_CLOUD=https://<storage-account>.blob.core.windows.net/laws-collection-sk

--- a/.github/workflows/infra_deploy.yml
+++ b/.github/workflows/infra_deploy.yml
@@ -49,6 +49,7 @@ jobs:
       AZURE_POSTGRES_STORAGE_SIZE_GB: ${{ vars.AZURE_POSTGRES_STORAGE_SIZE_GB }}
       AZURE_STORAGE_ACCOUNT_NAME: ${{ vars.AZURE_STORAGE_ACCOUNT_NAME }}
       AZURE_STORAGE_CONTAINER_NAME: ${{ vars.AZURE_STORAGE_CONTAINER_NAME }}
+      AZURE_LAWS_STORAGE_CONTAINER_NAME: ${{ vars.AZURE_LAWS_STORAGE_CONTAINER_NAME }}
       AZURE_LOG_ANALYTICS_WORKSPACE_NAME: ${{ vars.AZURE_LOG_ANALYTICS_WORKSPACE_NAME }}
       AZURE_APPLICATION_INSIGHTS_NAME: ${{ vars.AZURE_APPLICATION_INSIGHTS_NAME }}
       AZURE_MANAGED_IDENTITY_NAME: ${{ vars.AZURE_MANAGED_IDENTITY_NAME }}
@@ -365,6 +366,7 @@ jobs:
               acrName="${{ steps.acr.outputs.acr_name }}" \
               storageAccountName="${{ steps.storage.outputs.storage_account_name }}" \
               storageContainerName="${{ steps.storage.outputs.storage_container_name }}" \
+              lawsStorageContainerName="${AZURE_LAWS_STORAGE_CONTAINER_NAME:-laws-collection-sk}" \
               logAnalyticsWorkspaceName="$AZURE_LOG_ANALYTICS_WORKSPACE_NAME" \
               applicationInsightsName="${{ steps.appinsights.outputs.application_insights_name }}" \
               managedIdentityName="$AZURE_MANAGED_IDENTITY_NAME" \

--- a/.github/workflows/laws_collector_build_deploy.yml
+++ b/.github/workflows/laws_collector_build_deploy.yml
@@ -79,6 +79,8 @@ jobs:
       AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
       AZURE_CONTAINERAPPS_ENVIRONMENT: ${{ vars.AZURE_CONTAINERAPPS_ENVIRONMENT }}
       AZURE_CONTAINER_REGISTRY: ${{ vars.AZURE_CONTAINER_REGISTRY }}
+      AZURE_STORAGE_ACCOUNT_NAME: ${{ vars.AZURE_STORAGE_ACCOUNT_NAME }}
+      AZURE_LAWS_STORAGE_CONTAINER_NAME: ${{ vars.AZURE_LAWS_STORAGE_CONTAINER_NAME }}
       AZURE_MANAGED_IDENTITY_NAME: ${{ vars.AZURE_MANAGED_IDENTITY_NAME }}
       AZURE_APPLICATION_INSIGHTS_NAME: ${{ vars.AZURE_APPLICATION_INSIGHTS_NAME }}
       AZURE_POSTGRES_SERVER_NAME: ${{ vars.AZURE_POSTGRES_SERVER_NAME }}
@@ -89,6 +91,7 @@ jobs:
       AZURE_LAWS_POSTGRES_DATABASE_NAME_SK: ${{ vars.AZURE_LAWS_POSTGRES_DATABASE_NAME_SK }}
       AZURE_LAWS_COLLECTOR_MAX_PROBES: ${{ vars.AZURE_LAWS_COLLECTOR_MAX_PROBES }}
       LAWS_COLLECTOR_MAX_RUNNING_TIME: ${{ vars.LAWS_COLLECTOR_MAX_RUNNING_TIME }}
+      LAWS_STORAGE_CLOUD: ${{ vars.LAWS_STORAGE_CLOUD }}
       LAWS_COLLECTOR_IMPORT: ${{ vars.LAWS_COLLECTOR_IMPORT || 'zip' }}
       SYSTEM_EMBEDDING_MODEL_OPTION: ${{ vars.SYSTEM_EMBEDDING_MODEL_OPTION || 'local' }}
       SYSTEM_EMBEDDING_MODEL: ${{ vars.SYSTEM_EMBEDDING_MODEL || 'all-MiniLM-L6-v2' }}
@@ -106,6 +109,7 @@ jobs:
             "AZURE_LOCATION",
             "AZURE_CONTAINERAPPS_ENVIRONMENT",
             "AZURE_CONTAINER_REGISTRY",
+            "AZURE_STORAGE_ACCOUNT_NAME",
             "AZURE_MANAGED_IDENTITY_NAME",
             "AZURE_POSTGRES_SERVER_NAME",
             "AZURE_POSTGRES_ADMIN_USERNAME",
@@ -221,11 +225,14 @@ jobs:
             -ContainerAppName $containerAppName `
             -AcrName "${{ steps.acr.outputs.acr_name }}" `
             -ManagedIdentityName $env:AZURE_MANAGED_IDENTITY_NAME `
+            -StorageAccountName $env:AZURE_STORAGE_ACCOUNT_NAME `
+            -StorageContainerName $env:AZURE_LAWS_STORAGE_CONTAINER_NAME `
             -ApplicationInsightsName $env:AZURE_APPLICATION_INSIGHTS_NAME `
             -PostgresServerName $env:AZURE_POSTGRES_SERVER_NAME `
             -PostgresDatabaseName $postgresDatabaseName `
             -PostgresAdminUsername $env:AZURE_POSTGRES_ADMIN_USERNAME `
             -PostgresAdminPassword $env:AZURE_POSTGRES_ADMIN_PASSWORD `
+            -LawsStorageCloud $env:LAWS_STORAGE_CLOUD `
             -LawsCollectorImport $env:LAWS_COLLECTOR_IMPORT `
             -SystemEmbeddingModelOption $env:SYSTEM_EMBEDDING_MODEL_OPTION `
             -SystemEmbeddingModel $env:SYSTEM_EMBEDDING_MODEL `

--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -200,6 +200,7 @@ If the database is unreachable or misconfigured, the endpoint returns `503` with
 - `model_knowledge_cutoff_date`: LLM cutoff date resolved from the current model metadata and cached in `permanent_memory`.
 - `model_knowledge_cutoff_source`: source URL used for the resolved cutoff date, typically an official OpenAI model page.
 - `law_reference_links`: recent official law links available in the system knowledge store.
+- `law_citations`: structured version-specific legal citations resolved from the current answer/session context. Each item includes the law identifier, title, version token, effective date, and an `open_url` that can stream the stored full-law source from local storage or Azure Blob.
 - `mobile_app_version`: latest mobile app version from `mobile_app/pubspec.yaml`.
 - `mobile_app_release_url`: release page used by the mobile app update flow.
 - `mobile_app_apk_download_url`: default APK asset URL used by Android in-app update flow.
@@ -415,7 +416,14 @@ The dedicated local database layout guide now lives under `docs/DATABASE_LAYOUT.
 - Direct `POST /v1/chat/sessions/{session_id}/reply` sessions also persist a session result now, so the mobile `Real Agent` flow can download PDFs without going through the simulator stream.
 - In `Real Agent` mode, the lawyer can first ask whether a formal document should be prepared as PDF; once the user confirms, the next direct reply marks `metadata.document_ready=true` in `GET /v1/chat/sessions/{session_id}/result`.
 - Explicit document-revision requests that mention uploaded documents plus update/fix wording such as reviewing a contract against newer laws are also treated as document-preparation requests, so the API can prepare an updated export without waiting for a separate summary-only path.
-- `GET /v1/chat/sessions/{session_id}/result` metadata now also includes `last_law_update_date`, `last_law_update_source`, `model_knowledge_cutoff_date`, `model_knowledge_cutoff_source`, `law_reference_links`, `api_version`, and the backward-compatible `knowledge_last_updated_at` alias.
+- `GET /v1/chat/sessions/{session_id}/result` metadata now also includes `last_law_update_date`, `last_law_update_source`, `model_knowledge_cutoff_date`, `model_knowledge_cutoff_source`, `law_reference_links`, `law_citations`, `api_version`, and the backward-compatible `knowledge_last_updated_at` alias.
+- `GET /v1/laws/source?...` streams the stored full-law source for a resolved citation. For local imports it reads the persisted local file, and for Azure imports it reads the same artifact from Blob storage.
+
+Citation payload demo:
+
+```bash
+python examples/law_citation_resolution_demo.py
+```
 - When the laws database has no import timestamp yet, `knowledge_last_updated_at` falls back to the cached `MODEL_KNOWLEDGE_CUTOFF_DATE` value while `last_law_update_date` remains empty.
 - For Slovak and other Central European locales, the exporter uses a Unicode TrueType font when available so characters such as `á`, `č`, `ľ`, `ô`, and `ž` render correctly in the generated PDF.
 

--- a/api/aijuristiction-api/app/chat/api.py
+++ b/api/aijuristiction-api/app/chat/api.py
@@ -1047,16 +1047,20 @@ def stream_session(session_id: UUID, payload: StartSessionStreamRequest) -> Stre
                 message_callback=message_callback,
             )
             persisted_messages = _repository.list_messages(session_id)
+            metadata = build_session_result_metadata(
+                session=session,
+                messages=persisted_messages,
+                final_recommendation=result.final_recommendation,
+                base_metadata={"message_count": len(result.messages), "mode": "discussion_stream"},
+            )
             session_result = SessionResult(
                 final_recommendation=result.final_recommendation,
                 judge_rationale=result.judge_rationale,
-                citations=[{"filename": c.filename, "snippet": c.snippet} for c in result.citations],
-                metadata=build_session_result_metadata(
-                    session=session,
-                    messages=persisted_messages,
-                    final_recommendation=result.final_recommendation,
-                    base_metadata={"message_count": len(result.messages), "mode": "discussion_stream"},
+                citations=_merge_session_citations(
+                    generic_citations=[{"filename": c.filename, "snippet": c.snippet} for c in result.citations],
+                    metadata=metadata,
                 ),
+                metadata=metadata,
             )
             _repository.set_result(session_id, session_result)
             event_queue.put(("result", session_result.model_dump(mode="json")))
@@ -1264,24 +1268,25 @@ def _build_direct_reply_result(
         if visible_text
         else "Direct lawyer reply stored for session export."
     )
+    metadata = build_session_result_metadata(
+        session=session,
+        messages=messages,
+        final_recommendation=visible_text or f"Direct lawyer reply for session {session_id}.",
+        base_metadata={
+            "message_count": len(messages),
+            "mode": "direct_reply",
+            "country": session.country,
+            "language": session.language or "",
+            "document_requested": document_requested,
+            "document_confirmed": document_confirmed,
+            "document_ready": document_ready,
+        },
+    )
     return SessionResult(
         final_recommendation=visible_text or f"Direct lawyer reply for session {session_id}.",
         judge_rationale=rationale,
-        citations=[],
-        metadata=build_session_result_metadata(
-            session=session,
-            messages=messages,
-            final_recommendation=visible_text or f"Direct lawyer reply for session {session_id}.",
-            base_metadata={
-                "message_count": len(messages),
-                "mode": "direct_reply",
-                "country": session.country,
-                "language": session.language or "",
-                "document_requested": document_requested,
-                "document_confirmed": document_confirmed,
-                "document_ready": document_ready,
-            },
-        ),
+        citations=_merge_session_citations(generic_citations=[], metadata=metadata),
+        metadata=metadata,
     )
 
 
@@ -1882,6 +1887,42 @@ def _format_validation_accuracy(value: object) -> str:
     return f"{numeric:.1f}%"
 
 
+def _merge_session_citations(
+    *,
+    generic_citations: list[dict[str, str]],
+    metadata: dict[str, object],
+) -> list[dict[str, str]]:
+    merged = list(generic_citations)
+    for citation in _law_citation_session_citations(metadata):
+        if citation not in merged:
+            merged.append(citation)
+    return merged
+
+
+def _law_citation_session_citations(metadata: dict[str, object]) -> list[dict[str, str]]:
+    citations: list[dict[str, str]] = []
+    raw_law_citations = metadata.get("law_citations")
+    if not isinstance(raw_law_citations, list):
+        return citations
+    for raw_item in raw_law_citations:
+        if not isinstance(raw_item, dict):
+            continue
+        label = str(raw_item.get("law_identifier") or raw_item.get("label") or "").strip()
+        title = str(raw_item.get("title") or "").strip()
+        version_token = str(raw_item.get("version_token") or "").strip()
+        effective_from = str(raw_item.get("effective_from") or "").strip()
+        summary_bits = [part for part in (title, f"version {version_token}" if version_token else "", f"effective from {effective_from}" if effective_from else "") if part]
+        if not label:
+            continue
+        citations.append(
+            {
+                "filename": label,
+                "snippet": ", ".join(summary_bits),
+            }
+        )
+    return citations
+
+
 def _summary_citation_lines(citations: list[dict[str, str]]) -> list[str]:
     lines: list[str] = []
     for citation in citations[:5]:
@@ -1893,6 +1934,41 @@ def _summary_citation_lines(citations: list[dict[str, str]]) -> list[str]:
             lines.append(f"- {filename}")
         elif snippet:
             lines.append(f"- {snippet}")
+    return lines
+
+
+def _law_citation_export_lines(*, metadata: dict[str, object], language: str | None) -> list[str]:
+    prefers_slovak = (language or "").strip().lower().startswith("sk")
+    lines: list[str] = []
+    raw_law_citations = metadata.get("law_citations")
+    if not isinstance(raw_law_citations, list):
+        return lines
+    for raw_item in raw_law_citations:
+        if not isinstance(raw_item, dict):
+            continue
+        identifier = str(raw_item.get("law_identifier") or raw_item.get("label") or "").strip()
+        title = str(raw_item.get("title") or "").strip()
+        version_token = str(raw_item.get("version_token") or "").strip()
+        effective_from = str(raw_item.get("effective_from") or "").strip()
+        if not identifier:
+            continue
+        if prefers_slovak:
+            detail = f"- {identifier}"
+            if title:
+                detail += f": {title}"
+            if version_token:
+                detail += f", verzia {version_token}"
+            if effective_from:
+                detail += f", účinná od {effective_from}"
+        else:
+            detail = f"- {identifier}"
+            if title:
+                detail += f": {title}"
+            if version_token:
+                detail += f", version {version_token}"
+            if effective_from:
+                detail += f", effective from {effective_from}"
+        lines.append(detail)
     return lines
 
 
@@ -1930,25 +2006,50 @@ def _build_document_export_content(
                 break
     document_kind = _detect_document_kind(context_lines, case_update)
     facts = _extract_document_facts(context_lines, case_update)
+    law_citation_lines = _law_citation_export_lines(
+        metadata=result.metadata if result is not None else {},
+        language=language,
+    )
 
     if (language or "").strip().lower().startswith("sk"):
         title = f"Generovaný Dokument {session_id}"
         if document_kind == "rental_agreement":
-            return title, _build_standard_slovak_agreement_lines(facts)
+            lines = _build_standard_slovak_agreement_lines(facts)
+            return title, _append_document_law_citations(lines=lines, citations=law_citation_lines, language=language)
         if document_kind == "easement_demand":
-            return title, _build_slovak_easement_demand_lines(facts)
+            lines = _build_slovak_easement_demand_lines(facts)
+            return title, _append_document_law_citations(lines=lines, citations=law_citation_lines, language=language)
         if document_kind == "share_transfer":
-            return title, _build_slovak_share_transfer_lines(facts)
-        return title, _build_generic_slovak_case_document_lines(facts)
+            lines = _build_slovak_share_transfer_lines(facts)
+            return title, _append_document_law_citations(lines=lines, citations=law_citation_lines, language=language)
+        lines = _build_generic_slovak_case_document_lines(facts)
+        return title, _append_document_law_citations(lines=lines, citations=law_citation_lines, language=language)
 
     title = f"Generated Document {session_id}"
     if document_kind == "rental_agreement":
-        return title, _build_standard_english_agreement_lines(facts)
+        lines = _build_standard_english_agreement_lines(facts)
+        return title, _append_document_law_citations(lines=lines, citations=law_citation_lines, language=language)
     if document_kind == "easement_demand":
-        return title, _build_english_easement_demand_lines(facts)
+        lines = _build_english_easement_demand_lines(facts)
+        return title, _append_document_law_citations(lines=lines, citations=law_citation_lines, language=language)
     if document_kind == "share_transfer":
-        return title, _build_english_share_transfer_lines(facts)
-    return title, _build_generic_english_case_document_lines(facts)
+        lines = _build_english_share_transfer_lines(facts)
+        return title, _append_document_law_citations(lines=lines, citations=law_citation_lines, language=language)
+    lines = _build_generic_english_case_document_lines(facts)
+    return title, _append_document_law_citations(lines=lines, citations=law_citation_lines, language=language)
+
+
+def _append_document_law_citations(
+    *,
+    lines: List[str],
+    citations: list[str],
+    language: str | None,
+) -> List[str]:
+    if not citations:
+        return lines
+    prefers_slovak = (language or "").strip().lower().startswith("sk")
+    heading = "Právne citácie" if prefers_slovak else "Legal citations"
+    return [*lines, "", heading, *citations]
 
 
 def _pick_document_message(candidates: List[str]) -> str:

--- a/api/aijuristiction-api/app/chat/result_metadata.py
+++ b/api/aijuristiction-api/app/chat/result_metadata.py
@@ -13,6 +13,7 @@ from typing import Any, Sequence, cast
 from urllib.request import Request, urlopen
 
 from app.chat.models import Message, MessageRole, Session
+from app.law_citations import resolve_session_law_citations
 from app.versioning import get_api_version, get_core_version
 
 from aijurisdictionagents.agents import AIWebSearchAgent, AIAgentsValidator, ValidatorInputs
@@ -149,6 +150,11 @@ def build_session_result_metadata(
     )
 
     knowledge_snapshot = get_law_knowledge_snapshot(session.country)
+    law_citations = resolve_session_law_citations(
+        country_code=session.country,
+        messages=visible_messages,
+        final_recommendation=final_recommendation,
+    )
     metadata.update(
         {
             "validation_accuracy": report.weighted_accuracy,
@@ -177,6 +183,7 @@ def build_session_result_metadata(
             "model_knowledge_cutoff_date": knowledge_snapshot.model_knowledge_cutoff_date,
             "model_knowledge_cutoff_source": knowledge_snapshot.model_knowledge_cutoff_source,
             "law_reference_links": list(knowledge_snapshot.reference_links),
+            "law_citations": law_citations,
             "api_version": get_api_version(),
             "core_version": get_core_version(),
         }

--- a/api/aijuristiction-api/app/law_citations.py
+++ b/api/aijuristiction-api/app/law_citations.py
@@ -1,0 +1,643 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+import importlib
+from mimetypes import guess_type
+import os
+from pathlib import Path
+import re
+import sqlite3
+from typing import Any, Sequence, cast
+from urllib.parse import urlparse
+
+from azure.identity import DefaultAzureCredential
+from azure.storage.blob import BlobClient, BlobServiceClient
+
+from app.chat.models import Message, MessageRole
+
+from aijurisdictionagents.llm import get_embedding_client
+from services.laws_collector import LawsCollectorConfig, LawsCollectorService, PostgresLawStore, SqliteLawStore
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DEFAULT_COLLECTION_CODE = "ZZ"
+_EXPLICIT_LAW_PATTERN = re.compile(r"\b(?P<number>\d{1,4})/(?P<year>\d{4})\b")
+_ISO_DATE_PATTERN = re.compile(r"\b(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})\b")
+_DOT_DATE_PATTERN = re.compile(r"\b(?P<day>\d{1,2})\.(?P<month>\d{1,2})\.(?P<year>\d{4})\b")
+_LEGAL_STOPWORDS = {
+    "about",
+    "also",
+    "contract",
+    "document",
+    "documents",
+    "draft",
+    "generate",
+    "legal",
+    "please",
+    "prepare",
+    "review",
+    "what",
+    "with",
+    "zmluva",
+    "zmluvy",
+    "dokument",
+    "dokumenty",
+    "navrh",
+    "návrh",
+    "priprav",
+    "vygeneruj",
+}
+
+
+@dataclass(frozen=True)
+class LawCitation:
+    country_code: str
+    collection_code: str
+    law_year: int
+    law_number: int
+    law_identifier: str
+    title: str
+    version_token: str
+    effective_from: str
+    as_of_date: str
+    official_source_url: str
+    artifact_kind: str
+    open_url: str
+    storage_backend: str
+
+    @property
+    def summary(self) -> str:
+        return (
+            f"{self.law_identifier} ({self.title}), version {self.version_token}, "
+            f"effective from {self.effective_from}"
+        )
+
+    @property
+    def label(self) -> str:
+        return f"{self.law_identifier} - {self.title}"
+
+    def as_metadata(self) -> dict[str, str]:
+        return {
+            "country_code": self.country_code,
+            "collection_code": self.collection_code,
+            "law_year": str(self.law_year),
+            "law_number": str(self.law_number),
+            "law_identifier": self.law_identifier,
+            "title": self.title,
+            "version_token": self.version_token,
+            "effective_from": self.effective_from,
+            "as_of_date": self.as_of_date,
+            "official_source_url": self.official_source_url,
+            "artifact_kind": self.artifact_kind,
+            "open_url": self.open_url,
+            "storage_backend": self.storage_backend,
+            "label": self.label,
+            "summary": self.summary,
+        }
+
+
+@dataclass(frozen=True)
+class _ResolvedLawVersion:
+    country_code: str
+    collection_code: str
+    law_year: int
+    law_number: int
+    law_identifier: str
+    title: str
+    version_id: str
+    version_token: str
+    effective_from: str
+    official_source_url: str
+
+
+@dataclass(frozen=True)
+class _LawArtifactLocation:
+    artifact_kind: str
+    source_url: str
+    storage_backend: str
+    storage_path: str
+
+
+def resolve_session_law_citations(
+    *,
+    country_code: str | None,
+    messages: Sequence[Message],
+    final_recommendation: str,
+    limit: int = 3,
+) -> list[dict[str, str]]:
+    normalized_country = (country_code or "").strip().upper()
+    if not normalized_country:
+        return []
+
+    effective_on = _resolve_effective_on(messages=messages)
+    combined_text = "\n".join(
+        [final_recommendation.strip(), *[message.content for message in messages if message.role != MessageRole.SYSTEM]]
+    ).strip()
+    citations: list[LawCitation] = []
+    seen_keys: set[tuple[str, str, int, int]] = set()
+
+    for law_year, law_number in _extract_explicit_law_targets(combined_text):
+        citation = _resolve_citation_for_law(
+            country_code=normalized_country,
+            collection_code=_DEFAULT_COLLECTION_CODE,
+            law_year=law_year,
+            law_number=law_number,
+            effective_on=effective_on,
+        )
+        if citation is None:
+            continue
+        key = (citation.country_code, citation.collection_code, citation.law_year, citation.law_number)
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        citations.append(citation)
+        if len(citations) >= limit:
+            return [item.as_metadata() for item in citations]
+
+    semantic_query = _build_semantic_query(messages=messages, final_recommendation=final_recommendation)
+    if semantic_query:
+        for candidate in _search_semantic_candidates(
+            query=semantic_query,
+            country_code=normalized_country,
+            limit=max(limit * 3, 6),
+        ):
+            citation = _resolve_citation_for_law(
+                country_code=candidate.country_code,
+                collection_code=candidate.collection_code,
+                law_year=candidate.law_year,
+                law_number=candidate.law_number,
+                effective_on=effective_on,
+            )
+            if citation is None:
+                continue
+            key = (citation.country_code, citation.collection_code, citation.law_year, citation.law_number)
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            citations.append(citation)
+            if len(citations) >= limit:
+                break
+
+    return [item.as_metadata() for item in citations[:limit]]
+
+
+def read_law_source(
+    *,
+    country_code: str,
+    collection_code: str,
+    law_year: int,
+    law_number: int,
+    version_token: str,
+    artifact_kind: str,
+) -> tuple[bytes, str, str] | None:
+    version = _resolve_exact_version(
+        country_code=country_code,
+        collection_code=collection_code,
+        law_year=law_year,
+        law_number=law_number,
+        version_token=version_token,
+    )
+    if version is None:
+        return None
+
+    artifact = _load_preferred_artifact(version_id=version.version_id, artifact_kind=artifact_kind)
+    if artifact is None:
+        return None
+
+    filename = (
+        f"{version.collection_code.lower()}-{version.law_year}-{version.law_number}-"
+        f"{version.version_token}.{_artifact_extension(artifact.artifact_kind)}"
+    )
+    media_type = _artifact_media_type(artifact.storage_path, artifact.artifact_kind)
+    payload = _read_artifact_bytes(artifact)
+    return payload, media_type, filename
+
+
+def _resolve_effective_on(*, messages: Sequence[Message]) -> str:
+    for message in reversed(messages):
+        if message.role != MessageRole.USER:
+            continue
+        detected = _extract_date_reference(message.content)
+        if detected is not None:
+            return detected
+    return date.today().isoformat()
+
+
+def _extract_date_reference(text: str) -> str | None:
+    match = _ISO_DATE_PATTERN.search(text)
+    if match is not None:
+        return f"{match.group('year')}-{match.group('month')}-{match.group('day')}"
+    match = _DOT_DATE_PATTERN.search(text)
+    if match is not None:
+        try:
+            return date(
+                year=int(match.group("year")),
+                month=int(match.group("month")),
+                day=int(match.group("day")),
+            ).isoformat()
+        except ValueError:
+            return None
+    return None
+
+
+def _extract_explicit_law_targets(text: str) -> list[tuple[int, int]]:
+    targets: list[tuple[int, int]] = []
+    for match in _EXPLICIT_LAW_PATTERN.finditer(text):
+        number = int(match.group("number"))
+        year = int(match.group("year"))
+        candidate = (year, number)
+        if candidate not in targets:
+            targets.append(candidate)
+    return targets
+
+
+def _build_semantic_query(*, messages: Sequence[Message], final_recommendation: str) -> str:
+    segments = [
+        final_recommendation.strip(),
+        *[
+            message.content.strip()
+            for message in messages
+            if message.role in {MessageRole.USER, MessageRole.ASSISTANT}
+        ],
+    ]
+    text = " ".join(segment for segment in segments if segment).strip()
+    if not text:
+        return ""
+    terms: list[str] = []
+    for token in re.findall(r"[^\W\d_]{4,}", text.lower(), flags=re.UNICODE):
+        if token in _LEGAL_STOPWORDS:
+            continue
+        if token not in terms:
+            terms.append(token)
+        if len(terms) >= 24:
+            break
+    return " ".join(terms) if terms else text[:400]
+
+
+def _search_semantic_candidates(*, query: str, country_code: str, limit: int) -> Sequence[Any]:
+    try:
+        config = LawsCollectorConfig.from_env()
+        if config.country_code != country_code:
+            config = LawsCollectorConfig(
+                country_code=country_code,
+                db_backend=config.db_backend,
+                db_local=config.db_local,
+                db_cloud=config.db_cloud,
+                storage_local=config.storage_local,
+                storage_cloud=config.storage_cloud,
+                delta_poll_hours=config.delta_poll_hours,
+                initial_import_from=config.initial_import_from,
+                historical_import_from=config.historical_import_from,
+                import_mode=config.import_mode,
+            )
+        store: SqliteLawStore | PostgresLawStore
+        if config.db_backend == "sqlite":
+            if not config.db_path.exists():
+                return ()
+            store = SqliteLawStore.from_config(config)
+        else:
+            store = PostgresLawStore.from_config(config)
+        service = LawsCollectorService(
+            config=config,
+            store=store,
+            embedding_client=get_embedding_client(),
+        )
+        return service.search_semantic(query, limit=limit)
+    except Exception:
+        return ()
+
+
+def _resolve_citation_for_law(
+    *,
+    country_code: str,
+    collection_code: str,
+    law_year: int,
+    law_number: int,
+    effective_on: str,
+) -> LawCitation | None:
+    version = _resolve_applicable_version(
+        country_code=country_code,
+        collection_code=collection_code,
+        law_year=law_year,
+        law_number=law_number,
+        effective_on=effective_on,
+    )
+    if version is None:
+        return None
+    artifact = _load_preferred_artifact(version_id=version.version_id, artifact_kind="html")
+    if artifact is None:
+        artifact = _load_preferred_artifact(version_id=version.version_id, artifact_kind="pdf")
+    if artifact is None:
+        return None
+    return LawCitation(
+        country_code=version.country_code,
+        collection_code=version.collection_code,
+        law_year=version.law_year,
+        law_number=version.law_number,
+        law_identifier=version.law_identifier,
+        title=version.title,
+        version_token=version.version_token,
+        effective_from=version.effective_from,
+        as_of_date=effective_on,
+        official_source_url=version.official_source_url,
+        artifact_kind=artifact.artifact_kind,
+        open_url=_build_law_open_url(
+            country_code=version.country_code,
+            collection_code=version.collection_code,
+            law_year=version.law_year,
+            law_number=version.law_number,
+            version_token=version.version_token,
+            artifact_kind=artifact.artifact_kind,
+        ),
+        storage_backend=artifact.storage_backend,
+    )
+
+
+def _resolve_applicable_version(
+    *,
+    country_code: str,
+    collection_code: str,
+    law_year: int,
+    law_number: int,
+    effective_on: str,
+) -> _ResolvedLawVersion | None:
+    query = """
+        SELECT
+            d.country_code,
+            d.collection_code,
+            d.law_year,
+            d.law_number,
+            COALESCE(
+                m.law_identifier_text,
+                CAST(d.law_number AS TEXT) || '/' || CAST(d.law_year AS TEXT)
+            ) AS law_identifier,
+            COALESCE(NULLIF(m.title, ''), d.lawyer_title, d.official_name) AS title,
+            v.version_id,
+            v.version_token,
+            v.effective_from,
+            d.source_url
+        FROM law_documents AS d
+        JOIN law_versions AS v ON v.document_id = d.document_id
+        LEFT JOIN law_metadata AS m ON m.version_id = v.version_id
+        WHERE UPPER(d.country_code) = {country_filter}
+          AND UPPER(d.collection_code) = {collection_filter}
+          AND d.law_year = {year_filter}
+          AND d.law_number = {number_filter}
+          AND v.effective_from <= {effective_filter}
+        ORDER BY v.effective_from DESC
+        LIMIT 1
+    """
+    row = _fetchone_laws_query(
+        query=query.format(
+            country_filter=_laws_param("country"),
+            collection_filter=_laws_param("collection"),
+            year_filter=_laws_param("year"),
+            number_filter=_laws_param("number"),
+            effective_filter=_laws_param("effective"),
+        ),
+        params=(country_code, collection_code, law_year, law_number, effective_on),
+    )
+    if row is None:
+        fallback_query = """
+            SELECT
+                d.country_code,
+                d.collection_code,
+                d.law_year,
+                d.law_number,
+                COALESCE(
+                    m.law_identifier_text,
+                    CAST(d.law_number AS TEXT) || '/' || CAST(d.law_year AS TEXT)
+                ) AS law_identifier,
+                COALESCE(NULLIF(m.title, ''), d.lawyer_title, d.official_name) AS title,
+                v.version_id,
+                v.version_token,
+                v.effective_from,
+                d.source_url
+            FROM law_documents AS d
+            JOIN law_versions AS v ON v.document_id = d.document_id
+            LEFT JOIN law_metadata AS m ON m.version_id = v.version_id
+            WHERE UPPER(d.country_code) = {country_filter}
+              AND UPPER(d.collection_code) = {collection_filter}
+              AND d.law_year = {year_filter}
+              AND d.law_number = {number_filter}
+            ORDER BY v.effective_from DESC
+            LIMIT 1
+        """
+        row = _fetchone_laws_query(
+            query=fallback_query.format(
+                country_filter=_laws_param("country"),
+                collection_filter=_laws_param("collection"),
+                year_filter=_laws_param("year"),
+                number_filter=_laws_param("number"),
+            ),
+            params=(country_code, collection_code, law_year, law_number),
+        )
+    if row is None:
+        return None
+    return _resolved_law_version_from_row(row)
+
+
+def _resolve_exact_version(
+    *,
+    country_code: str,
+    collection_code: str,
+    law_year: int,
+    law_number: int,
+    version_token: str,
+) -> _ResolvedLawVersion | None:
+    query = """
+        SELECT
+            d.country_code,
+            d.collection_code,
+            d.law_year,
+            d.law_number,
+            COALESCE(
+                m.law_identifier_text,
+                CAST(d.law_number AS TEXT) || '/' || CAST(d.law_year AS TEXT)
+            ) AS law_identifier,
+            COALESCE(NULLIF(m.title, ''), d.lawyer_title, d.official_name) AS title,
+            v.version_id,
+            v.version_token,
+            v.effective_from,
+            d.source_url
+        FROM law_documents AS d
+        JOIN law_versions AS v ON v.document_id = d.document_id
+        LEFT JOIN law_metadata AS m ON m.version_id = v.version_id
+        WHERE UPPER(d.country_code) = {country_filter}
+          AND UPPER(d.collection_code) = {collection_filter}
+          AND d.law_year = {year_filter}
+          AND d.law_number = {number_filter}
+          AND v.version_token = {version_filter}
+        LIMIT 1
+    """
+    row = _fetchone_laws_query(
+        query=query.format(
+            country_filter=_laws_param("country"),
+            collection_filter=_laws_param("collection"),
+            year_filter=_laws_param("year"),
+            number_filter=_laws_param("number"),
+            version_filter=_laws_param("version"),
+        ),
+        params=(country_code, collection_code, law_year, law_number, version_token),
+    )
+    if row is None:
+        return None
+    return _resolved_law_version_from_row(row)
+
+
+def _load_preferred_artifact(*, version_id: str, artifact_kind: str) -> _LawArtifactLocation | None:
+    preferred_order: tuple[str, ...]
+    if artifact_kind == "html":
+        preferred_order = ("html", "pdf")
+    elif artifact_kind == "pdf":
+        preferred_order = ("pdf", "html")
+    else:
+        preferred_order = (artifact_kind, "html", "pdf")
+
+    order_cases = " ".join(
+        f"WHEN artifact_kind = '{kind}' THEN {index}" for index, kind in enumerate(preferred_order)
+    )
+    query = f"""
+        SELECT artifact_kind, source_url, storage_backend, storage_path
+        FROM source_artifacts
+        WHERE version_id = {_laws_param("version_id")}
+        ORDER BY CASE {order_cases} ELSE 99 END
+        LIMIT 1
+    """
+    row = _fetchone_laws_query(query=query, params=(version_id,))
+    if row is None:
+        return None
+    return _LawArtifactLocation(
+        artifact_kind=str(_law_row_value(row, 0)),
+        source_url=str(_law_row_value(row, 1)),
+        storage_backend=str(_law_row_value(row, 2)),
+        storage_path=str(_law_row_value(row, 3)),
+    )
+
+
+def _resolved_law_version_from_row(row: Sequence[Any]) -> _ResolvedLawVersion:
+    return _ResolvedLawVersion(
+        country_code=str(_law_row_value(row, 0)),
+        collection_code=str(_law_row_value(row, 1)),
+        law_year=int(_law_row_value(row, 2)),
+        law_number=int(_law_row_value(row, 3)),
+        law_identifier=str(_law_row_value(row, 4)),
+        title=str(_law_row_value(row, 5)),
+        version_id=str(_law_row_value(row, 6)),
+        version_token=str(_law_row_value(row, 7)),
+        effective_from=str(_law_row_value(row, 8)),
+        official_source_url=str(_law_row_value(row, 9)),
+    )
+
+
+def _fetchone_laws_query(*, query: str, params: Sequence[Any]) -> Sequence[Any] | None:
+    db_backend = os.getenv("LAWS_DB_BACKEND", "sqlite").strip().lower()
+    db_local = os.getenv(
+        "LAWS_DB_LOCAL",
+        "./runs/storage/laws-collector/sqlite/sk_laws.sqlite3",
+    ).strip()
+    db_cloud = os.getenv("LAWS_DB_CLOUD", "").strip()
+
+    if db_backend == "sqlite":
+        db_path = _resolve_repo_path(db_local)
+        if not db_path.exists():
+            return None
+        with sqlite3.connect(db_path) as conn:
+            return cast(Sequence[Any] | None, conn.execute(query, params).fetchone())
+
+    if db_backend == "postgres" and db_cloud:
+        psycopg = importlib.import_module("psycopg")
+        with psycopg.connect(db_cloud) as conn:
+            return cast(Sequence[Any] | None, conn.execute(query, params).fetchone())
+    return None
+
+
+def _laws_param(name: str) -> str:
+    if os.getenv("LAWS_DB_BACKEND", "sqlite").strip().lower() == "postgres":
+        return "%s"
+    return "?"
+
+
+def _law_row_value(row: Sequence[Any], index: int) -> Any:
+    return row[index]
+
+
+def _build_law_open_url(
+    *,
+    country_code: str,
+    collection_code: str,
+    law_year: int,
+    law_number: int,
+    version_token: str,
+    artifact_kind: str,
+) -> str:
+    return (
+        "/v1/laws/source"
+        f"?country_code={country_code}"
+        f"&collection_code={collection_code}"
+        f"&law_year={law_year}"
+        f"&law_number={law_number}"
+        f"&version_token={version_token}"
+        f"&artifact_kind={artifact_kind}"
+    )
+
+
+def _artifact_media_type(storage_path: str, artifact_kind: str) -> str:
+    guessed = guess_type(storage_path)[0]
+    if guessed:
+        return guessed
+    if artifact_kind == "html":
+        return "text/html; charset=utf-8"
+    if artifact_kind == "pdf":
+        return "application/pdf"
+    return "application/octet-stream"
+
+
+def _artifact_extension(artifact_kind: str) -> str:
+    if artifact_kind == "html":
+        return "html"
+    if artifact_kind == "pdf":
+        return "pdf"
+    return "bin"
+
+
+def _read_artifact_bytes(artifact: _LawArtifactLocation) -> bytes:
+    if artifact.storage_backend == "local_file":
+        path = Path(artifact.storage_path).resolve()
+        path.relative_to(_REPO_ROOT.resolve())
+        return path.read_bytes()
+    if artifact.storage_backend == "azure_blob":
+        return _read_azure_blob(artifact.storage_path)
+    raise ValueError(f"Unsupported source artifact storage backend: {artifact.storage_backend}")
+
+
+def _read_azure_blob(blob_url: str) -> bytes:
+    parsed = urlparse(blob_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError("Invalid Azure Blob URL.")
+    if parsed.query:
+        return BlobClient.from_blob_url(blob_url).download_blob().readall()
+
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if len(path_parts) < 2:
+        raise ValueError("Azure Blob URL must include container and blob path.")
+    container_name = path_parts[0]
+    blob_name = "/".join(path_parts[1:])
+    account_url = f"{parsed.scheme}://{parsed.netloc}"
+    managed_identity_client_id = os.getenv("AZURE_CLIENT_ID", "").strip() or None
+    credential = DefaultAzureCredential(
+        exclude_interactive_browser_credential=True,
+        managed_identity_client_id=managed_identity_client_id,
+    )
+    blob_client = BlobServiceClient(account_url=account_url, credential=credential).get_blob_client(
+        container=container_name,
+        blob=blob_name,
+    )
+    return blob_client.download_blob().readall()
+
+
+def _resolve_repo_path(value: str) -> Path:
+    candidate = Path(value)
+    if candidate.is_absolute():
+        return candidate
+    return _REPO_ROOT / candidate

--- a/api/aijuristiction-api/app/laws_api.py
+++ b/api/aijuristiction-api/app/laws_api.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import Response
+
+from app.law_citations import read_law_source
+from app.security import require_api_key
+
+router = APIRouter(prefix="/v1/laws", tags=["laws"], dependencies=[Depends(require_api_key)])
+
+
+@router.get("/source")
+def download_law_source(
+    country_code: str = Query(..., min_length=2, max_length=2),
+    collection_code: str = Query("ZZ", min_length=1, max_length=8),
+    law_year: int = Query(..., ge=1900),
+    law_number: int = Query(..., ge=1),
+    version_token: str = Query(..., min_length=1),
+    artifact_kind: str = Query("html", pattern="^(html|pdf)$"),
+) -> Response:
+    payload = read_law_source(
+        country_code=country_code.strip().upper(),
+        collection_code=collection_code.strip().upper(),
+        law_year=law_year,
+        law_number=law_number,
+        version_token=version_token.strip(),
+        artifact_kind=artifact_kind.strip().lower(),
+    )
+    if payload is None:
+        raise HTTPException(status_code=404, detail="Law source artifact not found.")
+    content, media_type, filename = payload
+    return Response(
+        content=content,
+        media_type=media_type,
+        headers={
+            "Content-Disposition": f'inline; filename="{filename}"',
+        },
+    )

--- a/api/aijuristiction-api/app/main.py
+++ b/api/aijuristiction-api/app/main.py
@@ -16,6 +16,7 @@ from fastapi.responses import JSONResponse
 from app.cases_api import router as cases_router
 from app.chat.result_metadata import get_law_knowledge_snapshot
 from app.chat.api import router as chat_router
+from app.laws_api import router as laws_router
 from app.logging_config import configure_logging
 from app.observability_api import router as observability_router
 from app.telemetry import configure_telemetry, instrument_fastapi
@@ -107,6 +108,7 @@ app.add_middleware(
     expose_headers=["Content-Disposition", "x-request-id", "x-correlation-id"],
 )
 app.include_router(chat_router)
+app.include_router(laws_router)
 app.include_router(users_router)
 app.include_router(cases_router)
 app.include_router(observability_router)

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260335"
+version = "1.0.260336"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -8,6 +8,7 @@ dependencies = [
   "azure-identity>=1.23.0",
   "azure-monitor-opentelemetry>=1.8.6",
   "azure-monitor-query>=1.4.0",
+  "azure-storage-blob>=12.26.0",
   "fastapi>=0.116.1",
   "opentelemetry-api>=1.27.0",
   "opentelemetry-exporter-otlp>=1.27.0",

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -1084,6 +1084,74 @@ def test_direct_reply_result_uses_latest_law_store_timestamp(monkeypatch, tmp_pa
     assert result.metadata["api_version"]
 
 
+def test_direct_reply_result_includes_structured_law_citations(monkeypatch) -> None:
+    from app.chat.api import _build_direct_reply_result
+    from app.chat.models import Message, MessageRole, Session
+    import app.chat.result_metadata as result_metadata
+
+    monkeypatch.setattr(
+        result_metadata,
+        "resolve_session_law_citations",
+        lambda **_kwargs: [
+            {
+                "law_identifier": "1/1993 Z. z.",
+                "label": "1/1993 Z. z. - Prvy zakon",
+                "title": "Prvy zakon",
+                "version_token": "19930101",
+                "effective_from": "1993-01-01",
+                "open_url": "/v1/laws/source?country_code=SK&collection_code=ZZ&law_year=1993&law_number=1&version_token=19930101&artifact_kind=html",
+                "summary": "1/1993 Z. z. (Prvy zakon), version 19930101, effective from 1993-01-01",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        result_metadata,
+        "get_law_knowledge_snapshot",
+        lambda _country: result_metadata.LawKnowledgeSnapshot(
+            last_law_update_date="2026-04-01T00:00:00Z",
+            last_law_update_source="law_documents_country",
+            model_knowledge_cutoff_date="2023-10-01",
+            model_knowledge_cutoff_source="https://platform.openai.com/docs/models/gpt-4o-mini",
+        ),
+    )
+
+    class _FakeValidator:
+        def evaluate(self, **_kwargs):
+            return SimpleNamespace(
+                weighted_accuracy=92.5,
+                summary="Validated.",
+                scores=[],
+            )
+
+    monkeypatch.setattr(result_metadata, "AIAgentsValidator", lambda **_kwargs: _FakeValidator())
+
+    session_id = uuid4()
+    session = Session(id=session_id, country="SK", language="SK")
+    messages = [
+        Message(
+            session_id=session_id,
+            role=MessageRole.USER,
+            content="Priprav mi dokument a odkaz na zakon 1/1993.",
+        ),
+        Message(
+            session_id=session_id,
+            role=MessageRole.ASSISTANT,
+            content="Pripravil som navrh a doplnil pravny zaklad.",
+        ),
+    ]
+
+    result = _build_direct_reply_result(
+        session_id=session_id,
+        session=session,
+        messages=messages,
+        lawyer_message=messages[-1].content,
+    )
+
+    assert result.metadata["law_citations"][0]["law_identifier"] == "1/1993 Z. z."
+    assert result.citations[0]["filename"] == "1/1993 Z. z."
+    assert "effective from 1993-01-01" in result.citations[0]["snippet"]
+
+
 def test_law_snapshot_falls_back_to_model_cutoff_and_writes_cache(monkeypatch, tmp_path) -> None:
     import app.chat.result_metadata as result_metadata
 

--- a/api/aijuristiction-api/tests/test_laws_api.py
+++ b/api/aijuristiction-api/tests/test_laws_api.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import app.law_citations as law_citations
+from app.main import app
+
+AUTH_HEADERS = {"x-api-key": "aijuris"}
+
+
+def test_download_law_source_streams_local_html_artifact(monkeypatch, tmp_path: Path) -> None:
+    laws_db = tmp_path / "laws.sqlite3"
+    artifact_path = tmp_path / "source-artifacts" / "sk-zz-1993-1-19930101.html"
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact_path.write_text("<html><body>Law text</body></html>", encoding="utf-8")
+
+    with sqlite3.connect(laws_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE law_documents (
+                document_id TEXT PRIMARY KEY,
+                country_code TEXT NOT NULL,
+                collection_code TEXT NOT NULL,
+                law_year INTEGER NOT NULL,
+                law_number INTEGER NOT NULL,
+                official_name TEXT NOT NULL,
+                lawyer_title TEXT NOT NULL,
+                source_url TEXT NOT NULL
+            );
+            CREATE TABLE law_versions (
+                version_id TEXT PRIMARY KEY,
+                document_id TEXT NOT NULL,
+                version_token TEXT NOT NULL,
+                effective_from TEXT NOT NULL
+            );
+            CREATE TABLE law_metadata (
+                law_metadata_id TEXT PRIMARY KEY,
+                document_id TEXT NOT NULL,
+                version_id TEXT NOT NULL,
+                law_identifier_text TEXT NOT NULL,
+                title TEXT NOT NULL
+            );
+            CREATE TABLE source_artifacts (
+                artifact_id TEXT PRIMARY KEY,
+                document_id TEXT NOT NULL,
+                version_id TEXT NOT NULL,
+                artifact_kind TEXT NOT NULL,
+                source_url TEXT NOT NULL,
+                storage_backend TEXT NOT NULL,
+                storage_path TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO law_documents(
+                document_id, country_code, collection_code, law_year, law_number,
+                official_name, lawyer_title, source_url
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "doc-1",
+                "SK",
+                "ZZ",
+                1993,
+                1,
+                "Prvy zakon",
+                "Prvy zakon",
+                "https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/1993/1/",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO law_versions(version_id, document_id, version_token, effective_from)
+            VALUES (?, ?, ?, ?)
+            """,
+            ("ver-1", "doc-1", "19930101", "1993-01-01"),
+        )
+        conn.execute(
+            """
+            INSERT INTO law_metadata(law_metadata_id, document_id, version_id, law_identifier_text, title)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            ("meta-1", "doc-1", "ver-1", "1/1993 Z. z.", "Prvy zakon"),
+        )
+        conn.execute(
+            """
+            INSERT INTO source_artifacts(
+                artifact_id, document_id, version_id, artifact_kind, source_url, storage_backend, storage_path
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "art-1",
+                "doc-1",
+                "ver-1",
+                "html",
+                "https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/1993/1/",
+                "local_file",
+                str(artifact_path),
+            ),
+        )
+        conn.commit()
+
+    monkeypatch.setenv("LAWS_DB_BACKEND", "sqlite")
+    monkeypatch.setenv("LAWS_DB_LOCAL", str(laws_db))
+    monkeypatch.setattr(law_citations, "_REPO_ROOT", tmp_path)
+
+    client = TestClient(app)
+    response = client.get(
+        "/v1/laws/source",
+        params={
+            "country_code": "SK",
+            "collection_code": "ZZ",
+            "law_year": 1993,
+            "law_number": 1,
+            "version_token": "19930101",
+            "artifact_kind": "html",
+        },
+        headers=AUTH_HEADERS,
+    )
+
+    assert response.status_code == 200
+    assert response.text == "<html><body>Law text</body></html>"
+    assert response.headers["content-type"].startswith("text/html")

--- a/databases/laws-collector/migrations/0006_add_archive_import_assets.sql
+++ b/databases/laws-collector/migrations/0006_add_archive_import_assets.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS archive_import_assets (
+    archive_import_asset_id TEXT PRIMARY KEY,
+    country_code TEXT NOT NULL,
+    source_system TEXT NOT NULL,
+    import_key TEXT NOT NULL,
+    import_label TEXT NOT NULL,
+    phase TEXT NOT NULL,
+    asset_name TEXT NOT NULL,
+    source_url TEXT NOT NULL,
+    storage_backend TEXT NOT NULL,
+    storage_path TEXT NOT NULL,
+    checksum TEXT NOT NULL,
+    file_size_bytes INTEGER NOT NULL,
+    processing_status TEXT NOT NULL,
+    downloaded_at TIMESTAMPTZ NOT NULL,
+    metadata_json JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    UNIQUE(country_code, import_key, asset_name, checksum)
+);
+
+CREATE INDEX IF NOT EXISTS idx_archive_import_assets_lookup
+    ON archive_import_assets(country_code, import_key, phase, processing_status, downloaded_at DESC);

--- a/databases/laws-collector/migrations/0007_add_source_artifact_storage_references.sql
+++ b/databases/laws-collector/migrations/0007_add_source_artifact_storage_references.sql
@@ -1,0 +1,5 @@
+ALTER TABLE source_artifacts
+    ADD COLUMN IF NOT EXISTS storage_backend TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE source_artifacts
+    ADD COLUMN IF NOT EXISTS storage_path TEXT NOT NULL DEFAULT '';

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -113,8 +113,10 @@ These are used by infrastructure deployment and API deployment workflows:
 | `AZURE_MANAGED_IDENTITY_NAME` | Managed identity name |
 | `AZURE_LAWS_COLLECTOR_CONTAINER_APP_NAME` | Optional laws collector Azure Container App name, default `laws-collector` |
 | `AZURE_LAWS_COLLECTOR_MAX_PROBES` | Optional laws collector live probe count per Azure job execution, default `1` |
+| `AZURE_LAWS_STORAGE_CONTAINER_NAME` | Optional blob container for immutable Slov-Lex ZIP source bundles, default `laws-collection-sk` |
 | `AZURE_LAWS_POSTGRES_DATABASE_NAME_SK` | Optional Slovak laws collector PostgreSQL database name, default `laws_sk`; the API deploy also uses it to inject `LAWS_DB_CLOUD` so `/version` can read the latest collector metadata |
 | `LAWS_COLLECTOR_IMPORT` | Laws collector import mode. Default `zip`; set `one_law_url` to keep the older sequential per-law probe importer |
+| `LAWS_STORAGE_CLOUD` | Optional explicit blob container URL override for laws source storage. When unset, the deploy derives `https://<AZURE_STORAGE_ACCOUNT_NAME>.blob.core.windows.net/<AZURE_LAWS_STORAGE_CONTAINER_NAME or laws-collection-sk>` |
 | `AZURE_DOCUMENT_PROCESSOR_JOB_NAME` | Optional ACA job name for the document processor, default `document-processor` |
 | `AZURE_DOCUMENT_PROCESSOR_CRON_EXPRESSION` | Optional ACA job schedule, default `*/15 * * * *` |
 | `DOCUMENT_PROCESSOR_MAX_RUNNING_TIME` | Optional max runtime per document-processor Azure run in minutes; default `15`, set `0` for unlimited |
@@ -188,7 +190,9 @@ These are used by the laws collector deployment workflow:
 | `AZURE_LAWS_COLLECTOR_MAX_PROBES` | Optional live probe count per scheduled job execution, default `1` |
 | `LAWS_COLLECTOR_MAX_RUNNING_TIME` | Optional max runtime per laws collector Azure job execution in minutes; default `60`, set `0` for unlimited |
 | `AZURE_LAWS_POSTGRES_DATABASE_NAME_SK` | Optional PostgreSQL database name for the Slovak laws corpus, default `laws_sk`; the laws deployment applies schema migrations to this database before updating the ACA job |
+| `AZURE_LAWS_STORAGE_CONTAINER_NAME` | Optional blob container that stores immutable Slov-Lex ZIP source bundles, default `laws-collection-sk` |
 | `LAWS_COLLECTOR_IMPORT` | Import mode for the live laws collector job. Default `zip`, which bootstraps from the full Slov-Lex archive and then continues from monthly `exportZmeny.zip` deltas |
+| `LAWS_STORAGE_CLOUD` | Optional explicit blob container URL override for laws source storage. Normally leave this unset and let the deploy derive it from `AZURE_STORAGE_ACCOUNT_NAME` plus `AZURE_LAWS_STORAGE_CONTAINER_NAME` |
 | `SYSTEM_EMBEDDING_MODEL_OPTION` | Shared embedding mode for the job; default `local`, or set `cloud` for Azure OpenAI embeddings |
 | `SYSTEM_EMBEDDING_MODEL` | Shared local embedding model name, default `all-MiniLM-L6-v2`. In `local` mode the deploy prefetches that model into the worker image before `az acr build` |
 
@@ -258,8 +262,10 @@ At minimum, you should expect these values to differ between `test` and `prod`:
 - `DOCUMENT_PROCESSOR_MAX_RUNNING_TIME`
 - `AZURE_LAWS_COLLECTOR_CONTAINER_APP_NAME`
 - `AZURE_LAWS_COLLECTOR_MAX_PROBES`
+- `AZURE_LAWS_STORAGE_CONTAINER_NAME=laws-collection-sk`
 - `LAWS_COLLECTOR_MAX_RUNNING_TIME`
 - `LAWS_COLLECTOR_IMPORT=zip`
+- `LAWS_STORAGE_CLOUD` if you need a non-default blob container URL
 - `AZURE_LAWS_POSTGRES_DATABASE_NAME_SK`
 - `API_BASE_URL`
 - `CORS_ALLOW_ORIGINS`

--- a/docs/LAWS_COLLECTOR.md
+++ b/docs/LAWS_COLLECTOR.md
@@ -266,6 +266,19 @@ Minimal local demo:
 conda activate .\.conda
 python examples/laws_collector_zip_import_demo.py
 ```
+
+Local PostgreSQL state replay demo:
+
+```powershell
+.\skills\start-postgres\scripts\start_postgres.ps1 -ProjectName laws-collector
+.\.conda\python.exe examples/laws_collector_zip_postgres_state_demo.py
+```
+
+This PostgreSQL demo replays three ZIP-import states with visible logs:
+
+- fresh database imports archive first and then monthly update
+- completed archive skips directly to monthly update only
+- completed monthly state with no newer monthly bundle skips all import work
 The shared embedding switch now supports:
 
 - `SYSTEM_EMBEDDING_MODEL_OPTION=local` as the default runtime mode

--- a/docs/LAWS_COLLECTOR.md
+++ b/docs/LAWS_COLLECTOR.md
@@ -12,7 +12,7 @@ Current scope:
 - `slovak_laws_collector` implemented now for country `SK`,
 - canonical Slovak source model based on `Slov-Lex`,
 - draft monitoring model for `NR SR`,
-- local runnable SQLite implementation with documents stored in the database,
+- local runnable SQLite implementation with searchable parsed text in the database,
 - schema that can move later to PostgreSQL on Azure.
 
 ## Project location
@@ -50,22 +50,22 @@ Pragmatic recommendation:
 
 Recommended production stack:
 
-- Azure Database for PostgreSQL Flexible Server for metadata, versions, and stored documents,
+- Azure Database for PostgreSQL Flexible Server for metadata, versions, and searchable parsed text,
 - `pgvector` in PostgreSQL for provision embeddings,
 - Azure Container Apps Jobs for scheduled syncs.
 
 ## Database storage model
 
-The current solution now stores the actual law documents in the database:
+The current solution keeps original source artifacts in persistent storage and keeps searchable/legal structure in the database:
 
-- HTML in `source_artifacts.content_text`
-- PDF in `source_artifacts.content_blob`
+- parsed searchable HTML text in `source_artifacts.content_text`
+- original HTML/PDF artifact references in `source_artifacts.storage_backend` and `source_artifacts.storage_path`
 - normalized structured JSON in `law_versions.normalized_json`
 
-That works in:
+Storage layout:
 
-- SQLite locally
-- PostgreSQL later in Azure using `TEXT` and `BYTEA`
+- local runs: `runs/storage/laws-collector/files/<country>/source-artifacts/...`
+- Azure: blob URLs under the configured `LAWS_STORAGE_CLOUD` container, by default `laws-collection-sk`
 
 ## Important columns
 
@@ -107,8 +107,9 @@ These are the most important columns now:
 - `artifact_kind`
 - `source_url`
 - `checksum`
+- `storage_backend`
+- `storage_path`
 - `content_text`
-- `content_blob`
 - `content_bytes`
 - `http_etag`
 - `http_last_modified`
@@ -186,7 +187,7 @@ This supports:
 
 - immutable version storage,
 - provision-level normalization,
-- raw artifact retention,
+- raw artifact retention by reference,
 - update event tracking.
 
 ## Minimal demo
@@ -194,6 +195,13 @@ This supports:
 ```powershell
 conda activate .\.conda
 python examples/laws_collector_minimal_demo.py
+```
+
+Artifact storage demo:
+
+```powershell
+conda activate .\.conda
+python examples/laws_collector_artifact_storage_demo.py
 ```
 
 ## CLI seed/update
@@ -208,8 +216,15 @@ python -m services.laws_collector --fixture delta
 
 The live Slovak collector now supports two import modes through `LAWS_COLLECTOR_IMPORT`:
 
-- `zip` (default): bootstrap once from the full Slov-Lex archive, persist archive/monthly resume state in `collector_import_state`, then continue from monthly `exportZmeny.zip` bundles downloaded under `./archivelaws/slovakia`
+- `zip` (default): bootstrap once from the full Slov-Lex archive, persist archive/monthly resume state in `collector_import_state`, then continue from monthly `exportZmeny.zip` bundles downloaded under `./archivelaws/laws-collection-sk`
 - `one_law_url`: keep the older sequential per-law HTTP probe flow backed by `collector_progress`
+
+Both modes use the same downstream laws schema. After a snapshot is built, they both:
+
+- vectorize through the same embedding pipeline
+- write into the same `law_documents`, `law_versions`, `law_provisions`, `law_metadata`, `law_metadata_relations`, and `update_events` tables
+- persist original HTML/PDF artifacts to local/blob storage
+- store the artifact reference in `source_artifacts`
 
 The Slovak collector now keeps a persisted sequential crawl state in `collector_progress`.
 
@@ -244,14 +259,28 @@ The default `zip` mode uses the Slov-Lex export index at `https://static.slov-le
 
 Flow:
 
-1. Download the full archive parts (`export.z01` ... `export.zip`) into `./archivelaws/slovakia/archive/<archive-date>/download/`
+1. Download the full archive parts (`export.z01` ... `export.zip`) into `./archivelaws/laws-collection-sk/archive/<archive-date>/download/`
 2. Extract the archive once and ingest every law version from local HTML files
 3. Persist archive cursor state in `collector_import_state` so interrupted runs continue from the last processed entry
 4. Mark the archive seed as completed and remember the archive snapshot date
-5. Download each monthly `exportZmeny.zip` into `./archivelaws/slovakia/monthly/<range-end>/download/`
+5. Download each monthly `exportZmeny.zip` into `./archivelaws/laws-collection-sk/monthly/<range-end>/download/`
 6. Extract and ingest only the changed law versions from that monthly ZIP
 7. Persist the monthly cursor and resume from the last processed entry on restart
 8. Skip archive bootstrap forever after the first completed archive seed, and only look for newer monthly bundles afterward
+
+The ZIP importer now also keeps immutable source-bundle inventory rows in `archive_import_assets`. Each downloaded archive part or monthly ZIP records:
+
+- archive/import key
+- checksum
+- file size
+- processing status (`downloaded`, `in_progress`, `processed`)
+- durable storage location
+
+Storage rules:
+
+- local dev/test keeps ZIPs under `./archivelaws/laws-collection-sk`
+- when `LAWS_STORAGE_CLOUD` is configured, the worker also persists those ZIPs to Azure Blob and records the blob URL in `archive_import_assets.storage_path`
+- Azure deployments now default that blob target to `https://<AZURE_STORAGE_ACCOUNT_NAME>.blob.core.windows.net/laws-collection-sk`
 
 Run the default ZIP importer locally:
 
@@ -272,6 +301,12 @@ Local PostgreSQL state replay demo:
 ```powershell
 .\skills\start-postgres\scripts\start_postgres.ps1 -ProjectName laws-collector
 .\.conda\python.exe examples/laws_collector_zip_postgres_state_demo.py
+```
+
+Archive inventory demo:
+
+```powershell
+.\.conda\python.exe examples/laws_collector_archive_inventory_demo.py
 ```
 
 This PostgreSQL demo replays three ZIP-import states with visible logs:
@@ -345,6 +380,7 @@ A minimal metadata/relations parsing example is also available:
 Add these to `.env` when you start wiring the service into real runs:
 
 - `LAWS_COLLECTOR_IMPORT=zip`
+- `LAWS_STORAGE_CLOUD=https://<storage-account>.blob.core.windows.net/laws-collection-sk` for durable ZIP source storage on Azure
 - `LAWS_DB_BACKEND=sqlite`
 - `LAWS_DB_LOCAL=./runs/storage/laws-collector/sqlite/sk_laws.sqlite3`
 - `LAWS_STORAGE_LOCAL=./runs/storage/laws-collector/files/sk`
@@ -354,7 +390,7 @@ Add these to `.env` when you start wiring the service into real runs:
 
 For Slovakia:
 
-- `zip` is the default import mode and stores downloaded bundles under `./archivelaws/slovakia`
+- `zip` is the default import mode and stores downloaded bundles under `./archivelaws/laws-collection-sk`
 - `one_law_url` keeps the older sequential Slov-Lex crawl that always starts from `1/1993`
 
 For PostgreSQL naming, keep the database mapping country-specific:

--- a/docs/LAWS_COLLECTOR_ARCHITECTURE.md
+++ b/docs/LAWS_COLLECTOR_ARCHITECTURE.md
@@ -23,6 +23,7 @@ Current implementation status:
 - `src/services/laws_collector/import_planner.py`
 - `src/services/laws_collector/slovlex_process.py`
 - `src/services/laws_collector/slovlex_live_source.py`
+- `src/services/laws_collector/source_artifact_storage.py`
 - `src/services/laws_collector/sqlite_store.py`
 - `src/services/laws_collector/postgres_store.py`
 - `infra/scripts/deploy_laws_collector.ps1`
@@ -277,6 +278,8 @@ erDiagram
         string artifact_kind
         string source_url
         string checksum
+        string storage_backend
+        string storage_path
         string http_etag
         string http_last_modified
         string verification_status
@@ -312,7 +315,7 @@ flowchart TB
     PROV["law_provisions\nprovision anchors and text"]
     META["law_metadata\nstructured law card fields"]
     REL["law_metadata_relations\ndependency graph edges"]
-    ART["source_artifacts\nHTML/PDF raw provenance"]
+    ART["source_artifacts\nHTML/PDF provenance + storage reference"]
     EVT["update_events\ningest audit trail"]
     PROG["collector_progress\nlegacy sequential cursor"]
     ZIPPROG["collector_import_state\narchive/monthly ZIP cursors"]

--- a/docs/SLOVAK_LAW_DATA_PLATFORM.md
+++ b/docs/SLOVAK_LAW_DATA_PLATFORM.md
@@ -53,7 +53,7 @@ Recommended core tables:
 | `law_versions` | One row per published or effective-time version of an act. |
 | `law_provisions` | Normalized sections, paragraphs, letters, annexes. |
 | `law_relationships` | Amendment, repeal, reference, implementing-regulation links. |
-| `source_artifacts` | HTML/PDF payloads, checksum, fetch time, source URL, ETag, download state. |
+| `source_artifacts` | Searchable text plus HTML/PDF storage references, checksum, fetch time, source URL, ETag, download state. |
 | `update_events` | Discovered change, parser result, publish result, failure state. |
 | `legislative_proposals` | Draft-bill metadata from NR SR before publication in Slov-Lex. |
 
@@ -86,7 +86,7 @@ For each discovered act:
 1. Capture source URL, act number, publication date, effective date, and author.
 2. Download the informative HTML and the legally binding PDF.
 3. Normalize structure into sections, paragraphs, points, letters, and annexes.
-4. Persist the source artifact bodies, parsed structure, and search segments inside the database.
+4. Persist original source artifacts in storage, store their references in the database, and keep parsed structure and search segments in the database.
 5. Build citation anchors so agents can cite `act + paragraph + effective version + source URL`.
 
 ### 2. Incremental update job

--- a/examples/law_citation_resolution_demo.py
+++ b/examples/law_citation_resolution_demo.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+
+
+def main() -> int:
+    sample_payload = {
+        "metadata": {
+            "law_citations": [
+                {
+                    "law_identifier": "1/1993 Z. z.",
+                    "title": "Prvy zakon",
+                    "version_token": "19930101",
+                    "effective_from": "1993-01-01",
+                    "open_url": (
+                        "/v1/laws/source?country_code=SK&collection_code=ZZ"
+                        "&law_year=1993&law_number=1&version_token=19930101&artifact_kind=html"
+                    ),
+                    "summary": (
+                        "1/1993 Z. z. (Prvy zakon), version 19930101, "
+                        "effective from 1993-01-01"
+                    ),
+                }
+            ]
+        }
+    }
+    print(json.dumps(sample_payload, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/laws_collector_archive_inventory_demo.py
+++ b/examples/laws_collector_archive_inventory_demo.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+import shutil
+import sqlite3
+import zipfile
+
+from aijurisdictionagents.llm.embeddings import MockEmbeddingClient
+from services.laws_collector import LawsCollectorConfig, SlovakLawsCollectorService, SqliteLawStore
+from services.laws_collector.slovlex_zip_import import (
+    SlovLexExportIndex,
+    SlovLexMonthlyExport,
+    SlovLexZipImportRunner,
+)
+
+
+def main() -> int:
+    temp_root = Path("runs/storage/laws-collector/archive-inventory-demo")
+    if temp_root.exists():
+        shutil.rmtree(temp_root)
+    temp_root.mkdir(parents=True, exist_ok=True)
+
+    db_path = temp_root / "laws.sqlite3"
+    zip_path = temp_root / "exportZmeny.zip"
+    _create_monthly_zip(zip_path)
+
+    config = LawsCollectorConfig(
+        country_code="SK",
+        db_backend="sqlite",
+        db_local=str(db_path),
+        db_cloud="",
+        storage_local="",
+        storage_cloud="",
+        delta_poll_hours=3,
+        initial_import_from=date(1993, 1, 1),
+        historical_import_from=date(1993, 1, 1),
+        import_mode="zip",
+    )
+    store = SqliteLawStore.from_config(config)
+    store.initialize()
+    service = SlovakLawsCollectorService(
+        config=config,
+        store=store,
+        embedding_client=MockEmbeddingClient(),
+    )
+
+    class FakeIndexLoader:
+        def load(self, *, timeout_seconds: float = 30.0) -> SlovLexExportIndex:
+            return SlovLexExportIndex(
+                archive_export=None,
+                monthly_export=SlovLexMonthlyExport(
+                    range_start="2026-03-01",
+                    range_end="2026-04-01",
+                    zip_url=zip_path.resolve().as_uri(),
+                ),
+            )
+
+    summary = SlovLexZipImportRunner(
+        config=config,
+        store=store,
+        service=service,
+        export_index_loader=FakeIndexLoader(),
+    ).run()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            """
+            SELECT import_key, asset_name, storage_backend, storage_path, checksum, processing_status
+            FROM archive_import_assets
+            ORDER BY asset_name
+            """
+        ).fetchall()
+
+    print(
+        f"summary processed={summary.sync_summary.processed} "
+        f"entries_processed={summary.entries_processed} monthly_completed={summary.monthly_completed}"
+    )
+    for row in rows:
+        print(
+            "asset "
+            f"import_key={row['import_key']} asset_name={row['asset_name']} "
+            f"storage_backend={row['storage_backend']} status={row['processing_status']} "
+            f"path={row['storage_path']} checksum={row['checksum']}"
+        )
+
+    return 0
+
+
+def _create_monthly_zip(zip_path: Path) -> None:
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+    html = """
+    <html>
+      <body>
+        <h1>1/1993 Z. z.</h1>
+        <table id="InfoTable">
+          <tr><td class="title">Číslo predpisu:</td><td class="value_bold">1/1993 Z. z.</td></tr>
+          <tr><td class="title">Názov:</td><td class="value">Prvy zakon</td></tr>
+          <tr><td class="title">Typ:</td><td class="value_bold">Zákon</td></tr>
+          <tr><td class="title">Dátum vyhlásenia:</td><td class="value_bold">01.01.1993</td></tr>
+          <tr><td class="title">Dátum účinnosti od:</td><td class="value">01.01.1993</td></tr>
+        </table>
+        <tr class="effectivenessHistoryItem" data-iri="/SK/ZZ/1993/1/19930101" data-vyhlasene="0" data-ucinnostod="1993-01-01" data-ucinnostdo=""></tr>
+        <div class="text" id="paragraf-1.odsek-1.text">Ukazkove ustanovenie.</div>
+        <div id="iri" data-iri="/SK/ZZ/1993/1/19930101"></div>
+      </body>
+    </html>
+    """
+    with zipfile.ZipFile(zip_path, "w") as archive:
+        archive.writestr("changed/SK/ZZ/1993/1/19930101.html", html)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/laws_collector_artifact_storage_demo.py
+++ b/examples/laws_collector_artifact_storage_demo.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+import sqlite3
+
+from aijurisdictionagents.llm.embeddings import MockEmbeddingClient
+from services.laws_collector import LawsCollectorConfig, SlovakLawsCollectorService, SqliteLawStore
+from services.laws_collector.slovak_source_fixtures import baseline_snapshots
+
+
+def main() -> None:
+    demo_root = Path("runs/storage/laws-collector/demo-artifacts")
+    config = LawsCollectorConfig(
+        country_code="SK",
+        db_backend="sqlite",
+        db_local=str(demo_root / "sqlite" / "laws.sqlite3"),
+        db_cloud="",
+        storage_local=str(demo_root / "files"),
+        storage_cloud="",
+        delta_poll_hours=3,
+        initial_import_from=date(1993, 1, 1),
+        historical_import_from=date(1993, 1, 1),
+    )
+    store = SqliteLawStore.from_config(config)
+    store.initialize()
+    service = SlovakLawsCollectorService(
+        config=config,
+        store=store,
+        embedding_client=MockEmbeddingClient(),
+    )
+    snapshot = baseline_snapshots()[0]
+    service.sync((snapshot,))
+
+    with sqlite3.connect(config.db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            """
+            SELECT artifact_kind, storage_backend, storage_path, content_bytes
+            FROM source_artifacts
+            ORDER BY artifact_kind
+            """
+        ).fetchall()
+
+    print("Database:", config.db_path)
+    for row in rows:
+        storage_path = Path(str(row["storage_path"]))
+        print(
+            f"{row['artifact_kind']}: backend={row['storage_backend']} "
+            f"bytes={row['content_bytes']} path={storage_path}"
+        )
+        print("  exists:", storage_path.exists())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/laws_collector_live_first_law_demo.py
+++ b/examples/laws_collector_live_first_law_demo.py
@@ -41,7 +41,9 @@ def main() -> None:
                    v.version_token, v.embedding_model, v.embedding_dimensions, v.embedding_vector,
                    m.law_type, m.author, m.legal_areas_json,
                    COUNT(r.law_metadata_relation_id) AS relation_count,
-                   LENGTH(a.content_text) AS html_text_length
+                   LENGTH(a.content_text) AS html_text_length,
+                   a.storage_backend,
+                   a.storage_path
             FROM law_documents AS d
             JOIN law_versions AS v ON v.document_id = d.document_id
             LEFT JOIN law_metadata AS m ON m.version_id = v.version_id
@@ -52,7 +54,8 @@ def main() -> None:
               AND d.law_year = 1993 AND d.law_number = 1
             GROUP BY d.law_year, d.law_number, d.official_name, d.last_download_status,
                      v.version_token, v.embedding_model, v.embedding_dimensions, v.embedding_vector,
-                     m.law_type, m.author, m.legal_areas_json, a.content_text, v.created_at
+                     m.law_type, m.author, m.legal_areas_json, a.content_text, a.storage_backend,
+                     a.storage_path, v.created_at
             ORDER BY v.created_at
             LIMIT 1
             """
@@ -85,6 +88,8 @@ def main() -> None:
         print("Legal areas:", law_row[10] or "[]")
         print("Relation count:", law_row[11])
         print("Stored text length:", law_row[12])
+        print("Artifact backend:", law_row[13] or "")
+        print("Artifact path:", law_row[14] or "")
     if progress_row is None:
         print("Collector progress: missing")
     else:

--- a/examples/laws_collector_zip_postgres_state_demo.py
+++ b/examples/laws_collector_zip_postgres_state_demo.py
@@ -1,0 +1,392 @@
+"""Replay SlovLex ZIP-import states against local PostgreSQL.
+
+Run:
+    python examples/laws_collector_zip_postgres_state_demo.py
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import date
+from pathlib import Path
+import logging
+import shutil
+import sys
+import tempfile
+import zipfile
+
+import psycopg
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+LOG_PATH = REPO_ROOT / "runs" / "laws-collector-zip-postgres-demo.log"
+SERVER_URI = "postgresql://postgres:postgres@127.0.0.1:5433"
+SCENARIO_DATABASE = "laws_zip_demo"
+
+
+class DemoIndexLoader:
+    def __init__(
+        self,
+        *,
+        archive_export,
+        monthly_export,
+    ) -> None:
+        self.archive_export = archive_export
+        self.monthly_export = monthly_export
+
+    def load(self, *, timeout_seconds: float = 30.0):
+        from services.laws_collector.slovlex_zip_import import SlovLexExportIndex
+
+        return SlovLexExportIndex(
+            archive_export=self.archive_export,
+            monthly_export=self.monthly_export,
+        )
+
+
+def main() -> None:
+    _configure_logging()
+    print(f"Logs: {LOG_PATH}")
+    for scenario in (
+        _run_archive_then_monthly_scenario,
+        _run_monthly_only_after_archive_scenario,
+        _run_skip_when_monthly_already_completed_scenario,
+    ):
+        scenario()
+
+
+def _run_archive_then_monthly_scenario() -> None:
+    from services.laws_collector.slovlex_zip_import import (
+        SlovLexArchiveExport,
+        SlovLexMonthlyExport,
+        SlovLexZipImportRunner,
+    )
+
+    _reset_demo_database()
+    config, store, service = _build_postgres_service()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_root = Path(temp_dir)
+        archive_zip = temp_root / "archive" / "export.zip"
+        monthly_zip = temp_root / "monthly" / "exportZmeny.zip"
+        _create_zip(
+            archive_zip,
+            laws=[
+                (1993, 1, "Prvy zakon", "1993-01-01"),
+                (1993, 2, "Druhy zakon", "1993-02-01"),
+            ],
+        )
+        _create_zip(
+            monthly_zip,
+            laws=[
+                (1993, 3, "Treti zakon", "1993-03-01"),
+            ],
+        )
+        summary = SlovLexZipImportRunner(
+            config=config,
+            store=store,
+            service=service,
+            export_index_loader=DemoIndexLoader(
+                archive_export=SlovLexArchiveExport(
+                    snapshot_date="2026-04-01",
+                    part_urls=(archive_zip.resolve().as_uri(),),
+                ),
+                monthly_export=SlovLexMonthlyExport(
+                    range_start="2026-04-02",
+                    range_end="2026-04-15",
+                    zip_url=monthly_zip.resolve().as_uri(),
+                ),
+            ),
+        ).run()
+    _print_scenario_result(
+        title="Scenario 1: fresh database imports archive first and then monthly update",
+        store=store,
+        summary=summary,
+        archive_key="slov-lex:zip:archive-seed",
+        monthly_key="slov-lex:zip:monthly:2026-04-02_2026-04-15",
+    )
+
+
+def _run_monthly_only_after_archive_scenario() -> None:
+    from services.laws_collector.domain import CollectorImportState
+    from services.laws_collector.slovlex_zip_import import (
+        SlovLexArchiveExport,
+        SlovLexMonthlyExport,
+        SlovLexZipImportRunner,
+    )
+
+    _reset_demo_database()
+    config, store, service = _build_postgres_service()
+    store.upsert_import_state(
+        CollectorImportState(
+            country_code="SK",
+            source_system="slov-lex",
+            import_key="slov-lex:zip:archive-seed",
+            import_label="archive seed 2026-05-01",
+            source_url="file://seeded/archive/export.zip",
+            status="completed",
+            started_at="2026-05-01T00:00:00Z",
+            last_processed_at="2026-05-01T00:00:00Z",
+            last_processed_entry="changed/SK/ZZ/1993/2/19930201.html",
+            last_processed_law_year=1993,
+            last_processed_law_number=2,
+            completed_at="2026-05-01T00:00:00Z",
+            metadata={"archive_snapshot_date": "2026-05-01", "phase": "archive"},
+        )
+    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_root = Path(temp_dir)
+        monthly_zip = temp_root / "monthly" / "exportZmeny.zip"
+        _create_zip(
+            monthly_zip,
+            laws=[
+                (1993, 4, "Stvrty zakon", "1993-04-01"),
+            ],
+        )
+        summary = SlovLexZipImportRunner(
+            config=config,
+            store=store,
+            service=service,
+            export_index_loader=DemoIndexLoader(
+                archive_export=SlovLexArchiveExport(
+                    snapshot_date="2026-05-01",
+                    part_urls=("file://seeded/archive/export.zip",),
+                ),
+                monthly_export=SlovLexMonthlyExport(
+                    range_start="2026-05-02",
+                    range_end="2026-05-15",
+                    zip_url=monthly_zip.resolve().as_uri(),
+                ),
+            ),
+        ).run()
+    _print_scenario_result(
+        title="Scenario 2: archive is already completed so startup imports monthly update only",
+        store=store,
+        summary=summary,
+        archive_key="slov-lex:zip:archive-seed",
+        monthly_key="slov-lex:zip:monthly:2026-05-02_2026-05-15",
+    )
+
+
+def _run_skip_when_monthly_already_completed_scenario() -> None:
+    from services.laws_collector.domain import CollectorImportState
+    from services.laws_collector.slovlex_zip_import import (
+        SlovLexArchiveExport,
+        SlovLexMonthlyExport,
+        SlovLexZipImportRunner,
+    )
+
+    _reset_demo_database()
+    config, store, service = _build_postgres_service()
+    store.upsert_import_state(
+        CollectorImportState(
+            country_code="SK",
+            source_system="slov-lex",
+            import_key="slov-lex:zip:archive-seed",
+            import_label="archive seed 2026-06-01",
+            source_url="file://seeded/archive/export.zip",
+            status="completed",
+            started_at="2026-06-01T00:00:00Z",
+            last_processed_at="2026-06-01T00:00:00Z",
+            last_processed_entry="changed/SK/ZZ/1993/2/19930201.html",
+            last_processed_law_year=1993,
+            last_processed_law_number=2,
+            completed_at="2026-06-01T00:00:00Z",
+            metadata={"archive_snapshot_date": "2026-06-01", "phase": "archive"},
+        )
+    )
+    store.upsert_import_state(
+        CollectorImportState(
+            country_code="SK",
+            source_system="slov-lex",
+            import_key="slov-lex:zip:monthly:2026-06-02_2026-06-15",
+            import_label="monthly 2026-06-02..2026-06-15",
+            source_url="file://seeded/monthly/exportZmeny.zip",
+            status="completed",
+            started_at="2026-06-15T00:00:00Z",
+            last_processed_at="2026-06-15T00:00:00Z",
+            last_processed_entry="changed/SK/ZZ/1993/4/19930401.html",
+            last_processed_law_year=1993,
+            last_processed_law_number=4,
+            completed_at="2026-06-15T00:00:00Z",
+            metadata={
+                "monthly_range_start": "2026-06-02",
+                "monthly_range_end": "2026-06-15",
+                "phase": "monthly",
+            },
+        )
+    )
+    summary = SlovLexZipImportRunner(
+        config=config,
+        store=store,
+        service=service,
+        export_index_loader=DemoIndexLoader(
+            archive_export=SlovLexArchiveExport(
+                snapshot_date="2026-06-01",
+                part_urls=("file://seeded/archive/export.zip",),
+            ),
+            monthly_export=SlovLexMonthlyExport(
+                range_start="2026-06-02",
+                range_end="2026-06-15",
+                zip_url="file://seeded/monthly/exportZmeny.zip",
+            ),
+        ),
+    ).run()
+    _print_scenario_result(
+        title="Scenario 3: monthly update is already completed and no newer one exists, so import is skipped",
+        store=store,
+        summary=summary,
+        archive_key="slov-lex:zip:archive-seed",
+        monthly_key="slov-lex:zip:monthly:2026-06-02_2026-06-15",
+    )
+
+
+def _build_postgres_service():
+    from aijurisdictionagents.llm.embeddings import MockEmbeddingClient
+    from services.laws_collector import LawsCollectorConfig, PostgresLawStore, SlovakLawsCollectorService
+
+    db_uri = f"{SERVER_URI}/{SCENARIO_DATABASE}"
+    config = LawsCollectorConfig(
+        country_code="SK",
+        db_backend="postgres",
+        db_local="",
+        db_cloud=db_uri,
+        storage_local="",
+        storage_cloud="",
+        delta_poll_hours=3,
+        initial_import_from=date(1993, 1, 1),
+        historical_import_from=date(1993, 1, 1),
+        import_mode="zip",
+    )
+    store = PostgresLawStore.from_config(config)
+    service = SlovakLawsCollectorService(
+        config=config,
+        store=store,
+        embedding_client=MockEmbeddingClient(),
+    )
+    return config, store, service
+
+
+def _reset_demo_database() -> None:
+    from aijurisdictionagents.db_migrations import apply_sql_migrations
+
+    _clean_demo_archive_folders()
+    maintenance_uri = f"{SERVER_URI}/postgres"
+    with psycopg.connect(maintenance_uri, autocommit=True) as conn:
+        conn.execute(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = %s AND pid <> pg_backend_pid()
+            """,
+            (SCENARIO_DATABASE,),
+        )
+        conn.execute(f'DROP DATABASE IF EXISTS "{SCENARIO_DATABASE}"')
+        conn.execute(f'CREATE DATABASE "{SCENARIO_DATABASE}"')
+    apply_sql_migrations(
+        project="laws",
+        db_option="postgres",
+        target=f"{SERVER_URI}/{SCENARIO_DATABASE}",
+    )
+
+
+def _clean_demo_archive_folders() -> None:
+    for suffix in (
+        REPO_ROOT / "archivelaws" / "slovakia" / "archive" / "2026-04-01",
+        REPO_ROOT / "archivelaws" / "slovakia" / "archive" / "2026-05-01",
+        REPO_ROOT / "archivelaws" / "slovakia" / "archive" / "2026-06-01",
+        REPO_ROOT / "archivelaws" / "slovakia" / "monthly" / "2026-04-15",
+        REPO_ROOT / "archivelaws" / "slovakia" / "monthly" / "2026-05-15",
+        REPO_ROOT / "archivelaws" / "slovakia" / "monthly" / "2026-06-15",
+    ):
+        shutil.rmtree(suffix, ignore_errors=True)
+
+
+def _create_zip(
+    zip_path: Path,
+    *,
+    laws: list[tuple[int, int, str, str]],
+) -> None:
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path, "w") as archive:
+        for year, number, title, effective_from in laws:
+            archive.writestr(
+                f"changed/SK/ZZ/{year}/{number}/{effective_from.replace('-', '')}.html",
+                _build_html(
+                    year=year,
+                    number=number,
+                    title=title,
+                    effective_from=effective_from,
+                ),
+            )
+
+
+def _build_html(*, year: int, number: int, title: str, effective_from: str) -> str:
+    return f"""
+    <html>
+      <body>
+        <h1>{number}/{year} Z. z.</h1>
+        <table id="InfoTable">
+          <tr><td class="title">Číslo predpisu:</td><td class="value_bold">{number}/{year} Z. z.</td></tr>
+          <tr><td class="title">Názov:</td><td class="value">{title}</td></tr>
+          <tr><td class="title">Typ:</td><td class="value_bold">Zákon</td></tr>
+          <tr><td class="title">Dátum vyhlásenia:</td><td class="value_bold">01.01.{year}</td></tr>
+          <tr><td class="title">Dátum účinnosti od:</td><td class="value">{effective_from[8:10]}.{effective_from[5:7]}.{effective_from[0:4]}</td></tr>
+        </table>
+        <tr class="effectivenessHistoryItem" data-iri="/SK/ZZ/{year}/{number}/{effective_from.replace('-', '')}" data-vyhlasene="0" data-ucinnostod="{effective_from}" data-ucinnostdo=""></tr>
+        <div class="text" id="paragraf-1.odsek-1.text">Ukážkový text pre {title}.</div>
+      </body>
+    </html>
+    """
+
+
+def _print_scenario_result(
+    *,
+    title: str,
+    store,
+    summary,
+    archive_key: str,
+    monthly_key: str,
+) -> None:
+    archive_state = store.get_import_state(country_code="SK", import_key=archive_key)
+    monthly_state = store.get_import_state(country_code="SK", import_key=monthly_key)
+    counts = store.get_counts()
+    print("")
+    print(title)
+    print(f"  phase={summary.phase}")
+    print(f"  entries_processed={summary.entries_processed}")
+    print(f"  processed={summary.sync_summary.processed}")
+    print(f"  new_documents={summary.sync_summary.new_documents}")
+    print(f"  archive_completed={str(summary.archive_completed).lower()}")
+    print(f"  monthly_completed={str(summary.monthly_completed).lower()}")
+    print(f"  skipped_as_already_completed={str(summary.skipped_as_already_completed).lower()}")
+    print(f"  last_processed_law={summary.last_processed_law or ''}")
+    print(f"  counts={asdict(counts)}")
+    print(f"  archive_state={_format_state(archive_state)}")
+    print(f"  monthly_state={_format_state(monthly_state)}")
+
+def _format_state(state) -> str:
+    if state is None:
+        return "missing"
+    return (
+        f"status={state.status}, "
+        f"last_processed_law={state.last_processed_law or ''}, "
+        f"last_processed_entry={state.last_processed_entry or ''}, "
+        f"completed_at={state.completed_at or ''}"
+    )
+
+
+def _configure_logging() -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(message)s",
+        handlers=[
+            logging.StreamHandler(sys.stdout),
+            logging.FileHandler(LOG_PATH, mode="w", encoding="utf-8"),
+        ],
+        force=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/README.md
+++ b/infra/README.md
@@ -450,7 +450,7 @@ A dedicated deployment script and Bicep template are available for the laws coll
 - Script: `infra/scripts/deploy_laws_collector.ps1`
 - Template: `infra/bicep/laws_collector.job.bicep`
 
-The deployment creates/updates a scheduled ACA Job named `laws-collector` (by default), assigns ACR pull identity, and configures runtime environment variables for PostgreSQL-backed ingestion.
+The deployment creates/updates a scheduled ACA Job named `laws-collector` (by default), assigns ACR pull identity plus Storage Blob Data Contributor on the selected storage account, and configures runtime environment variables for PostgreSQL-backed ingestion.
 Before updating the ACA job, the deploy path applies the laws collector PostgreSQL schema migrations to `AZURE_LAWS_POSTGRES_DATABASE_NAME_SK` or the explicit `-PostgresDatabaseName` override.
 
 Run from repository root:
@@ -483,9 +483,12 @@ GitHub Actions workflow:
 Required GitHub Environment variables/secrets for deployment:
 
 - Variables: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_RESOURCE_GROUP`, `AZURE_LOCATION`, `AZURE_CONTAINERAPPS_ENVIRONMENT`, `AZURE_CONTAINER_REGISTRY`, `AZURE_MANAGED_IDENTITY_NAME`, `AZURE_POSTGRES_SERVER_NAME`, `AZURE_POSTGRES_ADMIN_USERNAME`
+- Variables: `AZURE_STORAGE_ACCOUNT_NAME`
 - Secrets: `AZURE_POSTGRES_ADMIN_PASSWORD`
 - Optional variables: `AZURE_LAWS_COLLECTOR_CONTAINER_APP_NAME`, `AZURE_LAWS_COLLECTOR_MAX_PROBES`, `AZURE_LAWS_POSTGRES_DATABASE_NAME_SK`, `SYSTEM_EMBEDDING_MODEL_OPTION`, `SYSTEM_EMBEDDING_MODEL`
+- Optional variables: `AZURE_LAWS_STORAGE_CONTAINER_NAME` with default `laws-collection-sk`
 - Optional variables: `LAWS_COLLECTOR_IMPORT` with default `zip` (`one_law_url` keeps the older sequential probe importer)
+- Optional variables: `LAWS_STORAGE_CLOUD` to override the derived blob container URL
 - Optional schedule variable: `AZURE_LAWS_COLLECTOR_CRON_EXPRESSION` with default `0 0 * * *`
 
 Recommended GitHub Environment values:
@@ -493,12 +496,15 @@ Recommended GitHub Environment values:
 - `AZURE_LAWS_COLLECTOR_CONTAINER_APP_NAME=laws-collector`
 - `AZURE_LAWS_COLLECTOR_CRON_EXPRESSION=0 0 * * *`
 - `AZURE_LAWS_COLLECTOR_MAX_PROBES=1`
+- `AZURE_LAWS_STORAGE_CONTAINER_NAME=laws-collection-sk`
 - `AZURE_LAWS_POSTGRES_DATABASE_NAME_SK=laws_sk`
 - `LAWS_COLLECTOR_IMPORT=zip`
+- Leave `LAWS_STORAGE_CLOUD` unset unless you need a non-default container URL. The deploy derives `https://<AZURE_STORAGE_ACCOUNT_NAME>.blob.core.windows.net/laws-collection-sk` automatically.
 - `SYSTEM_EMBEDDING_MODEL_OPTION=local` by default, or `SYSTEM_EMBEDDING_MODEL_OPTION=cloud` if you want Azure/OpenAI embeddings
 - `SYSTEM_EMBEDDING_MODEL=all-MiniLM-L6-v2`
 - When `SYSTEM_EMBEDDING_MODEL_OPTION=local`, the deploy script prefetches the model into `aimodels/` before `az acr build`, and the Docker image bakes that cache into `/app/aimodels`.
-- `LAWS_COLLECTOR_IMPORT=zip` makes the Azure job bootstrap from the full Slov-Lex archive under `./archivelaws/slovakia`, mark that seed import complete once, and then continue only from monthly `exportZmeny.zip` bundles with resume support.
+- `LAWS_COLLECTOR_IMPORT=zip` makes the Azure job bootstrap from the full Slov-Lex archive under `./archivelaws/laws-collection-sk`, mark that seed import complete once, and then continue only from monthly `exportZmeny.zip` bundles with resume support.
+- ZIP source bundles are now tracked in `archive_import_assets`. On Azure, the job persists them to the configured blob container and records the blob URL plus checksum and processing status for audit/reprocessing.
 - The GitHub runner must install the root package before that prefetch step so dependencies such as `sentence-transformers` are available.
 
 Azure Container Apps Jobs use 5-field cron expressions. The deploy paths also accept legacy 6-field values with a leading `0` seconds field and normalize them automatically.

--- a/infra/bicep/laws_collector.job.bicep
+++ b/infra/bicep/laws_collector.job.bicep
@@ -4,6 +4,8 @@ param jobName string = 'laws-collector'
 param acrName string
 param managedIdentityName string
 param image string
+param storageAccountName string = ''
+param storageContainerName string = 'laws-collection-sk'
 param postgresServerName string
 param postgresDatabaseName string = 'laws_sk'
 param postgresAdminUsername string
@@ -13,6 +15,7 @@ param postgresAdminPassword string
 param postgresConnectionString string = ''
 @secure()
 param applicationInsightsConnectionString string = ''
+param lawsStorageCloud string = ''
 param lawsCollectorImport string = 'zip'
 param systemEmbeddingModelOption string = 'local'
 param systemEmbeddingModel string = 'all-MiniLM-L6-v2'
@@ -37,6 +40,20 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-
   name: managedIdentityName
 }
 
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = if (!empty(storageAccountName)) {
+  name: storageAccountName
+}
+
+resource storageBlobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' existing = if (!empty(storageAccountName)) {
+  parent: storageAccount
+  name: 'default'
+}
+
+resource storageContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = if (!empty(storageAccountName)) {
+  parent: storageBlobService
+  name: storageContainerName
+}
+
 resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' existing = {
   name: postgresServerName
 }
@@ -53,6 +70,25 @@ resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-
     principalType: 'ServicePrincipal'
   }
 }
+
+resource storageBlobDataRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(storageAccountName)) {
+  name: guid(storageAccount.id, managedIdentity.id, 'StorageBlobDataContributor')
+  scope: storageAccount
+  properties: {
+    principalId: managedIdentity.properties.principalId
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+    )
+    principalType: 'ServicePrincipal'
+  }
+}
+
+var lawsStorageCloudValue = !empty(lawsStorageCloud)
+  ? lawsStorageCloud
+  : (!empty(storageAccountName)
+      ? 'https://${storageAccount.name}.blob.core.windows.net/${storageContainerName}'
+      : '')
 
 resource lawsCollectorJob 'Microsoft.App/jobs@2024-03-01' = {
   name: jobName
@@ -124,6 +160,10 @@ resource lawsCollectorJob 'Microsoft.App/jobs@2024-03-01' = {
                 secretRef: 'laws-db-cloud'
               }
               {
+                name: 'AZURE_CLIENT_ID'
+                value: managedIdentity.properties.clientId
+              }
+              {
                 name: 'LAWS_WORKER_FIXTURE'
                 value: 'live'
               }
@@ -152,6 +192,14 @@ resource lawsCollectorJob 'Microsoft.App/jobs@2024-03-01' = {
                 value: systemEmbeddingModel
               }
             ],
+            !empty(lawsStorageCloudValue)
+              ? [
+                  {
+                    name: 'LAWS_STORAGE_CLOUD'
+                    value: lawsStorageCloudValue
+                  }
+                ]
+              : [],
             !empty(applicationInsightsConnectionString)
               ? [
                   {
@@ -167,6 +215,7 @@ resource lawsCollectorJob 'Microsoft.App/jobs@2024-03-01' = {
   }
   dependsOn: [
     acrPullRoleAssignment
+    storageBlobDataRoleAssignment
   ]
 }
 

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -13,6 +13,7 @@ param lawsCollectorImport string = 'zip'
 param acrName string
 param storageAccountName string = toLower('staijur${uniqueString(subscription().subscriptionId, resourceGroup().name)}')
 param storageContainerName string = 'case-documents'
+param lawsStorageContainerName string = 'laws-collection-sk'
 param logAnalyticsWorkspaceName string
 param applicationInsightsName string
 param managedIdentityName string
@@ -486,6 +487,8 @@ module documentProcessorJob 'document_processor.job.bicep' = if (createDocumentP
     acrName: acrName
     managedIdentityName: managedIdentityName
     image: 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+    storageAccountName: storageAccountName
+    storageContainerName: storageContainerName
     postgresServerName: postgresServerName
     postgresDatabaseName: postgresDatabaseName
     postgresAdminUsername: postgresAdminUsername
@@ -494,8 +497,6 @@ module documentProcessorJob 'document_processor.job.bicep' = if (createDocumentP
     applicationInsightsConnectionString: createApplicationInsights
       ? applicationInsights.properties.ConnectionString
       : applicationInsightsExisting.properties.ConnectionString
-    storageAccountName: storageAccountName
-    storageContainerName: storageContainerName
     llmProvider: llmProvider
     systemEmbeddingModelOption: systemEmbeddingModelOption
     systemEmbeddingModel: systemEmbeddingModel
@@ -530,6 +531,8 @@ module lawsCollectorJob 'laws_collector.job.bicep' = if (createLawsCollectorJob)
     acrName: acrName
     managedIdentityName: managedIdentityName
     image: 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+    storageAccountName: storageAccountName
+    storageContainerName: lawsStorageContainerName
     postgresServerName: postgresServerName
     postgresDatabaseName: lawsPostgresDatabaseName
     postgresAdminUsername: postgresAdminUsername
@@ -553,6 +556,8 @@ module lawsCollectorJob 'laws_collector.job.bicep' = if (createLawsCollectorJob)
     postgresServer
     lawsPostgresDatabaseOnNewServer
     lawsPostgresDatabaseOnExistingServer
+    storageContainerOnNewStorage
+    storageContainerOnExistingStorage
   ]
 }
 

--- a/infra/scripts/deploy_laws_collector.ps1
+++ b/infra/scripts/deploy_laws_collector.ps1
@@ -7,11 +7,14 @@ param(
     [string]$ContainerAppName = "laws-collector",
     [string]$AcrName,
     [string]$ManagedIdentityName,
+    [string]$StorageAccountName,
+    [string]$StorageContainerName = "laws-collection-sk",
     [string]$PostgresServerName,
     [string]$PostgresDatabaseName = "laws_sk",
     [string]$PostgresAdminUsername,
     [string]$PostgresAdminPassword,
     [string]$ApplicationInsightsName,
+    [string]$LawsStorageCloud,
     [string]$LawsCollectorImport = "zip",
     [string]$SystemEmbeddingModelOption = "local",
     [string]$SystemEmbeddingModel = "all-MiniLM-L6-v2",
@@ -205,11 +208,14 @@ $envLocation = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFi
 $envContainerEnv = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_CONTAINERAPPS_ENVIRONMENT" }
 $envAcr = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_CONTAINER_REGISTRY" }
 $envIdentity = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_MANAGED_IDENTITY_NAME" }
+$envStorageAccountName = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_STORAGE_ACCOUNT_NAME" }
+$envStorageContainerName = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_LAWS_STORAGE_CONTAINER_NAME" }
 $envPgServer = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_POSTGRES_SERVER_NAME" }
 $envPgDb = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_LAWS_POSTGRES_DATABASE_NAME_SK" }
 $envPgUser = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_POSTGRES_ADMIN_USERNAME" }
 $envPgPass = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_POSTGRES_ADMIN_PASSWORD" }
 $envApplicationInsightsName = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_APPLICATION_INSIGHTS_NAME" }
+$envLawsStorageCloud = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "LAWS_STORAGE_CLOUD" }
 $envLawsCollectorImport = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "LAWS_COLLECTOR_IMPORT" }
 $envSystemEmbeddingModelOption = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "SYSTEM_EMBEDDING_MODEL_OPTION" }
 $envSystemEmbeddingModel = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "SYSTEM_EMBEDDING_MODEL" }
@@ -222,11 +228,14 @@ $Location = Resolve-InputValue -ExplicitValue $Location -EnvFileValue $envLocati
 $ContainerAppEnvironmentName = Resolve-InputValue -ExplicitValue $ContainerAppEnvironmentName -EnvFileValue $envContainerEnv -EnvironmentValue $env:AZURE_CONTAINERAPPS_ENVIRONMENT
 $AcrName = Resolve-InputValue -ExplicitValue $AcrName -EnvFileValue $envAcr -EnvironmentValue $env:AZURE_CONTAINER_REGISTRY
 $ManagedIdentityName = Resolve-InputValue -ExplicitValue $ManagedIdentityName -EnvFileValue $envIdentity -EnvironmentValue $env:AZURE_MANAGED_IDENTITY_NAME
+$StorageAccountName = Resolve-InputValue -ExplicitValue $StorageAccountName -EnvFileValue $envStorageAccountName -EnvironmentValue $env:AZURE_STORAGE_ACCOUNT_NAME
+$StorageContainerName = Resolve-InputValue -ExplicitValue $StorageContainerName -EnvFileValue $envStorageContainerName -EnvironmentValue $env:AZURE_LAWS_STORAGE_CONTAINER_NAME
 $PostgresServerName = Resolve-InputValue -ExplicitValue $PostgresServerName -EnvFileValue $envPgServer -EnvironmentValue $env:AZURE_POSTGRES_SERVER_NAME
 $PostgresDatabaseName = Resolve-InputValue -ExplicitValue $PostgresDatabaseName -EnvFileValue $envPgDb -EnvironmentValue $env:AZURE_LAWS_POSTGRES_DATABASE_NAME_SK
 $PostgresAdminUsername = Resolve-InputValue -ExplicitValue $PostgresAdminUsername -EnvFileValue $envPgUser -EnvironmentValue $env:AZURE_POSTGRES_ADMIN_USERNAME
 $PostgresAdminPassword = Resolve-InputValue -ExplicitValue $PostgresAdminPassword -EnvFileValue $envPgPass -EnvironmentValue $env:AZURE_POSTGRES_ADMIN_PASSWORD
 $ApplicationInsightsName = Resolve-InputValue -ExplicitValue $ApplicationInsightsName -EnvFileValue $envApplicationInsightsName -EnvironmentValue $env:AZURE_APPLICATION_INSIGHTS_NAME
+$LawsStorageCloud = Resolve-InputValue -ExplicitValue $LawsStorageCloud -EnvFileValue $envLawsStorageCloud -EnvironmentValue $env:LAWS_STORAGE_CLOUD
 $LawsCollectorImport = Resolve-InputValue -ExplicitValue $LawsCollectorImport -EnvFileValue $envLawsCollectorImport -EnvironmentValue $env:LAWS_COLLECTOR_IMPORT
 $SystemEmbeddingModelOption = Resolve-InputValue -ExplicitValue $SystemEmbeddingModelOption -EnvFileValue $envSystemEmbeddingModelOption -EnvironmentValue $env:SYSTEM_EMBEDDING_MODEL_OPTION
 $SystemEmbeddingModel = Resolve-InputValue -ExplicitValue $SystemEmbeddingModel -EnvFileValue $envSystemEmbeddingModel -EnvironmentValue $env:SYSTEM_EMBEDDING_MODEL
@@ -247,6 +256,7 @@ if ([string]::IsNullOrWhiteSpace($LawsCollectorImport)) { $LawsCollectorImport =
 if ($LawsCollectorImport -notin @("one_law_url", "zip")) {
     throw "LawsCollectorImport must be one of: one_law_url, zip."
 }
+if ([string]::IsNullOrWhiteSpace($StorageContainerName)) { $StorageContainerName = "laws-collection-sk" }
 if ([string]::IsNullOrWhiteSpace($SystemEmbeddingModelOption)) { $SystemEmbeddingModelOption = "local" }
 if ([string]::IsNullOrWhiteSpace($SystemEmbeddingModel)) { $SystemEmbeddingModel = "all-MiniLM-L6-v2" }
 $CronExpression = Resolve-AcaCronExpression -Name "CronExpression" -Value $CronExpression -DefaultValue "0 0 * * *"
@@ -354,12 +364,15 @@ az deployment group create `
       acrName=$AcrName `
       managedIdentityName=$ManagedIdentityName `
       image=$image `
+      storageAccountName=$StorageAccountName `
+      storageContainerName=$StorageContainerName `
       postgresServerName=$PostgresServerName `
       postgresDatabaseName=$PostgresDatabaseName `
       postgresAdminUsername=$PostgresAdminUsername `
       postgresAdminPassword=$PostgresAdminPassword `
       postgresConnectionString=$dbCloud `
       applicationInsightsConnectionString=$applicationInsightsConnectionString `
+      lawsStorageCloud=$LawsStorageCloud `
       lawsCollectorImport=$LawsCollectorImport `
       systemEmbeddingModelOption=$SystemEmbeddingModelOption `
       systemEmbeddingModel=$SystemEmbeddingModel `

--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -205,7 +205,8 @@ In `Real Agent` mode, when the lawyer decides a formal document is needed, the a
 The mobile app now also resets document-export readiness to `false` when a fresh session result is unavailable, so a previous case cannot leave the `Documents` button enabled for a new conversation.
 In `AI User Simulator` mode, submitting the instruction starts discussion streaming (SSE)
 the same way as the chat simulator by using `user_simulation_mode=AIUserSimulatorAgent`.
-The app also reads `GET /v1/chat/sessions/{session_id}/result` metadata to show validation accuracy and the latest known legal-data update timestamp for the selected country.
+The app also reads `GET /v1/chat/sessions/{session_id}/result` metadata to show validation accuracy, the latest known legal-data update timestamp for the selected country, and version-specific `law_citations`.
+When citations are present, the mobile UI renders a dedicated legal-citations card. Tapping a citation opens the stored full-law source through the API `GET /v1/laws/source?...` endpoint, which serves the file from local storage or Azure Blob depending on how the laws collector imported it.
 
 
 ## Debug mode and log sharing (Android)

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -305,6 +305,11 @@ class AppStrings {
       'case_validation_title': 'Validacia pripadu',
       'validation_accuracy_label': 'Presnost',
       'validation_summary_label': 'Zhrnutie validacie',
+      'law_citations_title': 'Relevantné právne citácie',
+      'law_citation_open': 'Otvoriť plné znenie',
+      'law_citation_effective_from': 'Účinné od',
+      'law_citation_version': 'Verzia',
+      'law_citation_open_failed': 'Súbor zákona sa nepodarilo otvoriť.',
       'knowledge_updated_label': 'Pravne data aktualizovane',
       'model_version_label': 'Verzia modelu',
       'law_date_label': 'Law Date',
@@ -519,6 +524,11 @@ class AppStrings {
       'case_validation_title': 'Case validation',
       'validation_accuracy_label': 'Accuracy',
       'validation_summary_label': 'Validation summary',
+      'law_citations_title': 'Relevant legal citations',
+      'law_citation_open': 'Open full law',
+      'law_citation_effective_from': 'Effective from',
+      'law_citation_version': 'Version',
+      'law_citation_open_failed': 'Could not open the law file.',
       'knowledge_updated_label': 'Legal data updated',
       'model_version_label': 'Model version',
       'law_date_label': 'Law Date',
@@ -741,6 +751,12 @@ class AppStrings {
       'case_validation_title': 'Fallvalidierung',
       'validation_accuracy_label': 'Genauigkeit',
       'validation_summary_label': 'Validierungszusammenfassung',
+      'law_citations_title': 'Relevante Gesetzeszitate',
+      'law_citation_open': 'Vollständiges Gesetz öffnen',
+      'law_citation_effective_from': 'Wirksam ab',
+      'law_citation_version': 'Version',
+      'law_citation_open_failed':
+          'Die Gesetzesdatei konnte nicht geöffnet werden.',
       'knowledge_updated_label': 'Rechtsdaten aktualisiert',
       'model_version_label': 'Modellversion',
       'law_date_label': 'Law Date',
@@ -1422,6 +1438,7 @@ class SessionResultDetails {
     required this.validationSummary,
     required this.knowledgeLastUpdatedAt,
     required this.coreVersion,
+    required this.lawCitations,
   });
 
   final String finalRecommendation;
@@ -1431,6 +1448,7 @@ class SessionResultDetails {
   final String? validationSummary;
   final String? knowledgeLastUpdatedAt;
   final String? coreVersion;
+  final List<LawCitationDetails> lawCitations;
 
   bool get hasValidationData =>
       validationAccuracy != null ||
@@ -1443,6 +1461,8 @@ class SessionResultDetails {
     final metadata = Map<String, dynamic>.from(
       json['metadata'] as Map? ?? const <String, dynamic>{},
     );
+    final rawLawCitations =
+        metadata['law_citations'] as List? ?? const <Object>[];
     return SessionResultDetails(
       finalRecommendation: json['final_recommendation'] as String? ?? '',
       judgeRationale: json['judge_rationale'] as String? ?? '',
@@ -1451,6 +1471,41 @@ class SessionResultDetails {
       validationSummary: metadata['validation_summary'] as String?,
       knowledgeLastUpdatedAt: metadata['knowledge_last_updated_at'] as String?,
       coreVersion: metadata['core_version'] as String?,
+      lawCitations: rawLawCitations
+          .whereType<Map>()
+          .map((item) => LawCitationDetails.fromJson(
+                Map<String, dynamic>.from(item.cast<String, dynamic>()),
+              ))
+          .toList(),
+    );
+  }
+}
+
+class LawCitationDetails {
+  const LawCitationDetails({
+    required this.label,
+    required this.summary,
+    required this.openUrl,
+    required this.officialSourceUrl,
+    required this.effectiveFrom,
+    required this.versionToken,
+  });
+
+  final String label;
+  final String summary;
+  final String openUrl;
+  final String officialSourceUrl;
+  final String effectiveFrom;
+  final String versionToken;
+
+  static LawCitationDetails fromJson(Map<String, dynamic> json) {
+    return LawCitationDetails(
+      label: json['label'] as String? ?? '',
+      summary: json['summary'] as String? ?? '',
+      openUrl: json['open_url'] as String? ?? '',
+      officialSourceUrl: json['official_source_url'] as String? ?? '',
+      effectiveFrom: json['effective_from'] as String? ?? '',
+      versionToken: json['version_token'] as String? ?? '',
     );
   }
 }
@@ -7093,9 +7148,94 @@ class _ChatHomePageState extends State<ChatHomePage>
     }));
   }
 
+  Future<void> _openLawCitation(LawCitationDetails citation) async {
+    final rawUrl = citation.openUrl.trim().isNotEmpty
+        ? citation.openUrl.trim()
+        : citation.officialSourceUrl.trim();
+    if (rawUrl.isEmpty) {
+      _showSnackbar(_strings.t('law_citation_open_failed'));
+      return;
+    }
+    final uri = Uri.tryParse(rawUrl);
+    final resolvedUri = uri == null
+        ? null
+        : (uri.hasScheme ? uri : _apiClient.baseUri.resolveUri(uri));
+    if (resolvedUri == null) {
+      _showSnackbar(_strings.t('law_citation_open_failed'));
+      return;
+    }
+    final opened = await launchUrl(
+      resolvedUri,
+      mode: LaunchMode.platformDefault,
+    );
+    if (!opened) {
+      _showSnackbar(_strings.t('law_citation_open_failed'));
+    }
+  }
+
+  Widget _buildLawCitationsPanel({
+    required AppStrings strings,
+    required SessionResultDetails result,
+  }) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.94),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            strings.t('law_citations_title'),
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+          const SizedBox(height: 8),
+          for (final citation in result.lawCitations)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: OutlinedButton(
+                onPressed: () => unawaited(_openLawCitation(citation)),
+                style: OutlinedButton.styleFrom(
+                  padding: const EdgeInsets.all(12),
+                  alignment: Alignment.centerLeft,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      citation.label,
+                      style: const TextStyle(fontWeight: FontWeight.w700),
+                    ),
+                    if (citation.effectiveFrom.trim().isNotEmpty)
+                      Text(
+                        '${strings.t('law_citation_effective_from')}: ${citation.effectiveFrom}',
+                      ),
+                    if (citation.versionToken.trim().isNotEmpty)
+                      Text(
+                        '${strings.t('law_citation_version')}: ${citation.versionToken}',
+                      ),
+                    if (citation.summary.trim().isNotEmpty)
+                      Text(citation.summary),
+                    const SizedBox(height: 4),
+                    Text(strings.t('law_citation_open')),
+                  ],
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final strings = _strings;
+    final lawCitations =
+        _latestSessionResult?.lawCitations ?? const <LawCitationDetails>[];
     return Scaffold(
       body: Stack(
         children: [
@@ -7433,6 +7573,14 @@ class _ChatHomePageState extends State<ChatHomePage>
                     ],
                   ),
                 ),
+                if (lawCitations.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+                    child: _buildLawCitationsPanel(
+                      strings: strings,
+                      result: _latestSessionResult!,
+                    ),
+                  ),
                 Padding(
                   padding: const EdgeInsets.fromLTRB(12, 2, 12, 12),
                   child: Column(

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ai_jurisdiction_mobile
-version: 0.1.5+47
+version: 0.1.5+48
 publish_to: none
 
 environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aijurisdictionagents"
-version = "1.0.260351"
+version = "1.0.260353"
 description = "Multi-agent legal discussion scaffold."
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+  "azure-identity>=1.23.0",
+  "azure-storage-blob>=12.26.0",
   "azure-monitor-opentelemetry>=1.8.6",
   "numpy>=2.1",
   "openai>=1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aijurisdictionagents"
-version = "1.0.260350"
+version = "1.0.260351"
 description = "Multi-agent legal discussion scaffold."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260350"
+__version__ = "1.0.260351"

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260351"
+__version__ = "1.0.260353"

--- a/src/services/laws_collector/__init__.py
+++ b/src/services/laws_collector/__init__.py
@@ -3,6 +3,7 @@
 from .country_registry import CountryLawsCollectorDefinition, get_country_laws_collector_definition
 from .config import LawsCollectorConfig
 from .domain import (
+    ArchiveImportAsset,
     CollectorImportState,
     CollectorProgress,
     LawInformationField,
@@ -24,6 +25,7 @@ from .sqlite_store import SqliteLawStore
 
 __all__ = [
     "CountryLawsCollectorDefinition",
+    "ArchiveImportAsset",
     "CollectorImportState",
     "CollectorProgress",
     "LawInformationField",

--- a/src/services/laws_collector/archive_storage.py
+++ b/src/services/laws_collector/archive_storage.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+from azure.identity import DefaultAzureCredential
+from azure.core.exceptions import ResourceExistsError
+from azure.storage.blob import BlobServiceClient, ContainerClient
+
+from .config import LawsCollectorConfig
+
+
+@dataclass(frozen=True)
+class StoredArchiveObject:
+    storage_backend: str
+    storage_path: str
+
+
+class ArchiveObjectStore:
+    def persist_file(self, *, source_path: Path, relative_path: str) -> StoredArchiveObject:
+        raise NotImplementedError
+
+
+class LocalArchiveObjectStore(ArchiveObjectStore):
+    def persist_file(self, *, source_path: Path, relative_path: str) -> StoredArchiveObject:
+        return StoredArchiveObject(
+            storage_backend="local_file",
+            storage_path=str(source_path.resolve()),
+        )
+
+
+class AzureBlobArchiveObjectStore(ArchiveObjectStore):
+    def __init__(self, *, container_url: str) -> None:
+        self._container_url = container_url.rstrip("/")
+        self._container_client = _build_container_client(self._container_url)
+        try:
+            self._container_client.create_container()
+        except ResourceExistsError:
+            pass
+
+    def persist_file(self, *, source_path: Path, relative_path: str) -> StoredArchiveObject:
+        normalized_relative_path = relative_path.strip().replace("\\", "/").lstrip("/")
+        blob_client = self._container_client.get_blob_client(normalized_relative_path)
+        if not blob_client.exists():
+            with source_path.open("rb") as handle:
+                blob_client.upload_blob(handle, overwrite=False)
+        return StoredArchiveObject(
+            storage_backend="azure_blob",
+            storage_path=f"{self._container_url}/{normalized_relative_path}",
+        )
+
+
+def build_archive_object_store(config: LawsCollectorConfig) -> ArchiveObjectStore:
+    if config.storage_cloud:
+        return AzureBlobArchiveObjectStore(container_url=config.storage_cloud)
+    return LocalArchiveObjectStore()
+
+
+def _build_container_client(container_url: str) -> ContainerClient:
+    parsed = urlparse(container_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError("LAWS_STORAGE_CLOUD must be a valid Azure Blob container URL.")
+
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if len(path_parts) != 1:
+        raise ValueError(
+            "LAWS_STORAGE_CLOUD must point to a blob container, for example "
+            "'https://<account>.blob.core.windows.net/laws-collection-sk'."
+        )
+    container_name = path_parts[0]
+    account_url = f"{parsed.scheme}://{parsed.netloc}"
+    if parsed.query:
+        return ContainerClient.from_container_url(container_url)
+
+    managed_identity_client_id = os.getenv("AZURE_CLIENT_ID", "").strip() or None
+    credential = DefaultAzureCredential(
+        exclude_interactive_browser_credential=True,
+        managed_identity_client_id=managed_identity_client_id,
+    )
+    return BlobServiceClient(account_url=account_url, credential=credential).get_container_client(
+        container_name
+    )

--- a/src/services/laws_collector/config.py
+++ b/src/services/laws_collector/config.py
@@ -87,7 +87,7 @@ class LawsCollectorConfig:
     @property
     def archive_root(self) -> Path:
         if self.country_code == "SK":
-            return _resolve_repo_path("./archivelaws/slovakia")
+            return _resolve_repo_path("./archivelaws/laws-collection-sk")
         return _resolve_repo_path(f"./archivelaws/{self.country_code.lower()}")
 
     @property

--- a/src/services/laws_collector/domain.py
+++ b/src/services/laws_collector/domain.py
@@ -104,6 +104,7 @@ class LawSnapshot:
     relations: tuple[LawRelationRecord, ...] = ()
     http_etag: str = ""
     http_last_modified: str = ""
+    html_source_content: bytes | None = None
 
     def document_key(self) -> str:
         return f"{self.country_code}-{self.collection_code}-{self.year}-{self.number}"
@@ -263,6 +264,24 @@ class CollectorImportState:
 
     def evolve(self, **changes: object) -> "CollectorImportState":
         return replace(self, **changes)
+
+
+@dataclass(frozen=True)
+class ArchiveImportAsset:
+    country_code: str
+    source_system: str
+    import_key: str
+    import_label: str
+    phase: str
+    asset_name: str
+    source_url: str
+    storage_backend: str
+    storage_path: str
+    checksum: str
+    file_size_bytes: int
+    processing_status: str
+    downloaded_at: str
+    metadata: dict[str, object] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/src/services/laws_collector/postgres_store.py
+++ b/src/services/laws_collector/postgres_store.py
@@ -10,6 +10,7 @@ from psycopg.rows import dict_row
 
 from .config import LawsCollectorConfig
 from .domain import (
+    ArchiveImportAsset,
     CollectorImportState,
     CollectorProgress,
     LawSemanticCandidate,
@@ -432,7 +433,26 @@ class PostgresLawStore:
                 )
             conn.commit()
 
-    def upsert_artifact(self, *, document_id: str, version_id: str, source_system: str, artifact_kind: str, source_url: str, checksum: str, content_text: str, content_blob: bytes | None, content_bytes: int, http_etag: str, http_last_modified: str, should_redownload: bool, verification_status: str, download_error: str = "") -> None:
+    def upsert_artifact(
+        self,
+        *,
+        document_id: str,
+        version_id: str,
+        source_system: str,
+        artifact_kind: str,
+        source_url: str,
+        checksum: str,
+        storage_backend: str,
+        storage_path: str,
+        content_text: str,
+        content_blob: bytes | None,
+        content_bytes: int,
+        http_etag: str,
+        http_last_modified: str,
+        should_redownload: bool,
+        verification_status: str,
+        download_error: str = "",
+    ) -> None:
         now = _now_iso()
         with self._connect() as conn:
             row = conn.execute(
@@ -447,11 +467,13 @@ class PostgresLawStore:
                     """
                     INSERT INTO source_artifacts(
                         artifact_id, document_id, version_id, source_system, artifact_kind, source_url,
-                        checksum, content_text, content_blob, content_bytes, http_etag, http_last_modified,
+                        checksum, storage_backend, storage_path, content_text, content_blob,
+                        content_bytes, http_etag, http_last_modified,
                         should_redownload, verification_status, download_error, fetched_at, last_checked_at
                     ) VALUES (
                         %(artifact_id)s, %(document_id)s, %(version_id)s, %(source_system)s, %(artifact_kind)s,
-                        %(source_url)s, %(checksum)s, %(content_text)s, %(content_blob)s, %(content_bytes)s,
+                        %(source_url)s, %(checksum)s, %(storage_backend)s, %(storage_path)s,
+                        %(content_text)s, %(content_blob)s, %(content_bytes)s,
                         %(http_etag)s, %(http_last_modified)s, %(should_redownload)s,
                         %(verification_status)s, %(download_error)s, %(now)s, %(now)s
                     )
@@ -464,6 +486,8 @@ class PostgresLawStore:
                         "artifact_kind": artifact_kind,
                         "source_url": source_url,
                         "checksum": checksum,
+                        "storage_backend": storage_backend,
+                        "storage_path": storage_path,
                         "content_text": content_text,
                         "content_blob": content_blob,
                         "content_bytes": content_bytes,
@@ -479,12 +503,29 @@ class PostgresLawStore:
                 conn.execute(
                     """
                     UPDATE source_artifacts
-                    SET http_etag = %(http_etag)s, http_last_modified = %(http_last_modified)s,
-                        should_redownload = %(should_redownload)s, verification_status = %(verification_status)s,
-                        download_error = %(download_error)s, last_checked_at = %(now)s
+                    SET source_system = %(source_system)s,
+                        source_url = %(source_url)s,
+                        storage_backend = %(storage_backend)s,
+                        storage_path = %(storage_path)s,
+                        content_text = %(content_text)s,
+                        content_blob = %(content_blob)s,
+                        content_bytes = %(content_bytes)s,
+                        http_etag = %(http_etag)s,
+                        http_last_modified = %(http_last_modified)s,
+                        should_redownload = %(should_redownload)s,
+                        verification_status = %(verification_status)s,
+                        download_error = %(download_error)s,
+                        last_checked_at = %(now)s
                     WHERE artifact_id = %(artifact_id)s
                     """,
                     {
+                        "source_system": source_system,
+                        "source_url": source_url,
+                        "storage_backend": storage_backend,
+                        "storage_path": storage_path,
+                        "content_text": content_text,
+                        "content_blob": content_blob,
+                        "content_bytes": content_bytes,
                         "http_etag": http_etag,
                         "http_last_modified": http_last_modified,
                         "should_redownload": should_redownload,
@@ -657,6 +698,76 @@ class PostgresLawStore:
                     "completed_at": state.completed_at,
                     "metadata_json": json.dumps(state.metadata, ensure_ascii=True, sort_keys=True),
                     "now": _now_iso(),
+                },
+            )
+            conn.commit()
+
+    def upsert_archive_import_asset(self, asset: ArchiveImportAsset) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO archive_import_assets(
+                    archive_import_asset_id, country_code, source_system, import_key, import_label,
+                    phase, asset_name, source_url, storage_backend, storage_path, checksum,
+                    file_size_bytes, processing_status, downloaded_at, metadata_json, created_at, updated_at
+                ) VALUES (
+                    %(archive_import_asset_id)s, %(country_code)s, %(source_system)s, %(import_key)s, %(import_label)s,
+                    %(phase)s, %(asset_name)s, %(source_url)s, %(storage_backend)s, %(storage_path)s, %(checksum)s,
+                    %(file_size_bytes)s, %(processing_status)s, %(downloaded_at)s, %(metadata_json)s::jsonb, %(now)s, %(now)s
+                )
+                ON CONFLICT(country_code, import_key, asset_name, checksum) DO UPDATE SET
+                    import_label = EXCLUDED.import_label,
+                    phase = EXCLUDED.phase,
+                    source_url = EXCLUDED.source_url,
+                    storage_backend = EXCLUDED.storage_backend,
+                    storage_path = EXCLUDED.storage_path,
+                    file_size_bytes = EXCLUDED.file_size_bytes,
+                    processing_status = EXCLUDED.processing_status,
+                    downloaded_at = EXCLUDED.downloaded_at,
+                    metadata_json = EXCLUDED.metadata_json,
+                    updated_at = EXCLUDED.updated_at
+                """,
+                {
+                    "archive_import_asset_id": str(uuid.uuid4()),
+                    "country_code": asset.country_code,
+                    "source_system": asset.source_system,
+                    "import_key": asset.import_key,
+                    "import_label": asset.import_label,
+                    "phase": asset.phase,
+                    "asset_name": asset.asset_name,
+                    "source_url": asset.source_url,
+                    "storage_backend": asset.storage_backend,
+                    "storage_path": asset.storage_path,
+                    "checksum": asset.checksum,
+                    "file_size_bytes": asset.file_size_bytes,
+                    "processing_status": asset.processing_status,
+                    "downloaded_at": asset.downloaded_at,
+                    "metadata_json": json.dumps(asset.metadata, ensure_ascii=True, sort_keys=True),
+                    "now": _now_iso(),
+                },
+            )
+            conn.commit()
+
+    def update_archive_import_assets_status(
+        self,
+        *,
+        country_code: str,
+        import_key: str,
+        processing_status: str,
+    ) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE archive_import_assets
+                SET processing_status = %(processing_status)s,
+                    updated_at = %(updated_at)s
+                WHERE country_code = %(country_code)s AND import_key = %(import_key)s
+                """,
+                {
+                    "country_code": country_code,
+                    "import_key": import_key,
+                    "processing_status": processing_status,
+                    "updated_at": _now_iso(),
                 },
             )
             conn.commit()

--- a/src/services/laws_collector/service.py
+++ b/src/services/laws_collector/service.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from hashlib import sha256
 import json
 from math import fsum
+from pathlib import PurePosixPath
 from time import perf_counter
 from typing import Protocol
+from urllib.parse import urlparse
 
 from aijurisdictionagents.llm.embeddings import EmbeddingClient, get_embedding_client
 from services.document_processor.runtime import (
@@ -25,6 +27,11 @@ from .domain import (
     UpdateCheckItem,
     UpdateCheckPlan,
     format_law_identifier,
+)
+from .source_artifact_storage import (
+    SourceArtifactObjectStore,
+    StoredSourceArtifactObject,
+    build_source_artifact_object_store,
 )
 
 
@@ -73,6 +80,8 @@ class LawStore(Protocol):
         artifact_kind: str,
         source_url: str,
         checksum: str,
+        storage_backend: str,
+        storage_path: str,
         content_text: str,
         content_blob: bytes | None,
         content_bytes: int,
@@ -105,11 +114,13 @@ class LawsCollectorService:
         config: LawsCollectorConfig,
         store: LawStore,
         embedding_client: EmbeddingClient | None = None,
+        source_artifact_store: SourceArtifactObjectStore | None = None,
     ) -> None:
         config.validate()
         self.config = config
         self.store = store
         self.embedding_client = embedding_client or get_embedding_client()
+        self.source_artifact_store = source_artifact_store or build_source_artifact_object_store(config)
 
     def sync(self, snapshots: tuple[LawSnapshot, ...]) -> SyncSummary:
         summary = SyncSummary()
@@ -137,6 +148,7 @@ class LawsCollectorService:
                 snapshot=snapshot,
                 embedding_client=self.embedding_client,
             )
+            html_source_content = snapshot.html_source_content or snapshot.html_content.encode("utf-8")
             stored_version = self.store.upsert_version(
                 document_id=document_id,
                 snapshot=snapshot,
@@ -161,6 +173,19 @@ class LawsCollectorService:
                     relations=snapshot.relations,
                 )
             self.store.replace_provisions(version_id=stored_version.version_id, provisions=snapshot.provisions)
+            html_artifact = _persist_source_artifact(
+                source_artifact_store=self.source_artifact_store,
+                country_code=snapshot.country_code,
+                collection_code=snapshot.collection_code,
+                year=snapshot.year,
+                number=snapshot.number,
+                version_token=snapshot.version_token,
+                artifact_kind="html",
+                source_url=snapshot.html_url,
+                checksum=html_checksum,
+                default_extension=".html",
+                content=html_source_content,
+            )
             self.store.upsert_artifact(
                 document_id=document_id,
                 version_id=stored_version.version_id,
@@ -168,29 +193,47 @@ class LawsCollectorService:
                 artifact_kind="html",
                 source_url=snapshot.html_url,
                 checksum=html_checksum,
+                storage_backend=html_artifact.storage_backend,
+                storage_path=html_artifact.storage_path,
                 content_text=snapshot.html_content,
                 content_blob=None,
-                content_bytes=len(snapshot.html_content.encode("utf-8")),
+                content_bytes=len(html_source_content),
                 http_etag=snapshot.http_etag,
                 http_last_modified=snapshot.http_last_modified,
                 should_redownload=False,
                 verification_status="stored",
             )
-            self.store.upsert_artifact(
-                document_id=document_id,
-                version_id=stored_version.version_id,
-                source_system=snapshot.source_system,
-                artifact_kind="pdf",
-                source_url=snapshot.pdf_url,
-                checksum=pdf_checksum,
-                content_text="",
-                content_blob=snapshot.pdf_content,
-                content_bytes=len(snapshot.pdf_content),
-                http_etag=snapshot.http_etag,
-                http_last_modified=snapshot.http_last_modified,
-                should_redownload=False,
-                verification_status="stored",
-            )
+            if snapshot.pdf_content:
+                pdf_artifact = _persist_source_artifact(
+                    source_artifact_store=self.source_artifact_store,
+                    country_code=snapshot.country_code,
+                    collection_code=snapshot.collection_code,
+                    year=snapshot.year,
+                    number=snapshot.number,
+                    version_token=snapshot.version_token,
+                    artifact_kind="pdf",
+                    source_url=snapshot.pdf_url,
+                    checksum=pdf_checksum,
+                    default_extension=".pdf",
+                    content=snapshot.pdf_content,
+                )
+                self.store.upsert_artifact(
+                    document_id=document_id,
+                    version_id=stored_version.version_id,
+                    source_system=snapshot.source_system,
+                    artifact_kind="pdf",
+                    source_url=snapshot.pdf_url,
+                    checksum=pdf_checksum,
+                    storage_backend=pdf_artifact.storage_backend,
+                    storage_path=pdf_artifact.storage_path,
+                    content_text="",
+                    content_blob=None,
+                    content_bytes=len(snapshot.pdf_content),
+                    http_etag=snapshot.http_etag,
+                    http_last_modified=snapshot.http_last_modified,
+                    should_redownload=False,
+                    verification_status="stored",
+                )
 
             event_type = _event_type(document_created=document_created, version_state=stored_version.state)
             if event_type != "no_change":
@@ -327,6 +370,55 @@ def _hash_text(value: str) -> str:
 
 def _hash_bytes(value: bytes) -> str:
     return sha256(value).hexdigest()
+
+
+def _persist_source_artifact(
+    *,
+    source_artifact_store: SourceArtifactObjectStore,
+    country_code: str,
+    collection_code: str,
+    year: int,
+    number: int,
+    version_token: str,
+    artifact_kind: str,
+    source_url: str,
+    checksum: str,
+    default_extension: str,
+    content: bytes,
+) -> StoredSourceArtifactObject:
+    relative_path = _build_source_artifact_storage_relative_path(
+        country_code=country_code,
+        collection_code=collection_code,
+        year=year,
+        number=number,
+        version_token=version_token,
+        artifact_kind=artifact_kind,
+        source_url=source_url,
+        checksum=checksum,
+        default_extension=default_extension,
+    )
+    return source_artifact_store.persist_bytes(content=content, relative_path=relative_path)
+
+
+def _build_source_artifact_storage_relative_path(
+    *,
+    country_code: str,
+    collection_code: str,
+    year: int,
+    number: int,
+    version_token: str,
+    artifact_kind: str,
+    source_url: str,
+    checksum: str,
+    default_extension: str,
+) -> str:
+    parsed = urlparse(source_url)
+    extension = PurePosixPath(parsed.path).suffix or default_extension
+    filename = f"{artifact_kind}-{checksum[:16]}{extension}"
+    return (
+        f"source-artifacts/{country_code.lower()}/{collection_code.lower()}/"
+        f"{year}/{number}/{version_token}/{filename}"
+    )
 
 
 def _build_embedding_input(snapshot: LawSnapshot) -> str:

--- a/src/services/laws_collector/slovlex_live_source.py
+++ b/src/services/laws_collector/slovlex_live_source.py
@@ -145,6 +145,7 @@ class SlovLexLiveSnapshotLoader:
             html_url=html_url,
             pdf_url=pdf_url,
             html_content=text_content,
+            html_source_content=effective_html.body,
             pdf_content=pdf_resource.body,
             provisions=provisions,
             metadata=metadata_record,

--- a/src/services/laws_collector/slovlex_zip_import.py
+++ b/src/services/laws_collector/slovlex_zip_import.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from hashlib import sha256
+import json
 import logging
 from pathlib import Path
 import os
@@ -14,8 +16,9 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 import zipfile
 
+from .archive_storage import ArchiveObjectStore, build_archive_object_store
 from .config import LawsCollectorConfig
-from .domain import CollectorImportState, LawSnapshot, SyncSummary
+from .domain import ArchiveImportAsset, CollectorImportState, CollectorProgress, LawSnapshot, SyncSummary
 from .service import LawsCollectorService
 from .slovlex_live_source import (
     _build_metadata_record,
@@ -49,6 +52,26 @@ class ZipImportStateStore(Protocol):
     def get_import_state(self, *, country_code: str, import_key: str) -> CollectorImportState | None: ...
 
     def upsert_import_state(self, state: CollectorImportState) -> None: ...
+
+    def upsert_archive_import_asset(self, asset: ArchiveImportAsset) -> None: ...
+
+    def update_archive_import_assets_status(
+        self,
+        *,
+        country_code: str,
+        import_key: str,
+        processing_status: str,
+    ) -> None: ...
+
+    def get_or_create_collector_progress(
+        self,
+        *,
+        country_code: str,
+        source_system: str,
+        initial_year: int,
+    ) -> CollectorProgress: ...
+
+    def save_collector_progress(self, progress: CollectorProgress) -> None: ...
 
 
 @dataclass(frozen=True)
@@ -122,12 +145,14 @@ class SlovLexZipImportRunner:
         store: ZipImportStateStore,
         service: LawsCollectorService,
         export_index_loader: SlovLexExportIndexLoader | None = None,
+        archive_object_store: ArchiveObjectStore | None = None,
         monotonic_time_provider=time.monotonic,
     ) -> None:
         self.config = config
         self.store = store
         self.service = service
         self.export_index_loader = export_index_loader or SlovLexExportIndexLoader()
+        self.archive_object_store = archive_object_store or build_archive_object_store(config)
         self._monotonic_time = monotonic_time_provider
 
     def run(self, *, max_running_seconds: float = 0) -> SlovLexZipImportSummary:
@@ -262,6 +287,14 @@ class SlovLexZipImportRunner:
             destination = download_root / Path(url).name
             _log_zip(f"archive download source={url} destination={destination}")
             _download_file(url=url, destination=destination)
+            self._record_archive_asset(
+                import_key=export.import_key,
+                import_label=export.import_label,
+                phase="archive",
+                source_url=url,
+                source_file=destination,
+                metadata={"archive_snapshot_date": export.snapshot_date},
+            )
         _extract_archive_bundle(download_root=download_root, extract_root=extract_root)
         return self._process_extracted_entries(
             import_key=export.import_key,
@@ -289,6 +322,17 @@ class SlovLexZipImportRunner:
         destination = download_root / Path(export.zip_url).name
         _log_zip(f"monthly download source={export.zip_url} destination={destination}")
         _download_file(url=export.zip_url, destination=destination)
+        self._record_archive_asset(
+            import_key=export.import_key,
+            import_label=export.import_label,
+            phase="monthly",
+            source_url=export.zip_url,
+            source_file=destination,
+            metadata={
+                "monthly_range_start": export.range_start,
+                "monthly_range_end": export.range_end,
+            },
+        )
         _extract_zip_archive(zip_path=destination, extract_root=extract_root)
         return self._process_extracted_entries(
             import_key=export.import_key,
@@ -338,11 +382,21 @@ class SlovLexZipImportRunner:
                 metadata=metadata,
             )
             self.store.upsert_import_state(state)
+            self.store.update_archive_import_assets_status(
+                country_code=self.config.country_code,
+                import_key=import_key,
+                processing_status="in_progress",
+            )
             _log_zip(
                 "state initialized "
                 f"phase={metadata.get('phase', 'zip')} import_key={import_key}"
             )
         elif state.status == "completed":
+            self.store.update_archive_import_assets_status(
+                country_code=self.config.country_code,
+                import_key=import_key,
+                processing_status="processed",
+            )
             _log_zip(
                 "state already completed "
                 f"phase={metadata.get('phase', 'zip')} import_key={import_key} "
@@ -366,6 +420,11 @@ class SlovLexZipImportRunner:
         resume_entry = state.last_processed_entry
         resume_reached = resume_entry is None
         last_state = state
+        collector_progress = self.store.get_or_create_collector_progress(
+            country_code=self.config.country_code,
+            source_system="slov-lex",
+            initial_year=self.config.initial_import_from.year,
+        )
         if resume_entry is not None:
             _log_zip(
                 "resuming import "
@@ -409,6 +468,13 @@ class SlovLexZipImportRunner:
                 metadata=metadata,
             )
             self.store.upsert_import_state(last_state)
+            collector_progress = collector_progress.evolve(
+                last_collector_run_at=last_state.last_processed_at,
+                last_processed_at=last_state.last_processed_at,
+                last_processed_law_year=snapshot.year,
+                last_processed_law_number=snapshot.number,
+            )
+            self.store.save_collector_progress(collector_progress)
 
         completed_state = last_state.evolve(
             status="completed",
@@ -416,6 +482,11 @@ class SlovLexZipImportRunner:
             metadata=metadata,
         )
         self.store.upsert_import_state(completed_state)
+        self.store.update_archive_import_assets_status(
+            country_code=self.config.country_code,
+            import_key=import_key,
+            processing_status="processed",
+        )
         _log_zip(
             "state completed "
             f"phase={metadata.get('phase', 'zip')} import_key={import_key} "
@@ -432,6 +503,49 @@ class SlovLexZipImportRunner:
             monthly_completed=not archive_completed_on_success,
             last_processed_entry=completed_state.last_processed_entry,
             last_processed_law=completed_state.last_processed_law,
+        )
+
+    def _record_archive_asset(
+        self,
+        *,
+        import_key: str,
+        import_label: str,
+        phase: str,
+        source_url: str,
+        source_file: Path,
+        metadata: dict[str, object],
+    ) -> None:
+        relative_storage_path = _build_archive_storage_relative_path(
+            country_code=self.config.country_code,
+            archive_root=self.config.archive_root,
+            source_file=source_file,
+        )
+        stored_object = self.archive_object_store.persist_file(
+            source_path=source_file,
+            relative_path=relative_storage_path,
+        )
+        self.store.upsert_archive_import_asset(
+            ArchiveImportAsset(
+                country_code=self.config.country_code,
+                source_system="slov-lex",
+                import_key=import_key,
+                import_label=import_label,
+                phase=phase,
+                asset_name=source_file.name,
+                source_url=source_url,
+                storage_backend=stored_object.storage_backend,
+                storage_path=stored_object.storage_path,
+                checksum=_hash_file(source_file),
+                file_size_bytes=source_file.stat().st_size,
+                processing_status="downloaded",
+                downloaded_at=_now_iso(),
+                metadata=metadata,
+            )
+        )
+        _log_zip(
+            "asset stored "
+            f"phase={phase} import_key={import_key} asset_name={source_file.name} "
+            f"storage_backend={stored_object.storage_backend} storage_path={stored_object.storage_path}"
         )
 
 
@@ -485,7 +599,8 @@ def load_snapshot_from_entry_file(entry_file: Path) -> LawSnapshot:
     if parsed is None:
         raise ValueError(f"Unsupported SlovLex entry path: {entry_file}")
     year, number, version_token = parsed
-    html = entry_file.read_text(encoding="utf-8", errors="ignore")
+    html_bytes = entry_file.read_bytes()
+    html = html_bytes.decode("utf-8", errors="ignore")
     metadata_fields = _parse_metadata_fields(html)
     publication_date = _normalize_date_value(metadata_fields.get("datum vyhlasenia", ""))
     effective_from = _normalize_date_value(metadata_fields.get("datum ucinnosti od", "")) or _date_from_token(version_token)
@@ -522,6 +637,7 @@ def load_snapshot_from_entry_file(entry_file: Path) -> LawSnapshot:
         html_url=_build_html_url(year=year, number=number, version_token=version_token, suffix=entry_file.suffix),
         pdf_url=pdf_url,
         html_content=text_content,
+        html_source_content=html_bytes,
         pdf_content=b"",
         provisions=provisions,
         metadata=metadata_record,
@@ -582,27 +698,81 @@ def _download_file(*, url: str, destination: Path) -> None:
     temporary_path.replace(destination)
 
 
+def _build_archive_storage_relative_path(
+    *,
+    country_code: str,
+    archive_root: Path,
+    source_file: Path,
+) -> str:
+    relative_local_path = source_file.relative_to(archive_root).as_posix()
+    return f"{country_code.lower()}/{relative_local_path}"
+
+
+def _hash_file(path: Path) -> str:
+    digest = sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _reset_extract_root(extract_root: Path) -> None:
+    if extract_root.exists():
+        shutil.rmtree(extract_root)
+    extract_root.mkdir(parents=True, exist_ok=True)
+
+
+def _extract_marker_matches(*, marker: Path, expected_signature: dict[str, object]) -> bool:
+    if not marker.exists():
+        return False
+    try:
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return payload.get("signature") == expected_signature
+
+
+def _write_extract_marker(*, marker: Path, signature: dict[str, object]) -> None:
+    marker.write_text(
+        json.dumps({"completed_at": _now_iso(), "signature": signature}, ensure_ascii=True, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
 def _extract_zip_archive(*, zip_path: Path, extract_root: Path) -> None:
     marker = extract_root / ".extract.complete"
-    if marker.exists():
+    signature = {"mode": "single", "files": [{"name": zip_path.name, "checksum": _hash_file(zip_path)}]}
+    if _extract_marker_matches(marker=marker, expected_signature=signature):
+        _log_zip(f"extract skipped marker={marker}")
         return
-    extract_root.mkdir(parents=True, exist_ok=True)
+    _reset_extract_root(extract_root)
     with zipfile.ZipFile(zip_path) as archive:
         archive.extractall(extract_root)
-    marker.write_text(_now_iso(), encoding="utf-8")
+    _write_extract_marker(marker=marker, signature=signature)
 
 
 def _extract_archive_bundle(*, download_root: Path, extract_root: Path) -> None:
     marker = extract_root / ".extract.complete"
-    if marker.exists():
-        _log_zip(f"extract skipped marker={marker}")
-        return
-    extract_root.mkdir(parents=True, exist_ok=True)
     final_zip = download_root / "export.zip"
     split_parts = tuple(
         path for path in sorted(download_root.glob("export.z*"))
         if path.name.lower() != "export.zip"
     )
+    signature = {
+        "mode": "split" if split_parts else "single",
+        "files": [
+            {"name": path.name, "checksum": _hash_file(path)}
+            for path in (*split_parts, final_zip)
+            if path.exists()
+        ],
+    }
+    if _extract_marker_matches(marker=marker, expected_signature=signature):
+        _log_zip(f"extract skipped marker={marker}")
+        return
+    _reset_extract_root(extract_root)
     if final_zip.exists() and not split_parts:
         _log_zip(f"extract single zip source={final_zip} destination={extract_root}")
         _extract_zip_archive(zip_path=final_zip, extract_root=extract_root)
@@ -624,7 +794,7 @@ def _extract_archive_bundle(*, download_root: Path, extract_root: Path) -> None:
             "Split SlovLex archive extraction failed: "
             f"{completed.stderr.strip() or completed.stdout.strip()}"
         )
-    marker.write_text(_now_iso(), encoding="utf-8")
+    _write_extract_marker(marker=marker, signature=signature)
 
 
 def _resolve_7zip_command() -> list[str] | None:

--- a/src/services/laws_collector/slovlex_zip_import.py
+++ b/src/services/laws_collector/slovlex_zip_import.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import logging
 from pathlib import Path
 import os
 import re
@@ -41,6 +42,7 @@ _ARCHIVE_DATE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _HREF_PATTERN = re.compile(r'href="([^"]+)"', re.IGNORECASE)
+_LOGGER = logging.getLogger("laws-collector")
 
 
 class ZipImportStateStore(Protocol):
@@ -131,27 +133,55 @@ class SlovLexZipImportRunner:
     def run(self, *, max_running_seconds: float = 0) -> SlovLexZipImportSummary:
         started_at = self._monotonic_time()
         index = self.export_index_loader.load()
+        _log_zip(
+            "index loaded "
+            f"archive_snapshot={index.archive_export.snapshot_date if index.archive_export else ''} "
+            f"monthly_range={_format_monthly_range(index.monthly_export)}"
+        )
         archive_completed_state = self.store.get_import_state(
             country_code=self.config.country_code,
             import_key="slov-lex:zip:archive-seed",
         )
         archive_completed = archive_completed_state is not None and archive_completed_state.status == "completed"
+        if archive_completed_state is not None:
+            _log_zip(
+                "archive state loaded "
+                f"status={archive_completed_state.status} "
+                f"last_processed_law={archive_completed_state.last_processed_law or ''} "
+                f"archive_snapshot_date={_archive_snapshot_date(archive_completed_state) or ''}"
+            )
 
         if not archive_completed and index.archive_export is not None:
+            _log_zip(
+                "archive import starting "
+                f"snapshot_date={index.archive_export.snapshot_date} "
+                f"parts={len(index.archive_export.part_urls)}"
+            )
             summary = self._process_archive(
                 export=index.archive_export,
                 max_running_seconds=max_running_seconds,
                 started_at=started_at,
             )
             if summary.stopped_due_to_max_running_time or not summary.archive_completed:
+                _log_zip(
+                    "archive import paused "
+                    f"entries_processed={summary.entries_processed} "
+                    f"last_processed_law={summary.last_processed_law or ''}"
+                )
                 return summary
             archive_completed_state = self.store.get_import_state(
                 country_code=self.config.country_code,
                 import_key=index.archive_export.import_key,
             )
             archive_completed = archive_completed_state is not None and archive_completed_state.status == "completed"
+            _log_zip(
+                "archive import completed "
+                f"entries_processed={summary.entries_processed} "
+                f"last_processed_law={summary.last_processed_law or ''}"
+            )
 
         if index.monthly_export is None:
+            _log_zip("no monthly export available")
             return SlovLexZipImportSummary(
                 phase="idle",
                 import_key=None,
@@ -166,6 +196,11 @@ class SlovLexZipImportRunner:
 
         archive_date = _archive_snapshot_date(archive_completed_state)
         if archive_date is not None and index.monthly_export.range_end <= archive_date:
+            _log_zip(
+                "monthly import skipped because archive already covers range "
+                f"archive_snapshot_date={archive_date} "
+                f"monthly_range={index.monthly_export.range_start}..{index.monthly_export.range_end}"
+            )
             return SlovLexZipImportSummary(
                 phase="monthly",
                 import_key=index.monthly_export.import_key,
@@ -179,6 +214,33 @@ class SlovLexZipImportRunner:
                 skipped_as_already_completed=True,
             )
 
+        monthly_state = self.store.get_import_state(
+            country_code=self.config.country_code,
+            import_key=index.monthly_export.import_key,
+        )
+        if monthly_state is not None and monthly_state.status == "completed":
+            _log_zip(
+                "monthly import skipped because the same monthly bundle was already completed "
+                f"range={index.monthly_export.range_start}..{index.monthly_export.range_end} "
+                f"last_processed_law={monthly_state.last_processed_law or ''}"
+            )
+            return SlovLexZipImportSummary(
+                phase="monthly",
+                import_key=index.monthly_export.import_key,
+                import_label=index.monthly_export.import_label,
+                entries_processed=0,
+                sync_summary=SyncSummary(),
+                archive_completed=archive_completed,
+                monthly_completed=True,
+                last_processed_entry=monthly_state.last_processed_entry,
+                last_processed_law=monthly_state.last_processed_law,
+                skipped_as_already_completed=True,
+            )
+
+        _log_zip(
+            "monthly import starting "
+            f"range={index.monthly_export.range_start}..{index.monthly_export.range_end}"
+        )
         return self._process_monthly(
             export=index.monthly_export,
             max_running_seconds=max_running_seconds,
@@ -198,6 +260,7 @@ class SlovLexZipImportRunner:
         extract_root = base_root / "extract"
         for url in export.part_urls:
             destination = download_root / Path(url).name
+            _log_zip(f"archive download source={url} destination={destination}")
             _download_file(url=url, destination=destination)
         _extract_archive_bundle(download_root=download_root, extract_root=extract_root)
         return self._process_extracted_entries(
@@ -224,6 +287,7 @@ class SlovLexZipImportRunner:
         download_root = base_root / "download"
         extract_root = base_root / "extract"
         destination = download_root / Path(export.zip_url).name
+        _log_zip(f"monthly download source={export.zip_url} destination={destination}")
         _download_file(url=export.zip_url, destination=destination)
         _extract_zip_archive(zip_path=destination, extract_root=extract_root)
         return self._process_extracted_entries(
@@ -274,7 +338,16 @@ class SlovLexZipImportRunner:
                 metadata=metadata,
             )
             self.store.upsert_import_state(state)
+            _log_zip(
+                "state initialized "
+                f"phase={metadata.get('phase', 'zip')} import_key={import_key}"
+            )
         elif state.status == "completed":
+            _log_zip(
+                "state already completed "
+                f"phase={metadata.get('phase', 'zip')} import_key={import_key} "
+                f"last_processed_law={state.last_processed_law or ''}"
+            )
             return SlovLexZipImportSummary(
                 phase=str(metadata.get("phase", "zip")),
                 import_key=import_key,
@@ -293,6 +366,12 @@ class SlovLexZipImportRunner:
         resume_entry = state.last_processed_entry
         resume_reached = resume_entry is None
         last_state = state
+        if resume_entry is not None:
+            _log_zip(
+                "resuming import "
+                f"phase={metadata.get('phase', 'zip')} import_key={import_key} "
+                f"resume_after={resume_entry}"
+            )
 
         for entry in entries:
             relative_entry = entry.relative_to(extract_root).as_posix()
@@ -301,6 +380,11 @@ class SlovLexZipImportRunner:
                     resume_reached = True
                 continue
             if max_running_seconds > 0 and (self._monotonic_time() - started_at) >= max_running_seconds:
+                _log_zip(
+                    "max running time reached "
+                    f"phase={metadata.get('phase', 'zip')} import_key={import_key} "
+                    f"last_processed_law={last_state.last_processed_law or ''}"
+                )
                 return SlovLexZipImportSummary(
                     phase=str(metadata.get("phase", "zip")),
                     import_key=import_key,
@@ -332,6 +416,12 @@ class SlovLexZipImportRunner:
             metadata=metadata,
         )
         self.store.upsert_import_state(completed_state)
+        _log_zip(
+            "state completed "
+            f"phase={metadata.get('phase', 'zip')} import_key={import_key} "
+            f"entries_processed={entries_processed} "
+            f"last_processed_law={completed_state.last_processed_law or ''}"
+        )
         return SlovLexZipImportSummary(
             phase=str(metadata.get("phase", "zip")),
             import_key=import_key,
@@ -505,12 +595,24 @@ def _extract_zip_archive(*, zip_path: Path, extract_root: Path) -> None:
 def _extract_archive_bundle(*, download_root: Path, extract_root: Path) -> None:
     marker = extract_root / ".extract.complete"
     if marker.exists():
+        _log_zip(f"extract skipped marker={marker}")
         return
     extract_root.mkdir(parents=True, exist_ok=True)
     final_zip = download_root / "export.zip"
+    split_parts = tuple(
+        path for path in sorted(download_root.glob("export.z*"))
+        if path.name.lower() != "export.zip"
+    )
+    if final_zip.exists() and not split_parts:
+        _log_zip(f"extract single zip source={final_zip} destination={extract_root}")
+        _extract_zip_archive(zip_path=final_zip, extract_root=extract_root)
+        return
     command = _resolve_7zip_command()
     if command is None:
         raise RuntimeError("7-Zip is required for split SlovLex archive extraction but was not found.")
+    _log_zip(
+        f"extract split archive source={final_zip} destination={extract_root} tool={command[0]}"
+    )
     completed = subprocess.run(
         [*command, "x", "-y", f"-o{extract_root}", str(final_zip)],
         check=False,
@@ -544,6 +646,16 @@ def _archive_snapshot_date(state: CollectorImportState | None) -> str | None:
     if isinstance(value, str):
         return value
     return None
+
+
+def _format_monthly_range(export: SlovLexMonthlyExport | None) -> str:
+    if export is None:
+        return ""
+    return f"{export.range_start}..{export.range_end}"
+
+
+def _log_zip(message: str) -> None:
+    _LOGGER.info("[laws-collector] zip-import %s", message)
 
 
 def _to_iso_date(value: str) -> str:

--- a/src/services/laws_collector/source_artifact_storage.py
+++ b/src/services/laws_collector/source_artifact_storage.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+from azure.core.exceptions import ResourceExistsError
+from azure.identity import DefaultAzureCredential
+from azure.storage.blob import BlobServiceClient, ContainerClient
+
+from .config import LawsCollectorConfig
+
+
+@dataclass(frozen=True)
+class StoredSourceArtifactObject:
+    storage_backend: str
+    storage_path: str
+
+
+class SourceArtifactObjectStore:
+    def persist_bytes(self, *, content: bytes, relative_path: str) -> StoredSourceArtifactObject:
+        raise NotImplementedError
+
+
+class LocalSourceArtifactObjectStore(SourceArtifactObjectStore):
+    def __init__(self, *, root_path: Path) -> None:
+        self._root_path = root_path
+
+    def persist_bytes(self, *, content: bytes, relative_path: str) -> StoredSourceArtifactObject:
+        normalized_relative_path = relative_path.strip().replace("\\", "/").lstrip("/")
+        destination = self._root_path / normalized_relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if not destination.exists():
+            destination.write_bytes(content)
+        return StoredSourceArtifactObject(
+            storage_backend="local_file",
+            storage_path=str(destination.resolve()),
+        )
+
+
+class AzureBlobSourceArtifactObjectStore(SourceArtifactObjectStore):
+    def __init__(self, *, container_url: str) -> None:
+        self._container_url = container_url.rstrip("/")
+        self._container_client = _build_container_client(self._container_url)
+        try:
+            self._container_client.create_container()
+        except ResourceExistsError:
+            pass
+
+    def persist_bytes(self, *, content: bytes, relative_path: str) -> StoredSourceArtifactObject:
+        normalized_relative_path = relative_path.strip().replace("\\", "/").lstrip("/")
+        blob_client = self._container_client.get_blob_client(normalized_relative_path)
+        if not blob_client.exists():
+            blob_client.upload_blob(content, overwrite=False)
+        return StoredSourceArtifactObject(
+            storage_backend="azure_blob",
+            storage_path=f"{self._container_url}/{normalized_relative_path}",
+        )
+
+
+def build_source_artifact_object_store(config: LawsCollectorConfig) -> SourceArtifactObjectStore:
+    if config.storage_cloud:
+        return AzureBlobSourceArtifactObjectStore(container_url=config.storage_cloud)
+    return LocalSourceArtifactObjectStore(root_path=config.storage_root)
+
+
+def _build_container_client(container_url: str) -> ContainerClient:
+    parsed = urlparse(container_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError("LAWS_STORAGE_CLOUD must be a valid Azure Blob container URL.")
+
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if len(path_parts) != 1:
+        raise ValueError(
+            "LAWS_STORAGE_CLOUD must point to a blob container, for example "
+            "'https://<account>.blob.core.windows.net/laws-collection-sk'."
+        )
+    container_name = path_parts[0]
+    account_url = f"{parsed.scheme}://{parsed.netloc}"
+    if parsed.query:
+        return ContainerClient.from_container_url(container_url)
+
+    managed_identity_client_id = os.getenv("AZURE_CLIENT_ID", "").strip() or None
+    credential = DefaultAzureCredential(
+        exclude_interactive_browser_credential=True,
+        managed_identity_client_id=managed_identity_client_id,
+    )
+    return BlobServiceClient(account_url=account_url, credential=credential).get_container_client(
+        container_name
+    )

--- a/src/services/laws_collector/sqlite_store.py
+++ b/src/services/laws_collector/sqlite_store.py
@@ -9,6 +9,7 @@ import uuid
 
 from .config import LawsCollectorConfig
 from .domain import (
+    ArchiveImportAsset,
     CollectorImportState,
     CollectorProgress,
     LawSemanticCandidate,
@@ -49,7 +50,7 @@ class LawDocumentOverview:
 
 
 class SqliteLawStore:
-    """SQLite-backed law metadata store with documents stored inside the database."""
+    """SQLite-backed law metadata store with parsed text in DB and artifact references on storage."""
 
     def __init__(self, *, db_path: Path) -> None:
         self.db_path = db_path
@@ -136,6 +137,8 @@ class SqliteLawStore:
                     artifact_kind TEXT NOT NULL,
                     source_url TEXT NOT NULL,
                     checksum TEXT NOT NULL,
+                    storage_backend TEXT NOT NULL DEFAULT '',
+                    storage_path TEXT NOT NULL DEFAULT '',
                     content_text TEXT NOT NULL,
                     content_blob BLOB,
                     content_bytes INTEGER NOT NULL,
@@ -233,9 +236,31 @@ class SqliteLawStore:
                     updated_at TEXT NOT NULL,
                     PRIMARY KEY(country_code, import_key)
                 );
+
+                CREATE TABLE IF NOT EXISTS archive_import_assets (
+                    archive_import_asset_id TEXT PRIMARY KEY,
+                    country_code TEXT NOT NULL,
+                    source_system TEXT NOT NULL,
+                    import_key TEXT NOT NULL,
+                    import_label TEXT NOT NULL,
+                    phase TEXT NOT NULL,
+                    asset_name TEXT NOT NULL,
+                    source_url TEXT NOT NULL,
+                    storage_backend TEXT NOT NULL,
+                    storage_path TEXT NOT NULL,
+                    checksum TEXT NOT NULL,
+                    file_size_bytes INTEGER NOT NULL,
+                    processing_status TEXT NOT NULL,
+                    downloaded_at TEXT NOT NULL,
+                    metadata_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    UNIQUE(country_code, import_key, asset_name, checksum)
+                );
                 """
             )
             _ensure_law_versions_columns(conn)
+            _ensure_source_artifacts_columns(conn)
 
     def upsert_document(self, snapshot: LawSnapshot) -> tuple[str, bool]:
         now = _now_iso()
@@ -596,6 +621,8 @@ class SqliteLawStore:
         artifact_kind: str,
         source_url: str,
         checksum: str,
+        storage_backend: str,
+        storage_path: str,
         content_text: str,
         content_blob: bytes | None,
         content_bytes: int,
@@ -620,11 +647,11 @@ class SqliteLawStore:
                     """
                     INSERT INTO source_artifacts(
                         artifact_id, document_id, version_id, source_system, artifact_kind, source_url,
-                        checksum, content_text, content_blob, content_bytes, http_etag,
+                        checksum, storage_backend, storage_path, content_text, content_blob, content_bytes, http_etag,
                         http_last_modified, should_redownload, verification_status,
                         download_error, fetched_at, last_checked_at
                     )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         str(uuid.uuid4()),
@@ -634,6 +661,8 @@ class SqliteLawStore:
                         artifact_kind,
                         source_url,
                         checksum,
+                        storage_backend,
+                        storage_path,
                         content_text,
                         content_blob,
                         content_bytes,
@@ -651,11 +680,19 @@ class SqliteLawStore:
             conn.execute(
                 """
                 UPDATE source_artifacts
-                SET http_etag = ?, http_last_modified = ?, should_redownload = ?,
-                    verification_status = ?, download_error = ?, last_checked_at = ?
+                SET source_system = ?, source_url = ?, storage_backend = ?, storage_path = ?,
+                    content_text = ?, content_blob = ?, content_bytes = ?, http_etag = ?, http_last_modified = ?,
+                    should_redownload = ?, verification_status = ?, download_error = ?, last_checked_at = ?
                 WHERE artifact_id = ?
                 """,
                 (
+                    source_system,
+                    source_url,
+                    storage_backend,
+                    storage_path,
+                    content_text,
+                    content_blob,
+                    content_bytes,
                     http_etag,
                     http_last_modified,
                     1 if should_redownload else 0,
@@ -823,6 +860,73 @@ class SqliteLawStore:
                 ),
             )
 
+    def upsert_archive_import_asset(self, asset: ArchiveImportAsset) -> None:
+        now = _now_iso()
+        metadata_json = json.dumps(asset.metadata, ensure_ascii=True, sort_keys=True)
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO archive_import_assets(
+                    archive_import_asset_id, country_code, source_system, import_key, import_label,
+                    phase, asset_name, source_url, storage_backend, storage_path, checksum,
+                    file_size_bytes, processing_status, downloaded_at, metadata_json, created_at, updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(country_code, import_key, asset_name, checksum) DO UPDATE SET
+                    import_label = excluded.import_label,
+                    phase = excluded.phase,
+                    source_url = excluded.source_url,
+                    storage_backend = excluded.storage_backend,
+                    storage_path = excluded.storage_path,
+                    file_size_bytes = excluded.file_size_bytes,
+                    processing_status = excluded.processing_status,
+                    downloaded_at = excluded.downloaded_at,
+                    metadata_json = excluded.metadata_json,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    str(uuid.uuid4()),
+                    asset.country_code,
+                    asset.source_system,
+                    asset.import_key,
+                    asset.import_label,
+                    asset.phase,
+                    asset.asset_name,
+                    asset.source_url,
+                    asset.storage_backend,
+                    asset.storage_path,
+                    asset.checksum,
+                    asset.file_size_bytes,
+                    asset.processing_status,
+                    asset.downloaded_at,
+                    metadata_json,
+                    now,
+                    now,
+                ),
+            )
+
+    def update_archive_import_assets_status(
+        self,
+        *,
+        country_code: str,
+        import_key: str,
+        processing_status: str,
+    ) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE archive_import_assets
+                SET processing_status = ?, updated_at = ?
+                WHERE country_code = ? AND import_key = ?
+                """,
+                (
+                    processing_status,
+                    _now_iso(),
+                    country_code,
+                    import_key,
+                ),
+            )
+
     def get_counts(self) -> CollectorCounts:
         with self._connect() as conn:
             return CollectorCounts(
@@ -922,6 +1026,19 @@ def _ensure_law_versions_columns(conn: sqlite3.Connection) -> None:
     if "embedding_dimensions" not in existing:
         conn.execute(
             "ALTER TABLE law_versions ADD COLUMN embedding_dimensions INTEGER NOT NULL DEFAULT 0"
+        )
+
+
+def _ensure_source_artifacts_columns(conn: sqlite3.Connection) -> None:
+    rows = conn.execute("PRAGMA table_info(source_artifacts)").fetchall()
+    existing = {str(row["name"]) for row in rows}
+    if "storage_backend" not in existing:
+        conn.execute(
+            "ALTER TABLE source_artifacts ADD COLUMN storage_backend TEXT NOT NULL DEFAULT ''"
+        )
+    if "storage_path" not in existing:
+        conn.execute(
+            "ALTER TABLE source_artifacts ADD COLUMN storage_path TEXT NOT NULL DEFAULT ''"
         )
 
 

--- a/tests/test_laws_collector.py
+++ b/tests/test_laws_collector.py
@@ -40,7 +40,7 @@ def _build_service(tmp_path: Path) -> tuple[SqliteLawStore, SlovakLawsCollectorS
         db_backend="sqlite",
         db_local=str(tmp_path / "laws.sqlite3"),
         db_cloud="",
-        storage_local="",
+        storage_local=str(tmp_path / "files"),
         storage_cloud="",
         delta_poll_hours=3,
         initial_import_from=date(1993, 1, 1),
@@ -106,6 +106,27 @@ def _get_law_metadata(
             (metadata_row["law_metadata_id"],),
         ).fetchall()
     return metadata_row, list(relation_rows)
+
+
+def _get_source_artifacts(
+    store: SqliteLawStore,
+    *,
+    law_year: int,
+    law_number: int,
+) -> list[sqlite3.Row]:
+    with store._connect() as conn:  # noqa: SLF001 - test-only verification of persisted values
+        rows = conn.execute(
+            """
+            SELECT a.artifact_kind, a.storage_backend, a.storage_path, a.content_text, a.content_blob, a.content_bytes
+            FROM source_artifacts AS a
+            JOIN law_versions AS v ON v.version_id = a.version_id
+            JOIN law_documents AS d ON d.document_id = v.document_id
+            WHERE d.law_year = ? AND d.law_number = ?
+            ORDER BY a.artifact_kind
+            """,
+            (law_year, law_number),
+        ).fetchall()
+    return list(rows)
 
 
 def test_laws_collector_baseline_sync_creates_documents_and_versions(tmp_path: Path) -> None:
@@ -449,6 +470,46 @@ def test_sqlite_store_initialize_backfills_embedding_metadata_columns(tmp_path: 
     assert columns["embedding_dimensions"] == "INTEGER"
 
 
+def test_sqlite_store_initialize_backfills_source_artifact_storage_columns(tmp_path: Path) -> None:
+    db_path = tmp_path / "legacy-source-artifacts.sqlite3"
+    store = SqliteLawStore(db_path=db_path)
+    with store._connect() as conn:  # noqa: SLF001 - constructing a legacy schema fixture
+        conn.executescript(
+            """
+            CREATE TABLE source_artifacts (
+                artifact_id TEXT PRIMARY KEY,
+                document_id TEXT NOT NULL,
+                version_id TEXT NOT NULL,
+                source_system TEXT NOT NULL,
+                artifact_kind TEXT NOT NULL,
+                source_url TEXT NOT NULL,
+                checksum TEXT NOT NULL,
+                content_text TEXT NOT NULL,
+                content_blob BLOB,
+                content_bytes INTEGER NOT NULL,
+                http_etag TEXT NOT NULL,
+                http_last_modified TEXT NOT NULL,
+                should_redownload INTEGER NOT NULL,
+                verification_status TEXT NOT NULL,
+                download_error TEXT NOT NULL,
+                fetched_at TEXT NOT NULL,
+                last_checked_at TEXT NOT NULL
+            );
+            """
+        )
+
+    store.initialize()
+
+    with store._connect() as conn:  # noqa: SLF001 - test-only schema inspection
+        columns = {
+            str(row["name"]): str(row["type"])
+            for row in conn.execute("PRAGMA table_info(source_artifacts)").fetchall()
+        }
+
+    assert columns["storage_backend"] == "TEXT"
+    assert columns["storage_path"] == "TEXT"
+
+
 def test_laws_collector_logs_embedding_pipeline_steps(tmp_path: Path, capsys) -> None:
     _, service = _build_service(tmp_path)
 
@@ -608,6 +669,62 @@ def test_laws_collector_persists_metadata_and_relations(tmp_path: Path) -> None:
     assert json.loads(str(metadata_row["legal_areas_json"])) == ["Stat", "Stavebne pravo"]
     assert [row["relation_type"] for row in relation_rows] == ["amends", "implements"]
     assert relation_rows[0]["target_law_identifier_text"] == "50/2001 Z. z."
+
+
+def test_laws_collector_persists_source_artifact_references_for_live_style_snapshots(
+    tmp_path: Path,
+) -> None:
+    store, service = _build_service(tmp_path)
+    snapshot = replace(
+        baseline_snapshots()[0],
+        html_content="Uplne znenie zakona.",
+        html_source_content=b"<html><body><p>Uplne znenie zakona.</p></body></html>",
+        pdf_content=b"%PDF-1.4 test-law",
+    )
+
+    service.sync((snapshot,))
+    artifacts = _get_source_artifacts(store, law_year=snapshot.year, law_number=snapshot.number)
+
+    assert [row["artifact_kind"] for row in artifacts] == ["html", "pdf"]
+    for row in artifacts:
+        assert row["storage_backend"] == "local_file"
+        assert Path(str(row["storage_path"])).exists()
+        assert row["content_blob"] is None
+    assert artifacts[0]["content_text"] == "Uplne znenie zakona."
+    assert Path(str(artifacts[0]["storage_path"])).read_text(encoding="utf-8").startswith("<html>")
+
+
+def test_laws_collector_resync_replaces_legacy_pdf_blob_with_storage_reference(
+    tmp_path: Path,
+) -> None:
+    store, service = _build_service(tmp_path)
+    snapshot = replace(
+        baseline_snapshots()[0],
+        html_content="Uplne znenie zakona.",
+        html_source_content=b"<html><body><p>Uplne znenie zakona.</p></body></html>",
+        pdf_content=b"%PDF-1.4 test-law",
+    )
+
+    service.sync((snapshot,))
+    with store._connect() as conn:  # noqa: SLF001 - mutate to simulate pre-migration rows
+        conn.execute(
+            """
+            UPDATE source_artifacts
+            SET storage_backend = '',
+                storage_path = '',
+                content_blob = ?
+            WHERE artifact_kind = 'pdf'
+            """,
+            (b"legacy-pdf-blob",),
+        )
+
+    service.sync((snapshot,))
+    artifacts = _get_source_artifacts(store, law_year=snapshot.year, law_number=snapshot.number)
+    pdf_artifact = next(row for row in artifacts if row["artifact_kind"] == "pdf")
+
+    assert pdf_artifact["storage_backend"] == "local_file"
+    assert Path(str(pdf_artifact["storage_path"])).exists()
+    assert pdf_artifact["content_blob"] is None
 
 
 def test_slovlex_live_snapshot_loader_parses_metadata_and_relations(monkeypatch) -> None:
@@ -835,7 +952,7 @@ def test_laws_collector_local_embedding_mode_supports_semantic_search(
         db_backend="sqlite",
         db_local=str(tmp_path / "laws.sqlite3"),
         db_cloud="",
-        storage_local="",
+        storage_local=str(tmp_path / "files"),
         storage_cloud="",
         delta_poll_hours=3,
         initial_import_from=date(1993, 1, 1),

--- a/tests/test_laws_collector_zip_import.py
+++ b/tests/test_laws_collector_zip_import.py
@@ -12,7 +12,6 @@ from services.laws_collector.slovlex_zip_import import (
     SlovLexExportIndex,
     SlovLexMonthlyExport,
     SlovLexZipImportRunner,
-    _extract_zip_archive,
     parse_export_index_html,
 )
 
@@ -240,7 +239,75 @@ def test_zip_import_runner_skips_monthly_export_covered_by_completed_archive(tmp
     assert summary.monthly_completed is True
 
 
-def test_zip_import_runner_processes_archive_seed(tmp_path: Path, monkeypatch) -> None:
+def test_zip_import_runner_skips_already_completed_monthly_export(tmp_path: Path) -> None:
+    store, service, config = _build_service(tmp_path)
+    store.upsert_import_state(
+        CollectorImportState(
+            country_code="SK",
+            source_system="slov-lex",
+            import_key="slov-lex:zip:archive-seed",
+            import_label="archive seed 2026-04-01",
+            source_url="https://static.slov-lex.sk/static/exporty/ZZ/export.zip",
+            status="completed",
+            started_at="2026-04-01T00:00:00Z",
+            last_processed_at="2026-04-01T00:00:00Z",
+            last_processed_entry="changed/SK/ZZ/1993/1/19930101.html",
+            last_processed_law_year=1993,
+            last_processed_law_number=1,
+            completed_at="2026-04-01T00:00:00Z",
+            metadata={"archive_snapshot_date": "2026-04-01", "phase": "archive"},
+        )
+    )
+    store.upsert_import_state(
+        CollectorImportState(
+            country_code="SK",
+            source_system="slov-lex",
+            import_key="slov-lex:zip:monthly:2026-04-02_2026-04-15",
+            import_label="monthly 2026-04-02..2026-04-15",
+            source_url="https://static.slov-lex.sk/static/exporty/ZZ/exportZmeny.zip",
+            status="completed",
+            started_at="2026-04-15T00:00:00Z",
+            last_processed_at="2026-04-15T00:00:00Z",
+            last_processed_entry="changed/SK/ZZ/1993/2/19930201.html",
+            last_processed_law_year=1993,
+            last_processed_law_number=2,
+            completed_at="2026-04-15T00:00:00Z",
+            metadata={
+                "monthly_range_start": "2026-04-02",
+                "monthly_range_end": "2026-04-15",
+                "phase": "monthly",
+            },
+        )
+    )
+
+    class FakeIndexLoader:
+        def load(self, *, timeout_seconds: float = 30.0) -> SlovLexExportIndex:
+            return SlovLexExportIndex(
+                archive_export=SlovLexArchiveExport(
+                    snapshot_date="2026-04-01",
+                    part_urls=("https://static.slov-lex.sk/static/exporty/ZZ/export.zip",),
+                ),
+                monthly_export=SlovLexMonthlyExport(
+                    range_start="2026-04-02",
+                    range_end="2026-04-15",
+                    zip_url="https://static.slov-lex.sk/static/exporty/ZZ/exportZmeny.zip",
+                ),
+            )
+
+    summary = SlovLexZipImportRunner(
+        config=config,
+        store=store,
+        service=service,
+        export_index_loader=FakeIndexLoader(),
+    ).run()
+
+    assert summary.phase == "monthly"
+    assert summary.skipped_as_already_completed is True
+    assert summary.entries_processed == 0
+    assert summary.monthly_completed is True
+
+
+def test_zip_import_runner_processes_archive_seed(tmp_path: Path) -> None:
     store, service, config = _build_service(tmp_path)
     archive_zip = tmp_path / "fixtures" / "export.zip"
     _create_monthly_zip(
@@ -250,9 +317,6 @@ def test_zip_import_runner_processes_archive_seed(tmp_path: Path, monkeypatch) -
             (1993, 2, "Druhy zakon", "1993-02-01"),
         ],
     )
-
-    def fake_extract_archive_bundle(*, download_root: Path, extract_root: Path) -> None:
-        _extract_zip_archive(zip_path=download_root / "export.zip", extract_root=extract_root)
 
     class FakeIndexLoader:
         def load(self, *, timeout_seconds: float = 30.0) -> SlovLexExportIndex:
@@ -264,10 +328,6 @@ def test_zip_import_runner_processes_archive_seed(tmp_path: Path, monkeypatch) -
                 monthly_export=None,
             )
 
-    monkeypatch.setattr(
-        "services.laws_collector.slovlex_zip_import._extract_archive_bundle",
-        fake_extract_archive_bundle,
-    )
     summary = SlovLexZipImportRunner(
         config=config,
         store=store,

--- a/tests/test_laws_collector_zip_import.py
+++ b/tests/test_laws_collector_zip_import.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from datetime import date
 from pathlib import Path
+import sqlite3
 import zipfile
 
 from aijurisdictionagents.llm.embeddings import MockEmbeddingClient
+from services.laws_collector.archive_storage import StoredArchiveObject
 from services.laws_collector import LawsCollectorConfig, SqliteLawStore, SlovakLawsCollectorService
 from services.laws_collector.domain import CollectorImportState
 from services.laws_collector.slovlex_zip_import import (
@@ -22,7 +24,7 @@ def _build_service(tmp_path: Path) -> tuple[SqliteLawStore, SlovakLawsCollectorS
         db_backend="sqlite",
         db_local=str(tmp_path / "laws.sqlite3"),
         db_cloud="",
-        storage_local="",
+        storage_local=str(tmp_path / "files"),
         storage_cloud="",
         delta_poll_hours=3,
         initial_import_from=date(1993, 1, 1),
@@ -37,6 +39,11 @@ def _build_service(tmp_path: Path) -> tuple[SqliteLawStore, SlovakLawsCollectorS
         embedding_client=MockEmbeddingClient(),
     )
     return store, service, config
+
+
+def test_slovak_archive_root_defaults_to_laws_collection_sk(tmp_path: Path) -> None:
+    _, _, config = _build_service(tmp_path)
+    assert config.archive_root.as_posix().endswith("/archivelaws/laws-collection-sk")
 
 
 def _build_html(*, number: int, year: int, title: str, effective_from: str) -> str:
@@ -140,6 +147,52 @@ def test_zip_import_runner_imports_monthly_zip_and_marks_state_complete(tmp_path
     assert state.status == "completed"
     assert state.last_processed_law == "2/1993"
     assert store.get_counts().documents == 2
+
+
+def test_zip_import_runner_persists_html_source_artifact_references(tmp_path: Path) -> None:
+    store, service, config = _build_service(tmp_path)
+    monthly_zip = tmp_path / "fixtures" / "exportZmeny.zip"
+    _create_monthly_zip(
+        monthly_zip,
+        laws=[(1993, 1, "Prvy zakon", "1993-01-01")],
+    )
+
+    class FakeIndexLoader:
+        def load(self, *, timeout_seconds: float = 30.0) -> SlovLexExportIndex:
+            return SlovLexExportIndex(
+                archive_export=None,
+                monthly_export=SlovLexMonthlyExport(
+                    range_start="2026-03-01",
+                    range_end="2026-04-01",
+                    zip_url=monthly_zip.resolve().as_uri(),
+                ),
+            )
+
+    SlovLexZipImportRunner(
+        config=config,
+        store=store,
+        service=service,
+        export_index_loader=FakeIndexLoader(),
+    ).run()
+
+    with sqlite3.connect(config.db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            """
+            SELECT artifact_kind, storage_backend, storage_path, content_text, content_blob
+            FROM source_artifacts
+            WHERE artifact_kind = 'html'
+            ORDER BY fetched_at
+            LIMIT 1
+            """
+        ).fetchone()
+
+    assert row is not None
+    assert row["artifact_kind"] == "html"
+    assert row["storage_backend"] == "local_file"
+    assert Path(str(row["storage_path"])).exists()
+    assert row["content_blob"] is None
+    assert "Ustanovenie pre Prvy zakon." in str(row["content_text"])
 
 
 def test_zip_import_runner_resumes_after_timeout(tmp_path: Path) -> None:
@@ -342,3 +395,132 @@ def test_zip_import_runner_processes_archive_seed(tmp_path: Path) -> None:
     assert state.status == "completed"
     assert state.metadata["archive_snapshot_date"] == "2026-04-01"
     assert store.get_counts().documents == 2
+
+
+def test_zip_import_runner_updates_collector_progress(tmp_path: Path) -> None:
+    store, service, config = _build_service(tmp_path)
+    archive_zip = tmp_path / "fixtures" / "export.zip"
+    _create_monthly_zip(
+        archive_zip,
+        laws=[
+            (1993, 1, "Prvy zakon", "1993-01-01"),
+            (1993, 2, "Druhy zakon", "1993-02-01"),
+        ],
+    )
+
+    class FakeIndexLoader:
+        def load(self, *, timeout_seconds: float = 30.0) -> SlovLexExportIndex:
+            return SlovLexExportIndex(
+                archive_export=SlovLexArchiveExport(
+                    snapshot_date="2026-04-01",
+                    part_urls=(archive_zip.resolve().as_uri(),),
+                ),
+                monthly_export=None,
+            )
+
+    SlovLexZipImportRunner(
+        config=config,
+        store=store,
+        service=service,
+        export_index_loader=FakeIndexLoader(),
+    ).run()
+
+    progress = store.get_or_create_collector_progress(
+        country_code="SK",
+        source_system="slov-lex",
+        initial_year=1993,
+    )
+    assert progress.last_processed_law == "2/1993"
+    assert progress.last_processed_at is not None
+    assert progress.last_collector_run_at is not None
+
+
+def test_zip_import_runner_reextracts_when_marker_signature_does_not_match(tmp_path: Path) -> None:
+    store, service, config = _build_service(tmp_path)
+    archive_root = config.archive_root / "archive" / "2026-04-01"
+    extract_root = archive_root / "extract"
+    extract_root.mkdir(parents=True, exist_ok=True)
+    (extract_root / ".extract.complete").write_text("2026-04-01T00:00:00Z", encoding="utf-8")
+    stale_entry = extract_root / "changed" / "SK" / "ZZ" / "1993" / "999" / "19990101.html"
+    stale_entry.parent.mkdir(parents=True, exist_ok=True)
+    stale_entry.write_text("stale", encoding="utf-8")
+
+    archive_zip = tmp_path / "fixtures" / "export.zip"
+    _create_monthly_zip(
+        archive_zip,
+        laws=[(1993, 1, "Prvy zakon", "1993-01-01")],
+    )
+
+    class FakeIndexLoader:
+        def load(self, *, timeout_seconds: float = 30.0) -> SlovLexExportIndex:
+            return SlovLexExportIndex(
+                archive_export=SlovLexArchiveExport(
+                    snapshot_date="2026-04-01",
+                    part_urls=(archive_zip.resolve().as_uri(),),
+                ),
+                monthly_export=None,
+            )
+
+    SlovLexZipImportRunner(
+        config=config,
+        store=store,
+        service=service,
+        export_index_loader=FakeIndexLoader(),
+    ).run()
+
+    assert not stale_entry.exists()
+    assert (extract_root / "changed" / "SK" / "ZZ" / "1993" / "1" / "19930101.html").exists()
+
+
+def test_zip_import_runner_records_archive_assets_and_marks_them_processed(tmp_path: Path) -> None:
+    store, service, config = _build_service(tmp_path)
+    archive_zip = tmp_path / "fixtures" / "export.zip"
+    _create_monthly_zip(
+        archive_zip,
+        laws=[(1993, 1, "Prvy zakon", "1993-01-01")],
+    )
+
+    class FakeIndexLoader:
+        def load(self, *, timeout_seconds: float = 30.0) -> SlovLexExportIndex:
+            return SlovLexExportIndex(
+                archive_export=SlovLexArchiveExport(
+                    snapshot_date="2026-04-01",
+                    part_urls=(archive_zip.resolve().as_uri(),),
+                ),
+                monthly_export=None,
+            )
+
+    class FakeArchiveObjectStore:
+        def persist_file(self, *, source_path: Path, relative_path: str) -> StoredArchiveObject:
+            return StoredArchiveObject(
+                storage_backend="azure_blob",
+                storage_path=f"https://example.blob.core.windows.net/laws-collection-sk/{relative_path}",
+            )
+
+    SlovLexZipImportRunner(
+        config=config,
+        store=store,
+        service=service,
+        export_index_loader=FakeIndexLoader(),
+        archive_object_store=FakeArchiveObjectStore(),
+    ).run()
+
+    with sqlite3.connect(config.db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            """
+            SELECT import_key, phase, asset_name, storage_backend, storage_path,
+                   processing_status, metadata_json
+            FROM archive_import_assets
+            WHERE import_key = ?
+            """,
+            ("slov-lex:zip:archive-seed",),
+        ).fetchone()
+
+    assert row is not None
+    assert row["phase"] == "archive"
+    assert row["asset_name"] == "export.zip"
+    assert row["storage_backend"] == "azure_blob"
+    assert row["processing_status"] == "processed"
+    assert "laws-collection-sk/sk/archive/2026-04-01/download/export.zip" in str(row["storage_path"])
+    assert "archive_snapshot_date" in str(row["metadata_json"])


### PR DESCRIPTION
## Summary
- make ZIP import state transitions and skip/resume behavior explicit in laws collector logs
- support extracting a single export.zip archive in addition to split archive bundles
- add local PostgreSQL replay demo and regression coverage for archive, monthly, and skip scenarios

## Testing
- .\\.conda\\python.exe -m pytest tests/test_laws_collector_zip_import.py -q
- .\\.conda\\python.exe -m ruff check src/services/laws_collector/slovlex_zip_import.py tests/test_laws_collector_zip_import.py examples/laws_collector_zip_postgres_state_demo.py
- .\\.conda\\python.exe examples/laws_collector_zip_postgres_state_demo.py