### PR TITLE
Task #245: Update chat window visuals

### DIFF
--- a/examples/frontend_chat_window_visuals_task_245_minimal_demo.py
+++ b/examples/frontend_chat_window_visuals_task_245_minimal_demo.py
@@ -1,0 +1,53 @@
+"""Minimal runnable verification for frontend task #245 chat window visuals.
+
+Run:
+    python examples/frontend_chat_window_visuals_task_245_minimal_demo.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOME_PATH = REPO_ROOT / "frontend" / "aijurisdictionfronend" / "src" / "pages" / "Home.tsx"
+CASE_PROVIDER_PATH = (
+    REPO_ROOT / "frontend" / "aijurisdictionfronend" / "src" / "state" / "CaseProvider.tsx"
+)
+
+
+def _require_contains(path: Path, token: str, message: str) -> None:
+    content = path.read_text(encoding="utf-8")
+    if token not in content:
+        raise AssertionError(f"{message}\nMissing token: {token}\nChecked file: {path}")
+
+
+def _require_not_contains(path: Path, token: str, message: str) -> None:
+    content = path.read_text(encoding="utf-8")
+    if token in content:
+        raise AssertionError(f"{message}\nUnexpected token: {token}\nChecked file: {path}")
+
+
+if __name__ == "__main__":
+    _require_contains(
+        CASE_PROVIDER_PATH,
+        "stripSeededAssistantIntro",
+        "Case provider must strip the seeded assistant intro after the first user message.",
+    )
+    _require_contains(
+        CASE_PROVIDER_PATH,
+        "isUserInteractionActor(actor)",
+        "First-message cleanup must be gated to real user-authored interactions.",
+    )
+    _require_not_contains(
+        HOME_PATH,
+        "workspace-callout",
+        "Home workspace should no longer render the bottom recommendation card.",
+    )
+    _require_not_contains(
+        HOME_PATH,
+        't("workspaceNextRecommendedAction")',
+        "Home workspace should no longer render the next recommended action label.",
+    )
+
+    print("Frontend task #245 chat window visuals minimal demo checks passed.")

--- a/frontend/aijurisdictionfronend/README.md
+++ b/frontend/aijurisdictionfronend/README.md
@@ -123,6 +123,14 @@ Task `#243` keeps the selected UI language active across routes and applies it t
 - User-provided content such as case titles and uploaded filenames stays unchanged
 - New chat sessions pass the selected frontend language to the API session creation call
 
+## Chat Window Visuals (Task #245)
+
+Task `#245` refines the signed-in workspace chat presentation.
+
+- The seeded assistant intro message is removed after the user sends the first chat message
+- The chat timeline keeps system notices and live API replies intact
+- The bottom `Next recommended action` card is removed from the workspace chat view
+
 ## Legal pages and footer links
 
 Global footer links are available in all language modes (`en`, `sk`, `de`) and are visible on both public and signed-in screens.
@@ -198,6 +206,12 @@ Task #243 language switching minimal demo:
 
 ```bash
 python examples/frontend_language_switching_task_243_minimal_demo.py
+```
+
+Task #245 chat window visuals minimal demo:
+
+```bash
+python examples/frontend_chat_window_visuals_task_245_minimal_demo.py
 ```
 
 The demo defaults to the shared Azure dev API endpoint. Override it for local API testing with

--- a/frontend/aijurisdictionfronend/src/__tests__/caseProvider.test.tsx
+++ b/frontend/aijurisdictionfronend/src/__tests__/caseProvider.test.tsx
@@ -143,6 +143,28 @@ const LocalizedSystemMessageConsumer: React.FC = () => {
   );
 };
 
+const FirstUserMessageConsumer: React.FC = () => {
+  const { cases, addInteraction } = useCases();
+  const activeCase = cases.find((caseItem) => caseItem.id === "case-001");
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => addInteraction("case-001", "You", "Please review the first issue.")}
+      >
+        Send first user message
+      </button>
+      <div data-testid="case-001-history-actors">
+        {activeCase?.interactionHistory.map((interaction) => interaction.actor).join("|") ?? ""}
+      </div>
+      <div data-testid="case-001-history-messages">
+        {activeCase?.interactionHistory.map((interaction) => interaction.message).join("|") ?? ""}
+      </div>
+    </div>
+  );
+};
+
 describe("CaseProvider", () => {
   beforeEach(() => {
     cleanup();
@@ -320,6 +342,35 @@ describe("CaseProvider", () => {
 
     expect(screen.getByTestId("localized-system-message").textContent).toBe(
       "API ist nicht erreichbar. Network request failed."
+    );
+  });
+
+  it("removes the seeded assistant intro after the first user message is added", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LanguageProvider>
+        <CaseProvider>
+          <FirstUserMessageConsumer />
+        </CaseProvider>
+      </LanguageProvider>
+    );
+
+    expect(screen.getByTestId("case-001-history-actors").textContent).toContain("AI Lawyer");
+    expect(screen.getByTestId("case-001-history-messages").textContent).toContain(
+      "Opened new case workspace from the intake form."
+    );
+
+    await user.click(screen.getByRole("button", { name: "Send first user message" }));
+
+    expect(screen.getByTestId("case-001-history-actors").textContent).not.toContain("AI Lawyer");
+    expect(screen.getByTestId("case-001-history-actors").textContent).toContain("System");
+    expect(screen.getByTestId("case-001-history-actors").textContent).toContain("You");
+    expect(screen.getByTestId("case-001-history-messages").textContent).not.toContain(
+      "Opened new case workspace from the intake form."
+    );
+    expect(screen.getByTestId("case-001-history-messages").textContent).toContain(
+      "Please review the first issue."
     );
   });
 });

--- a/frontend/aijurisdictionfronend/src/__tests__/homeChatVisuals.test.tsx
+++ b/frontend/aijurisdictionfronend/src/__tests__/homeChatVisuals.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { LanguageProvider } from "../components/LanguageProvider";
+import Home from "../pages/Home";
+
+vi.mock("../auth/mockAuth", () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    user: {
+      name: "Admin User",
+      email: "admin@admin.com"
+    },
+    signOut: vi.fn()
+  })
+}));
+
+vi.mock("../state/CaseProvider", () => ({
+  buildLocalizedInteractionMessage: vi.fn(),
+  useCases: () => ({
+    cases: [
+      {
+        id: "case-001",
+        title: "Keystone Holdings Intake",
+        description: "EU + UK matter involving Northshore Advisory.",
+        status: "In progress"
+      }
+    ],
+    activeCase: {
+      id: "case-001",
+      title: "Keystone Holdings Intake",
+      description: "EU + UK matter involving Northshore Advisory.",
+      status: "In progress",
+      selectedCommunicationMode: "Chat",
+      selectedRole: "AI Lawyer",
+      workspace: {
+        meta: "Due in 2 days",
+        nextAction: "Schedule a follow-up.",
+        objective: "Prepare the briefing memo.",
+        jurisdiction: "EU + UK",
+        output: "Briefing memo + checklist"
+      },
+      interactionHistory: [
+        {
+          id: "interaction-1",
+          actor: "System",
+          message: "Stored 1 uploaded document in mock profile storage.",
+          createdAt: "2026-04-16T10:00:00.000Z"
+        },
+        {
+          id: "interaction-2",
+          actor: "You",
+          message: "Please review the jurisdiction scope.",
+          createdAt: "2026-04-16T10:02:00.000Z"
+        }
+      ]
+    },
+    hasSelectedCase: true,
+    continueRequested: false,
+    setContinueRequested: vi.fn(),
+    addInteraction: vi.fn(),
+    sendCaseMessage: vi.fn(),
+    setCaseRole: vi.fn(),
+    setCaseCommunicationMode: vi.fn()
+  })
+}));
+
+describe("Home chat visuals", () => {
+  it("does not render the next recommended action field in the workspace chat", () => {
+    render(
+      <LanguageProvider>
+        <MemoryRouter initialEntries={["/"]}>
+          <Home />
+        </MemoryRouter>
+      </LanguageProvider>
+    );
+
+    expect(screen.queryByText("Next recommended action")).toBeNull();
+    expect(screen.getByText("Keystone Holdings Intake")).toBeDefined();
+    expect(screen.getByText("Connected through API chat.")).toBeDefined();
+  });
+});

--- a/frontend/aijurisdictionfronend/src/pages/Home.tsx
+++ b/frontend/aijurisdictionfronend/src/pages/Home.tsx
@@ -63,20 +63,17 @@ const Home: React.FC = () => {
       {
         mode: "Chat" as CaseCommunicationMode,
         label: t("commsChat"),
-        icon: <FiMessageSquare aria-hidden="true" />,
-        actionLabel: t("commsChatAction")
+        icon: <FiMessageSquare aria-hidden="true" />
       },
       {
         mode: "Voice" as CaseCommunicationMode,
         label: t("commsVoice"),
-        icon: <FiMic aria-hidden="true" />,
-        actionLabel: t("commsVoiceAction")
+        icon: <FiMic aria-hidden="true" />
       },
       {
         mode: "Video" as CaseCommunicationMode,
         label: t("commsVideo"),
-        icon: <FiVideo aria-hidden="true" />,
-        actionLabel: t("commsVideoAction")
+        icon: <FiVideo aria-hidden="true" />
       }
     ],
     [t]
@@ -165,19 +162,6 @@ const Home: React.FC = () => {
       if (sent) {
         setModeDraftMessage("");
       }
-    };
-
-    const handleNextAction = async () => {
-      if (!activeCase) {
-        return;
-      }
-      const defaultPrompt =
-        activeCase.selectedCommunicationMode === "Voice"
-          ? "Please run a voice-style legal briefing for the current case."
-          : activeCase.selectedCommunicationMode === "Video"
-            ? "Please run a video-style legal briefing for the current case."
-            : "Please continue the legal chat for the current case with next steps.";
-      await submitMessageToApi(activeCase.selectedCommunicationMode, defaultPrompt);
     };
 
     return (
@@ -313,22 +297,6 @@ const Home: React.FC = () => {
                           ) : null}
                         </article>
                       )}
-                      <article className="workspace-callout">
-                        <h3>{t("workspaceNextRecommendedAction")}</h3>
-                        <p>{activeCase?.workspace.nextAction}</p>
-                        <button
-                          type="button"
-                          className="button primary"
-                          onClick={handleNextAction}
-                          disabled={isSendingMessage}
-                        >
-                          {
-                            communicationModeOptions.find(
-                              (option) => option.mode === activeCase?.selectedCommunicationMode
-                            )?.actionLabel
-                          }
-                        </button>
-                      </article>
                     </div>
                   </>
                 )}

--- a/frontend/aijurisdictionfronend/src/state/CaseProvider.tsx
+++ b/frontend/aijurisdictionfronend/src/state/CaseProvider.tsx
@@ -142,6 +142,36 @@ const parseLocalizedInteractionMessage = (
   }
 };
 
+const USER_INTERACTION_ACTORS = ["You", "You (Voice)", "You (Video)"] as const;
+const ROLE_INTERACTION_ACTORS = ["AI Lawyer", "AI Judge", "Opposing Counsel"] as const;
+
+const isUserInteractionActor = (actor: string): boolean =>
+  USER_INTERACTION_ACTORS.includes(actor as (typeof USER_INTERACTION_ACTORS)[number]);
+
+const isSeededAssistantIntroInteraction = (interaction: CaseInteraction): boolean => {
+  if (!ROLE_INTERACTION_ACTORS.includes(interaction.actor as (typeof ROLE_INTERACTION_ACTORS)[number])) {
+    return false;
+  }
+
+  const localizedDescriptor = parseLocalizedInteractionMessage(interaction.message);
+  return localizedDescriptor?.key === "mockCreatedCaseOpenMessage";
+};
+
+const stripSeededAssistantIntro = (interactionHistory: CaseInteraction[]): CaseInteraction[] =>
+  interactionHistory.filter((interaction) => !isSeededAssistantIntroInteraction(interaction));
+
+const normalizeInteractionHistory = (interactionHistory: CaseInteraction[]): CaseInteraction[] => {
+  const hasUserInteraction = interactionHistory.some((interaction) =>
+    isUserInteractionActor(interaction.actor)
+  );
+
+  if (!hasUserInteraction) {
+    return interactionHistory;
+  }
+
+  return stripSeededAssistantIntro(interactionHistory);
+};
+
 const buildCreatedCaseDescription = (jurisdiction: string, opposingParty: string, language: Language) =>
   translate(language, "mockCreatedCaseDescription", {
     jurisdiction,
@@ -598,7 +628,7 @@ const normalizeStoredCase = (value: unknown): CaseRecord | null => {
     description: candidate.description,
     status,
     createdAt: candidate.createdAt,
-    interactionHistory,
+    interactionHistory: normalizeInteractionHistory(interactionHistory),
     selectedRole,
     selectedMode,
     selectedCommunicationMode,
@@ -756,7 +786,15 @@ export const CaseProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setStoredCases((prev) =>
         prev.map((caseItem) =>
           caseItem.id === caseId
-            ? { ...caseItem, interactionHistory: [...caseItem.interactionHistory, interaction] }
+            ? {
+                ...caseItem,
+                interactionHistory: [
+                  ...(isUserInteractionActor(actor)
+                    ? stripSeededAssistantIntro(caseItem.interactionHistory)
+                    : caseItem.interactionHistory),
+                  interaction
+                ]
+              }
             : caseItem
         )
       );

--- a/frontend/aijurisdictionfronend/src/styles/app.css
+++ b/frontend/aijurisdictionfronend/src/styles/app.css
@@ -518,14 +518,6 @@
   gap: 0.5rem;
 }
 
-.workspace-callout {
-  background: var(--surface-muted);
-  padding: 1.2rem;
-  border-radius: 16px;
-  display: grid;
-  gap: 0.8rem;
-}
-
 .config-list {
   display: grid;
   gap: 1rem;


### PR DESCRIPTION
## Summary
- remove the bottom next recommended action callout from the workspace chat view
- remove the seeded assistant intro after the first user message is sent
- add regression tests, docs, and a task-specific minimal demo

## Verification
- npm run test
- npm run build
- python examples/frontend_chat_window_visuals_task_245_minimal_demo.py