### PR TITLE
Connect frontend workspace to API chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,15 @@ LLM_PROVIDER=azurefoundry
 # GitHub Project automation
 # GH_PROJECT_TOKEN=ghp_xxx
 
+# Frontend Vite runtime (frontend/aijurisdictionfronend)
+# VITE_API_BASE_URL=https://api-juris-dev.victoriousdesert-e45eec11.westeurope.azurecontainerapps.io
+# VITE_API_KEY=aijuris
+# VITE_API_COUNTRY=SK
+# VITE_API_LANGUAGE=en
+
+# Shared API endpoint override for local scripts/examples
+# AIJ_API_BASE_URL=https://api-juris-dev.victoriousdesert-e45eec11.westeurope.azurecontainerapps.io
+
 # Mobile Android release signing for CI/GitHub Release APKs.
 # Use one stable keystore for every published mobile release so Android in-app
 # upgrades keep the same package signature across versions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,3 +82,9 @@ Custom project skills:
 - `start-mobile-app` at `skills/start-mobile-app/SKILL.md`
   - Purpose: start and verify the local Flutter mobile app.
   - Script: `.\skills\start-mobile-app\scripts\start_mobile_app.ps1`
+- `start-frontend-api` at `skills/start-frontend-api/SKILL.md`
+  - Purpose: start the local React frontend wired to the local API and verify readiness.
+  - Script: `.\skills\start-frontend-api\scripts\start_frontend_api.ps1`
+- `frontend-api` at `skills/frontend-api/SKILL.md`
+  - Purpose: alias skill to start frontend wired to API using the same launcher.
+  - Script: `.\skills\start-frontend-api\scripts\start_frontend_api.ps1`

--- a/examples/frontend_api_chat_minimal_demo.py
+++ b/examples/frontend_api_chat_minimal_demo.py
@@ -1,0 +1,96 @@
+"""Minimal runnable demo for Task #238 frontend/API chat connectivity.
+
+Run:
+    python examples/frontend_api_chat_minimal_demo.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+API_BASE_URL = os.getenv(
+    "AIJ_API_BASE_URL",
+    "https://api-juris-dev.victoriousdesert-e45eec11.westeurope.azurecontainerapps.io",
+).rstrip("/")
+API_KEY = os.getenv("AIJ_API_KEY", "aijuris")
+
+
+def _safe_print(message: str) -> None:
+    encoding = sys.stdout.encoding or "utf-8"
+    sys.stdout.buffer.write((message + "\n").encode(encoding, errors="replace"))
+
+
+def _request_json(method: str, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    body = None
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url=f"{API_BASE_URL}{path}",
+        method=method,
+        data=body,
+        headers={
+            "x-api-key": API_KEY,
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            content = response.read().decode("utf-8")
+            return json.loads(content) if content else {}
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {exc.code} on {path}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            f"Unable to connect to API at {API_BASE_URL}. "
+            "Set AIJ_API_BASE_URL to a reachable API or start the local API first."
+        ) from exc
+
+
+def main() -> None:
+    _safe_print(f"API base URL: {API_BASE_URL}")
+    session = _request_json(
+        "POST",
+        "/v1/chat/sessions",
+        {
+            "country": "SK",
+            "language": "en",
+            "discussion_type": "advice",
+            # Use a standalone API session for local frontend simulation.
+            # Passing a non-existent case_id can trigger DB FK failures on /reply.
+            "case_id": None,
+        },
+    )
+    session_id = str(session.get("id", ""))
+    if not session_id:
+        raise RuntimeError("Session creation failed: missing session id.")
+    _safe_print(f"Session created: {session_id}")
+
+    prompts = [
+        ("chat", "Please summarize the next legal step for this contract dispute."),
+        ("voice", "Voice message transcript from the user: Please highlight major legal risks."),
+        (
+            "video",
+            "Video message transcript from the user: Give a stakeholder-ready legal briefing.",
+        ),
+    ]
+    for mode, prompt in prompts:
+        reply = _request_json(
+            "POST",
+            f"/v1/chat/sessions/{session_id}/reply",
+            {"content": prompt},
+        )
+        actor = reply.get("agent_name") or "AI Assistant"
+        content = str(reply.get("content", "")).strip()
+        _safe_print(f"\n[{mode.upper()}] {actor}")
+        _safe_print(content[:400] + ("..." if len(content) > 400 else ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/aijurisdictionfronend/.env.example
+++ b/frontend/aijurisdictionfronend/.env.example
@@ -1,2 +1,6 @@
 VITE_AUTH_GOOGLE_START_URL=
 VITE_AUTH_X_START_URL=
+VITE_API_BASE_URL=https://api-juris-dev.victoriousdesert-e45eec11.westeurope.azurecontainerapps.io
+VITE_API_KEY=aijuris
+VITE_API_COUNTRY=SK
+VITE_API_LANGUAGE=en

--- a/frontend/aijurisdictionfronend/README.md
+++ b/frontend/aijurisdictionfronend/README.md
@@ -20,6 +20,29 @@ npm run dev
 
 Open `http://localhost:5173`.
 
+## API Chat Integration (Task #238)
+
+The signed-in workspace now uses the live API for case communication in all three modes (`Chat`, `Voice`, `Video`).
+Voice and video are simulated by sending transcript payloads through the same chat reply endpoint.
+
+Frontend environment variables:
+
+- `VITE_API_BASE_URL` (default: `https://api-juris-dev.victoriousdesert-e45eec11.westeurope.azurecontainerapps.io`)
+- `VITE_API_KEY` (default: `aijuris`)
+- `VITE_API_COUNTRY` (default: `SK`)
+- `VITE_API_LANGUAGE` (default: `en`)
+
+Flow used by the workspace:
+
+1. `POST /v1/chat/sessions` once per case.
+2. `POST /v1/chat/sessions/{session_id}/reply` for each outgoing user message.
+3. The API response is appended back to the active case timeline.
+
+Console logging:
+
+- Frontend emits process logs to browser console with `INFO`, `WARN`, and `ERROR` levels.
+- API request lifecycle and failures are logged with structured JSON context.
+
 ## Simulated Login (Frontend-only)
 
 The UI includes an in-memory auth state used for local development. It resets on refresh.
@@ -130,3 +153,12 @@ Task-specific frontend check:
 ```bash
 python examples/frontend_navbar_task_211_minimal_demo.py
 ```
+
+Task #238 API chat minimal demo:
+
+```bash
+python examples/frontend_api_chat_minimal_demo.py
+```
+
+The demo defaults to the shared Azure dev API endpoint. Override it for local API testing with
+`AIJ_API_BASE_URL=http://127.0.0.1:8080`.

--- a/frontend/aijurisdictionfronend/src/api/chatClient.ts
+++ b/frontend/aijurisdictionfronend/src/api/chatClient.ts
@@ -1,0 +1,169 @@
+import { consoleLogger } from "../logging/consoleLogger";
+
+const DEFAULT_API_BASE_URL =
+  "https://api-juris-dev.victoriousdesert-e45eec11.westeurope.azurecontainerapps.io";
+const DEFAULT_API_KEY = "aijuris";
+const DEFAULT_COUNTRY = "SK";
+const DEFAULT_LANGUAGE = "en";
+
+export type ChatMessageRole = "user" | "assistant" | "system";
+
+export type ChatSession = {
+  id: string;
+  user_id: string | null;
+  case_id: string | null;
+  country: string;
+  language: string | null;
+  discussion_type: "advice" | "court";
+  state: string;
+  created_at: string;
+};
+
+export type ChatMessage = {
+  id: string;
+  session_id: string;
+  role: ChatMessageRole;
+  content: string;
+  agent_name: string | null;
+  created_at: string;
+};
+
+export type CreateChatSessionInput = {
+  caseId?: string;
+  country?: string;
+  language?: string;
+  discussionType?: "advice" | "court";
+};
+
+export type ReplyToSessionInput = {
+  sessionId: string;
+  content: string;
+};
+
+export class ApiRequestError extends Error {
+  kind: "network" | "http";
+  status?: number;
+
+  constructor(kind: "network" | "http", message: string, status?: number) {
+    super(message);
+    this.name = "ApiRequestError";
+    this.kind = kind;
+    this.status = status;
+  }
+}
+
+type RuntimeApiConfig = {
+  baseUrl: string;
+  apiKey: string;
+  country: string;
+  language: string;
+};
+
+const resolveApiConfig = (): RuntimeApiConfig => {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL?.trim() || DEFAULT_API_BASE_URL;
+  const apiKey = import.meta.env.VITE_API_KEY?.trim() || DEFAULT_API_KEY;
+  const country = import.meta.env.VITE_API_COUNTRY?.trim() || DEFAULT_COUNTRY;
+  const language = import.meta.env.VITE_API_LANGUAGE?.trim() || DEFAULT_LANGUAGE;
+  return {
+    baseUrl: baseUrl.replace(/\/+$/, ""),
+    apiKey,
+    country,
+    language
+  };
+};
+
+const parseErrorBody = async (response: Response): Promise<string> => {
+  try {
+    const payload = (await response.json()) as { detail?: string; message?: string };
+    return payload.detail || payload.message || `HTTP ${response.status}`;
+  } catch {
+    try {
+      const textPayload = (await response.text()).trim();
+      return textPayload || `HTTP ${response.status}`;
+    } catch {
+      return `HTTP ${response.status}`;
+    }
+  }
+};
+
+const requestJson = async <T>(path: string, init: RequestInit): Promise<T> => {
+  const config = resolveApiConfig();
+  const url = `${config.baseUrl}${path}`;
+  const method = init.method || "GET";
+
+  consoleLogger.info("Sending API request", {
+    method,
+    path,
+    url
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(url, init);
+  } catch (error) {
+    consoleLogger.error(
+      "API network request failed",
+      {
+        method,
+        path,
+        url
+      },
+      error
+    );
+    throw new ApiRequestError(
+      "network",
+      "Network request failed. Check API availability, CORS, and URL/protocol."
+    );
+  }
+
+  if (!response.ok) {
+    const detail = await parseErrorBody(response);
+    consoleLogger.warn("API request failed", {
+      method,
+      path,
+      status: response.status,
+      detail
+    });
+    throw new ApiRequestError("http", detail, response.status);
+  }
+
+  consoleLogger.info("API request succeeded", {
+    method,
+    path,
+    status: response.status
+  });
+  return (await response.json()) as T;
+};
+
+export const createChatSession = async (input: CreateChatSessionInput = {}): Promise<ChatSession> => {
+  const config = resolveApiConfig();
+  return requestJson<ChatSession>("/v1/chat/sessions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": config.apiKey
+    },
+    body: JSON.stringify({
+      case_id: input.caseId || null,
+      country: input.country || config.country,
+      language: input.language || config.language,
+      discussion_type: input.discussionType || "advice"
+    })
+  });
+};
+
+export const replyToSession = async (input: ReplyToSessionInput): Promise<ChatMessage> => {
+  const config = resolveApiConfig();
+  return requestJson<ChatMessage>(`/v1/chat/sessions/${input.sessionId}/reply`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": config.apiKey
+    },
+    body: JSON.stringify({
+      content: input.content
+    })
+  });
+};
+
+export const chatApiRuntimeConfig = resolveApiConfig;

--- a/frontend/aijurisdictionfronend/src/logging/consoleLogger.ts
+++ b/frontend/aijurisdictionfronend/src/logging/consoleLogger.ts
@@ -1,0 +1,58 @@
+export type LogLevel = "INFO" | "WARN" | "ERROR";
+
+type LogContext = Record<string, unknown> | undefined;
+
+const formatPrefix = (level: LogLevel): string => {
+  return `[${new Date().toISOString()}] [${level}]`;
+};
+
+const safeStringify = (value: unknown): string => {
+  try {
+    return JSON.stringify(value, (_key, currentValue) => {
+      if (currentValue instanceof Error) {
+        return {
+          name: currentValue.name,
+          message: currentValue.message,
+          stack: currentValue.stack
+        };
+      }
+      return currentValue;
+    });
+  } catch {
+    return "{\"error\":\"unable_to_stringify_log_context\"}";
+  }
+};
+
+const formatLine = (level: LogLevel, message: string, context?: LogContext): string => {
+  const suffix = context ? ` | ${safeStringify(context)}` : "";
+  return `${formatPrefix(level)} ${message}${suffix}`;
+};
+
+const write = (level: LogLevel, message: string, context?: LogContext, error?: unknown): void => {
+  const line = formatLine(level, message, context);
+  if (level === "ERROR") {
+    if (typeof error === "undefined") {
+      console.error(line);
+      return;
+    }
+    console.error(line, error);
+    return;
+  }
+  if (level === "WARN") {
+    console.warn(line);
+    return;
+  }
+  console.info(line);
+};
+
+export const consoleLogger = {
+  info: (message: string, context?: LogContext): void => {
+    write("INFO", message, context);
+  },
+  warn: (message: string, context?: LogContext): void => {
+    write("WARN", message, context);
+  },
+  error: (message: string, context?: LogContext, error?: unknown): void => {
+    write("ERROR", message, context, error);
+  }
+};

--- a/frontend/aijurisdictionfronend/src/pages/Home.tsx
+++ b/frontend/aijurisdictionfronend/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { FiMessageSquare, FiMic, FiVideo } from "react-icons/fi";
+import { ApiRequestError } from "../api/chatClient";
 import { useAuth } from "../auth/mockAuth";
 import { useLanguage } from "../components/LanguageProvider";
 import WorkspaceWelcome from "../components/WorkspaceWelcome";
@@ -16,10 +17,14 @@ const Home: React.FC = () => {
     continueRequested,
     setContinueRequested,
     addInteraction,
+    sendCaseMessage,
     setCaseRole,
     setCaseCommunicationMode
   } = useCases();
   const [draftMessage, setDraftMessage] = React.useState("");
+  const [modeDraftMessage, setModeDraftMessage] = React.useState("");
+  const [isSendingMessage, setIsSendingMessage] = React.useState(false);
+  const [apiError, setApiError] = React.useState<string | null>(null);
   const roleOptions = React.useMemo(
     () => [
       {
@@ -69,13 +74,79 @@ const Home: React.FC = () => {
 
     const showWelcome = !hasSelectedCase;
 
-    const handleSendMessage = (event: React.FormEvent) => {
+    const submitMessageToApi = async (
+      communicationMode: CaseCommunicationMode,
+      content: string
+    ): Promise<boolean> => {
+      if (!activeCase) {
+        return false;
+      }
+
+      const normalized = content.trim();
+      if (!normalized) {
+        return false;
+      }
+
+      const userActor = communicationMode === "Chat" ? "You" : `You (${communicationMode})`;
+      addInteraction(activeCase.id, userActor, normalized);
+      setApiError(null);
+      setIsSendingMessage(true);
+
+      try {
+        const response = await sendCaseMessage({
+          caseId: activeCase.id,
+          content: normalized,
+          communicationMode
+        });
+        addInteraction(activeCase.id, response.assistantActor, response.assistantMessage);
+        return true;
+      } catch (error) {
+        const fallbackMessage = "Unknown API error.";
+        const apiErrorMessage = error instanceof Error ? error.message : fallbackMessage;
+
+        if (error instanceof ApiRequestError && error.kind === "network") {
+          setApiError(`Unable to reach API. ${apiErrorMessage}`);
+          addInteraction(activeCase.id, "System", `Unable to reach API. ${apiErrorMessage}`);
+          return false;
+        }
+
+        setApiError(`API request failed. ${apiErrorMessage}`);
+        addInteraction(activeCase.id, "System", `API request failed. ${apiErrorMessage}`);
+        return false;
+      } finally {
+        setIsSendingMessage(false);
+      }
+    };
+
+    const handleSendMessage = async (event: React.FormEvent) => {
       event.preventDefault();
-      if (!activeCase || !draftMessage.trim()) {
+      const sent = await submitMessageToApi("Chat", draftMessage);
+      if (sent) {
+        setDraftMessage("");
+      }
+    };
+
+    const handleModeMessageSend = async () => {
+      if (!activeCase) {
         return;
       }
-      addInteraction(activeCase.id, "You", draftMessage.trim());
-      setDraftMessage("");
+      const sent = await submitMessageToApi(activeCase.selectedCommunicationMode, modeDraftMessage);
+      if (sent) {
+        setModeDraftMessage("");
+      }
+    };
+
+    const handleNextAction = async () => {
+      if (!activeCase) {
+        return;
+      }
+      const defaultPrompt =
+        activeCase.selectedCommunicationMode === "Voice"
+          ? "Please run a voice-style legal briefing for the current case."
+          : activeCase.selectedCommunicationMode === "Video"
+            ? "Please run a video-style legal briefing for the current case."
+            : "Please continue the legal chat for the current case with next steps.";
+      await submitMessageToApi(activeCase.selectedCommunicationMode, defaultPrompt);
     };
 
     return (
@@ -120,7 +191,7 @@ const Home: React.FC = () => {
                         <div className="workspace-chat">
                           <div className="workspace-chat__history">
                             {activeCase?.interactionHistory.map((item) => {
-                              const isUser = item.actor === "You";
+                              const isUser = item.actor.startsWith("You");
                               return (
                                 <article
                                   key={item.id}
@@ -141,11 +212,24 @@ const Home: React.FC = () => {
                               value={draftMessage}
                               onChange={(event) => setDraftMessage(event.target.value)}
                               placeholder="Type your message..."
+                              disabled={isSendingMessage}
                             />
-                            <button type="submit" className="button primary">
-                              Send
+                            <button
+                              type="submit"
+                              className="button primary"
+                              disabled={isSendingMessage || !draftMessage.trim()}
+                            >
+                              {isSendingMessage ? "Sending..." : "Send"}
                             </button>
                           </form>
+                          <p className="workspace-chat__status">
+                            {isSendingMessage ? "Waiting for API response..." : "Connected through API chat."}
+                          </p>
+                          {apiError ? (
+                            <p className="workspace-chat__status workspace-chat__status--error">
+                              API error: {apiError}
+                            </p>
+                          ) : null}
                         </div>
                       ) : (
                         <article className="workspace-mode-card">
@@ -159,17 +243,49 @@ const Home: React.FC = () => {
                               ? t("commsVoiceBody")
                               : t("commsVideoBody")}
                           </p>
-                          <button type="button" className="button primary">
-                            {activeCase?.selectedCommunicationMode === "Voice"
-                              ? t("commsVoiceAction")
-                              : t("commsVideoAction")}
+                          <label className="workspace-mode-card__input-label" htmlFor="mode-transcript">
+                            Message transcript
+                          </label>
+                          <textarea
+                            id="mode-transcript"
+                            className="workspace-mode-card__textarea"
+                            value={modeDraftMessage}
+                            onChange={(event) => setModeDraftMessage(event.target.value)}
+                            placeholder={
+                              activeCase?.selectedCommunicationMode === "Voice"
+                                ? "Write a voice message transcript..."
+                                : "Write a video message transcript..."
+                            }
+                            disabled={isSendingMessage}
+                          />
+                          <button
+                            type="button"
+                            className="button primary"
+                            onClick={handleModeMessageSend}
+                            disabled={isSendingMessage || !modeDraftMessage.trim()}
+                          >
+                            {isSendingMessage
+                              ? "Sending..."
+                              : activeCase?.selectedCommunicationMode === "Voice"
+                                ? "Send voice transcript"
+                                : "Send video transcript"}
                           </button>
+                          {apiError ? (
+                            <p className="workspace-chat__status workspace-chat__status--error">
+                              API error: {apiError}
+                            </p>
+                          ) : null}
                         </article>
                       )}
                       <article className="workspace-callout">
                         <h3>Next recommended action</h3>
                         <p>{activeCase?.workspace.nextAction}</p>
-                        <button type="button" className="button primary">
+                        <button
+                          type="button"
+                          className="button primary"
+                          onClick={handleNextAction}
+                          disabled={isSendingMessage}
+                        >
                           {
                             communicationModeOptions.find(
                               (option) => option.mode === activeCase?.selectedCommunicationMode

--- a/frontend/aijurisdictionfronend/src/state/CaseProvider.tsx
+++ b/frontend/aijurisdictionfronend/src/state/CaseProvider.tsx
@@ -1,9 +1,23 @@
 import React from "react";
+import { createChatSession, replyToSession } from "../api/chatClient";
+import { consoleLogger } from "../logging/consoleLogger";
 
 export type CaseStatus = "In progress" | "On hold" | "Scheduled" | "Completed";
 export type CaseMode = "Draft" | "Review" | "Live" | "Archive";
 export type CaseRole = "AI Lawyer" | "AI Judge" | "Opposing Counsel";
 export type CaseCommunicationMode = "Chat" | "Voice" | "Video";
+
+export type SendCaseMessageInput = {
+  caseId: string;
+  content: string;
+  communicationMode: CaseCommunicationMode;
+};
+
+export type SendCaseMessageResult = {
+  sessionId: string;
+  assistantActor: string;
+  assistantMessage: string;
+};
 
 export type CaseInteraction = {
   id: string;
@@ -44,6 +58,7 @@ type CaseContextValue = {
   selectCase: (caseId: string) => void;
   setContinueRequested: (value: boolean) => void;
   addInteraction: (caseId: string, actor: string, message: string) => void;
+  sendCaseMessage: (input: SendCaseMessageInput) => Promise<SendCaseMessageResult>;
   updateCase: (caseId: string, update: Partial<CaseRecord>) => void;
   setCaseRole: (caseId: string, role: CaseRole) => void;
   setCaseMode: (caseId: string, mode: CaseMode) => void;
@@ -239,11 +254,25 @@ const buildNewCase = (index: number): CaseRecord => {
   };
 };
 
+const toApiMessageContent = (
+  content: string,
+  communicationMode: CaseCommunicationMode
+): string => {
+  if (communicationMode === "Voice") {
+    return `Voice message transcript from the user:\n${content}`;
+  }
+  if (communicationMode === "Video") {
+    return `Video message transcript from the user:\n${content}`;
+  }
+  return content;
+};
+
 export const CaseProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [cases, setCases] = React.useState<CaseRecord[]>(initialCases);
   const [activeCaseId, setActiveCaseId] = React.useState<string | null>(initialCases[0]?.id ?? null);
   const [hasSelectedCase, setHasSelectedCase] = React.useState(false);
   const [continueRequested, setContinueRequested] = React.useState(false);
+  const sessionIdsByCaseRef = React.useRef<Record<string, string>>({});
 
   const activeCase = React.useMemo(() => {
     return cases.find((caseItem) => caseItem.id === activeCaseId) ?? cases[0] ?? null;
@@ -294,6 +323,58 @@ export const CaseProvider: React.FC<{ children: React.ReactNode }> = ({ children
     []
   );
 
+  const ensureCaseSessionId = React.useCallback(async (caseId: string): Promise<string> => {
+    const existingSessionId = sessionIdsByCaseRef.current[caseId];
+    if (existingSessionId) {
+      return existingSessionId;
+    }
+
+    // Frontend sidebar case ids are local-only (not persisted in API DB), so we open
+    // API chat sessions without case_id for stable chat simulation.
+    const session = await createChatSession();
+    sessionIdsByCaseRef.current[caseId] = session.id;
+
+    consoleLogger.info("Created API session for case", {
+      caseId,
+      sessionId: session.id
+    });
+
+    return session.id;
+  }, []);
+
+  const sendCaseMessage = React.useCallback(
+    async (input: SendCaseMessageInput): Promise<SendCaseMessageResult> => {
+      const caseExists = cases.some((caseItem) => caseItem.id === input.caseId);
+      if (!caseExists) {
+        throw new Error(`Case ${input.caseId} was not found.`);
+      }
+      const normalizedContent = input.content.trim();
+      if (!normalizedContent) {
+        throw new Error("Message content is required.");
+      }
+
+      const sessionId = await ensureCaseSessionId(input.caseId);
+      const apiContent = toApiMessageContent(normalizedContent, input.communicationMode);
+      consoleLogger.info("Sending case communication through API", {
+        caseId: input.caseId,
+        sessionId,
+        communicationMode: input.communicationMode
+      });
+
+      const assistantMessage = await replyToSession({
+        sessionId,
+        content: apiContent
+      });
+
+      return {
+        sessionId,
+        assistantActor: assistantMessage.agent_name?.trim() || "AI Assistant",
+        assistantMessage: assistantMessage.content
+      };
+    },
+    [cases, ensureCaseSessionId]
+  );
+
   const setCaseRole = React.useCallback((caseId: string, role: CaseRole) => {
     updateCase(caseId, { selectedRole: role });
   }, [updateCase]);
@@ -321,6 +402,7 @@ export const CaseProvider: React.FC<{ children: React.ReactNode }> = ({ children
       selectCase,
       setContinueRequested,
       addInteraction,
+      sendCaseMessage,
       updateCase,
       setCaseRole,
       setCaseMode,
@@ -337,6 +419,7 @@ export const CaseProvider: React.FC<{ children: React.ReactNode }> = ({ children
       selectCase,
       setContinueRequested,
       addInteraction,
+      sendCaseMessage,
       updateCase,
       setCaseRole,
       setCaseMode,

--- a/frontend/aijurisdictionfronend/src/styles/app.css
+++ b/frontend/aijurisdictionfronend/src/styles/app.css
@@ -1381,6 +1381,26 @@ textarea {
   gap: 0.9rem;
 }
 
+.workspace-mode-card__input-label {
+  font-size: 0.85rem;
+  color: var(--ink-muted);
+}
+
+.workspace-mode-card__textarea {
+  width: 100%;
+  min-height: 7rem;
+  border-radius: 12px;
+  border: 1px solid rgba(31, 27, 22, 0.12);
+  padding: 0.75rem 0.9rem;
+  font: inherit;
+  resize: vertical;
+}
+
+.workspace-mode-card__textarea:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--brand) 35%, transparent);
+  outline-offset: 1px;
+}
+
 .workspace-chat__history {
   display: grid;
   gap: 1rem;
@@ -1416,5 +1436,15 @@ textarea {
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 0.8rem;
   align-items: center;
+}
+
+.workspace-chat__status {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ink-muted);
+}
+
+.workspace-chat__status--error {
+  color: #8d2b2b;
 }
 

--- a/frontend/aijurisdictionfronend/src/vite-env.d.ts
+++ b/frontend/aijurisdictionfronend/src/vite-env.d.ts
@@ -3,6 +3,10 @@
 interface ImportMetaEnv {
   readonly VITE_AUTH_GOOGLE_START_URL?: string;
   readonly VITE_AUTH_X_START_URL?: string;
+  readonly VITE_API_BASE_URL?: string;
+  readonly VITE_API_KEY?: string;
+  readonly VITE_API_COUNTRY?: string;
+  readonly VITE_API_LANGUAGE?: string;
 }
 
 interface ImportMeta {

--- a/skills/frontend-api/SKILL.md
+++ b/skills/frontend-api/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: frontend-api
+description: Start the local React frontend connected to the dev API endpoint for chat simulation from this repository. Use when asked for "/frontend-api", "run frontend with backend", "launch web app against dev API", or "simulate chat from UI with API".
+---
+
+# Frontend API
+
+## Workflow
+
+1. Run the frontend+API launcher from repository root:
+   `.\skills\start-frontend-api\scripts\start_frontend_api.ps1`
+2. Verify the frontend is reachable at `http://127.0.0.1:5173`.
+3. Sign in with demo credentials and send a message in a case chat.
+
+## Commands
+
+- Foreground start:
+  `.\skills\start-frontend-api\scripts\start_frontend_api.ps1`
+- Background start:
+  `.\skills\start-frontend-api\scripts\start_frontend_api.ps1 -Background`
+- Visible console window:
+  `.\skills\start-frontend-api\scripts\start_frontend_api.ps1 -ConsoleWindow`

--- a/skills/frontend-api/agents/openai.yaml
+++ b/skills/frontend-api/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Frontend API"
+  short_description: "Launch React app with dev API wiring"
+  default_prompt: "Use $frontend-api to run the local frontend connected to Azure dev API for chat simulation."

--- a/skills/start-api/scripts/start_api.ps1
+++ b/skills/start-api/scripts/start_api.ps1
@@ -42,7 +42,7 @@ function Resolve-EffectiveLlmProvider {
 function Resolve-PythonPath {
     param([string]$RepoRoot)
 
-    foreach ($candidate in @(".conda\\python.exe", "conda\\python.exe")) {
+    foreach ($candidate in @(".conda\\Scripts\\python.exe", ".conda\\python.exe", "conda\\Scripts\\python.exe", "conda\\python.exe")) {
         $pythonPath = Join-Path $RepoRoot $candidate
         if (Test-Path $pythonPath) {
             return $pythonPath

--- a/skills/start-frontend-api/SKILL.md
+++ b/skills/start-frontend-api/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: start-frontend-api
+description: Start the local React frontend (`frontend/aijurisdictionfronend`) wired to the dev API endpoint by default. Use when asked to "start frontend with api", "run vite against backend", "launch web UI for chat simulation", "wire frontend to dev API", or "debug frontend API chat fetch errors".
+---
+
+# Start Frontend API
+
+## Workflow
+
+1. Run the bundled launcher from repository root:
+   `.\skills\start-frontend-api\scripts\start_frontend_api.ps1`
+2. The launcher verifies API health at `/health` for the configured API URL.
+3. When the configured API URL is loopback (`127.0.0.1`/`localhost`) and API is down, it starts API via `start-api`.
+4. The launcher starts Vite with `VITE_API_BASE_URL` and `VITE_API_KEY` set for the frontend process.
+5. Open `http://127.0.0.1:5173` and sign in with demo credentials (`admin@admin.com` / `admin123`).
+6. Create a new case and send a message to verify chat replies come from API.
+
+## Commands
+
+- Foreground start:
+  `.\skills\start-frontend-api\scripts\start_frontend_api.ps1`
+- Background start:
+  `.\skills\start-frontend-api\scripts\start_frontend_api.ps1 -Background`
+- Visible console window:
+  `.\skills\start-frontend-api\scripts\start_frontend_api.ps1 -ConsoleWindow`
+- Install dependencies before start:
+  `.\skills\start-frontend-api\scripts\start_frontend_api.ps1 -Install`
+- Use custom API URL:
+  `.\skills\start-frontend-api\scripts\start_frontend_api.ps1 -ApiBaseUrl http://127.0.0.1:8081`
+- Skip API auto-start (fail fast if API is down):
+  `.\skills\start-frontend-api\scripts\start_frontend_api.ps1 -SkipApiStart`
+
+## Stop Frontend
+
+If started with `-Background`, stop via:
+
+`Stop-Process -Id (Get-Content .\runs\frontend-local.pid) -Force`
+
+## Environment Notes
+
+- Default frontend URL: `http://127.0.0.1:5173`
+- Default API base URL: `https://api-juris-dev.victoriousdesert-e45eec11.westeurope.azurecontainerapps.io`
+- Default API key: `aijuris`
+- The launcher only sets frontend API env vars for the launched process; it does not modify files.

--- a/skills/start-frontend-api/agents/openai.yaml
+++ b/skills/start-frontend-api/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Start Frontend API"
+  short_description: "Run Vite frontend wired to dev API"
+  default_prompt: "Use $start-frontend-api to start the React frontend and connect it to the Azure dev API."

--- a/skills/start-frontend-api/scripts/start_frontend_api.ps1
+++ b/skills/start-frontend-api/scripts/start_frontend_api.ps1
@@ -1,0 +1,266 @@
+param(
+    [string]$BindHost = "127.0.0.1",
+    [int]$Port = 5173,
+    [string]$ApiBaseUrl = "https://api-juris-dev.victoriousdesert-e45eec11.westeurope.azurecontainerapps.io",
+    [string]$ApiKey = "aijuris",
+    [switch]$Background,
+    [switch]$ConsoleWindow,
+    [switch]$Install,
+    [switch]$NoOpen,
+    [switch]$SkipApiStart
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-ShellPath {
+    $pwshCmd = Get-Command pwsh -ErrorAction SilentlyContinue
+    if ($pwshCmd) {
+        return $pwshCmd.Source
+    }
+
+    $powershellCmd = Get-Command powershell -ErrorAction SilentlyContinue
+    if ($powershellCmd) {
+        return $powershellCmd.Source
+    }
+
+    throw "PowerShell executable not found."
+}
+
+function Resolve-NpmPath {
+    $npmCmd = Get-Command npm -ErrorAction SilentlyContinue
+    if ($npmCmd) {
+        return $npmCmd.Source
+    }
+
+    $npmCmdWin = Get-Command npm.cmd -ErrorAction SilentlyContinue
+    if ($npmCmdWin) {
+        return $npmCmdWin.Source
+    }
+
+    throw "npm not found. Install Node.js and ensure npm is available on PATH."
+}
+
+function Test-UrlReady {
+    param([string]$Url)
+
+    try {
+        $response = Invoke-WebRequest -UseBasicParsing -Uri $Url -TimeoutSec 3
+        return $response.StatusCode -eq 200
+    } catch {
+        return $false
+    }
+}
+
+function Wait-ForUrl {
+    param(
+        [string]$Url,
+        [int]$TimeoutSeconds = 60
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        if (Test-UrlReady -Url $Url) {
+            return $true
+        }
+        Start-Sleep -Seconds 2
+    }
+
+    return $false
+}
+
+function Escape-SingleQuotes {
+    param([string]$Value)
+    return $Value.Replace("'", "''")
+}
+
+function Test-IsLoopbackApiUrl {
+    param([string]$Url)
+
+    try {
+        $uri = [System.Uri]$Url
+    } catch {
+        return $false
+    }
+
+    return $uri.Host -in @("127.0.0.1", "localhost")
+}
+
+function Reset-LogFile {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        return
+    }
+
+    try {
+        Remove-Item $Path -Force -ErrorAction Stop
+        return
+    } catch {
+    }
+
+    try {
+        Set-Content -Path $Path -Value @() -Encoding ascii -ErrorAction Stop
+    } catch {
+    }
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..\..")
+$frontendDir = Join-Path $repoRoot "frontend\aijurisdictionfronend"
+$apiSkillScript = Join-Path $repoRoot "skills\start-api\scripts\start_api.ps1"
+$scriptPath = Join-Path $repoRoot "skills\start-frontend-api\scripts\start_frontend_api.ps1"
+$shellPath = Resolve-ShellPath
+$npmPath = Resolve-NpmPath
+$frontendUrl = "http://$BindHost`:$Port"
+$apiHealthUrl = $ApiBaseUrl.TrimEnd("/") + "/health"
+
+if (-not (Test-Path $frontendDir)) {
+    throw "Frontend directory not found: $frontendDir"
+}
+
+if (-not (Test-UrlReady -Url $apiHealthUrl)) {
+    $isLoopbackApi = Test-IsLoopbackApiUrl -Url $ApiBaseUrl
+
+    if (-not $isLoopbackApi) {
+        throw "API is not reachable at $apiHealthUrl. This URL is remote, so local API auto-start is skipped. Provide -ApiBaseUrl http://127.0.0.1:8080 to use local API."
+    }
+
+    if ($SkipApiStart) {
+        throw "API is not reachable at $apiHealthUrl and -SkipApiStart is set."
+    }
+
+    if (-not (Test-Path $apiSkillScript)) {
+        throw "API start skill script not found: $apiSkillScript"
+    }
+
+    Write-Output "API is not reachable at $apiHealthUrl. Starting local API..."
+    & $apiSkillScript -Background | Write-Output
+}
+
+if (-not (Wait-ForUrl -Url $apiHealthUrl -TimeoutSeconds 90)) {
+    throw "API is still not healthy at $apiHealthUrl. Check .\runs\api-local.err.log"
+}
+
+Write-Output "API health OK: $apiHealthUrl"
+
+if ($ConsoleWindow) {
+    $args = @(
+        "-NoExit",
+        "-File",
+        $scriptPath,
+        "-BindHost",
+        $BindHost,
+        "-Port",
+        "$Port",
+        "-ApiBaseUrl",
+        $ApiBaseUrl,
+        "-ApiKey",
+        $ApiKey
+    )
+    if ($Install) { $args += "-Install" }
+    if ($NoOpen) { $args += "-NoOpen" }
+    if ($SkipApiStart) { $args += "-SkipApiStart" }
+
+    Start-Process -FilePath $shellPath -ArgumentList $args -WorkingDirectory $repoRoot | Out-Null
+    Write-Output "Frontend console window started."
+    Write-Output "Frontend URL: $frontendUrl"
+    exit 0
+}
+
+Push-Location $frontendDir
+try {
+    if ($Install -or -not (Test-Path "node_modules")) {
+        Write-Output "Installing frontend dependencies..."
+        & $npmPath install
+    }
+
+    if ($Background) {
+        $runsDir = Join-Path $repoRoot "runs"
+        if (-not (Test-Path $runsDir)) {
+            New-Item -Path $runsDir -ItemType Directory | Out-Null
+        }
+
+        $stdoutLog = Join-Path $runsDir "frontend-local.log"
+        $stderrLog = Join-Path $runsDir "frontend-local.err.log"
+        $pidFile = Join-Path $runsDir "frontend-local.pid"
+
+        $existingPidRaw = ""
+        $existingProcess = $null
+        if (Test-Path $pidFile) {
+            $existingPidRaw = (Get-Content $pidFile -Raw).Trim()
+            if ($existingPidRaw -match "^\d+$") {
+                $existingProcess = Get-Process -Id ([int]$existingPidRaw) -ErrorAction SilentlyContinue
+            }
+        }
+
+        if (Test-UrlReady -Url $frontendUrl) {
+            if ($existingProcess) {
+                Write-Output "Frontend is already running at $frontendUrl (PID $existingPidRaw)."
+                Write-Output "Stop: Stop-Process -Id (Get-Content `"$pidFile`") -Force"
+            } else {
+                Write-Output "Frontend is already reachable at $frontendUrl."
+            }
+            exit 0
+        }
+
+        if ((-not $existingProcess) -and (Test-Path $pidFile)) {
+            Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+        }
+
+        Reset-LogFile -Path $stdoutLog
+        Reset-LogFile -Path $stderrLog
+
+        $escapedFrontendDir = Escape-SingleQuotes -Value ([string]$frontendDir)
+        $escapedApiBaseUrl = Escape-SingleQuotes -Value $ApiBaseUrl
+        $escapedApiKey = Escape-SingleQuotes -Value $ApiKey
+        $escapedNpmPath = Escape-SingleQuotes -Value $npmPath
+        $escapedBindHost = Escape-SingleQuotes -Value $BindHost
+
+        $command = @"
+`$ErrorActionPreference = 'Stop'
+Set-Location '$escapedFrontendDir'
+`$env:VITE_API_BASE_URL = '$escapedApiBaseUrl'
+`$env:VITE_API_KEY = '$escapedApiKey'
+& '$escapedNpmPath' run dev -- --host '$escapedBindHost' --port $Port --strictPort
+"@
+
+        $process = Start-Process `
+            -FilePath $shellPath `
+            -ArgumentList @("-NoProfile", "-Command", $command) `
+            -WorkingDirectory $frontendDir `
+            -RedirectStandardOutput $stdoutLog `
+            -RedirectStandardError $stderrLog `
+            -PassThru
+
+        $process.Id | Out-File -FilePath $pidFile -Encoding ascii -NoNewline
+
+        if (Wait-ForUrl -Url $frontendUrl -TimeoutSeconds 60) {
+            Write-Output "Frontend started in background. PID: $($process.Id)"
+            Write-Output "Frontend URL: $frontendUrl"
+            Write-Output "API URL: $ApiBaseUrl"
+            Write-Output "Stop: Stop-Process -Id (Get-Content `"$pidFile`") -Force"
+            if (-not $NoOpen) {
+                Start-Process $frontendUrl | Out-Null
+            }
+        } else {
+            Write-Warning "Frontend process started (PID $($process.Id)) but URL is not ready yet."
+            Write-Output "Check logs:"
+            Write-Output "  $stdoutLog"
+            Write-Output "  $stderrLog"
+        }
+
+        exit 0
+    }
+
+    $env:VITE_API_BASE_URL = $ApiBaseUrl
+    $env:VITE_API_KEY = $ApiKey
+
+    if (-not $NoOpen) {
+        Start-Process $frontendUrl | Out-Null
+    }
+
+    Write-Output "Starting frontend in foreground on $frontendUrl"
+    Write-Output "Using VITE_API_BASE_URL=$ApiBaseUrl"
+    & $npmPath run dev -- --host $BindHost --port "$Port" --strictPort
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- connect the signed-in frontend workspace to the chat API for chat, voice transcript, and video transcript flows
- add structured frontend console logging and clearer API/network error handling
- add frontend/API local start skills plus a runnable task #238 demo and docs

## Verification
- npm --prefix frontend/aijurisdictionfronend run build
- npm --prefix frontend/aijurisdictionfronend run lint
- npm --prefix frontend/aijurisdictionfronend run test
- python examples/frontend_api_chat_minimal_demo.py

Closes #238