### PR TITLE
Add workflow engine and entity screening agents; docs, examples, and tests

### DIFF
--- a/docs/AI_WEB_SEARCH_AGENT.md
+++ b/docs/AI_WEB_SEARCH_AGENT.md
@@ -1,6 +1,7 @@
-# AIWebSearchAgent
+# EntityScreeningAgent (formerly AIWebSearchAgent)
 
-`AIWebSearchAgent` is a lightweight agent that can be used for internet screening support in document workflows.
+`EntityScreeningAgent` is a lightweight global screening agent for company/person internet checks.
+`AIWebSearchAgent` remains as a backward-compatible alias.
 
 ## Behavior
 
@@ -8,11 +9,18 @@
 - Supports entity-level screening prompts (person, company, car, etc.).
 - Performs a web lookup and returns structured records (`title`, `url`, `snippet`).
 - Falls back to DuckDuckGo HTML results when the instant-answer JSON endpoint does not return search hits.
+- Can be attached as a **global workflow step** (`global_entity_screening`) for all countries when:
+  - user explicitly requests screening, or
+  - model suggests screening based on risk/context.
+  - workflow engine auto-detects screening intent from question text (e.g., `Over mi jana hraska`).
+- Provides structured English prompt templates usable across countries:
+  - `CompanySearchAgent.build_search_prompt(...)`
+  - `PersonSearchAgent.build_search_prompt(...)`
 
 ## Permanent memory model metadata
 
 When API metadata is requested and the current model cutoff is not cached yet, the
-system uses `AIWebSearchAgent` to discover the current model page and stores a
+system uses `EntityScreeningAgent` (or `AIWebSearchAgent` alias) to discover the current model page and stores a
 permanent-memory key `llm_model_setup` with:
 
 - `llm_modelname`

--- a/docs/LEGAL_WORKFLOW_ROUTING.md
+++ b/docs/LEGAL_WORKFLOW_ROUTING.md
@@ -1,0 +1,75 @@
+# Legal Workflow Routing (Slovakia-first, multi-country ready)
+
+This module introduces a lightweight workflow engine for client legal questions.
+
+## Goals
+
+- Classify client questions into reusable legal process groups.
+- Select a country-specific workflow blueprint.
+- Validate required inputs before tool execution.
+- Fall back to a generic clarification mode when no workflow is a safe match.
+
+## Core components
+
+- `WorkflowBlueprint`: process definition for a case type (keywords, required fields, and **mandatory system documents only**).
+- `WorkflowStep`: explicit ordered steps within the workflow (each step can have a tool and step-specific inputs/outputs).
+- `WorkflowRegistry`: stores available workflows by country.
+- `WorkflowRouter`: scores intent + input coverage and selects the best candidate.
+- `WorkflowEngine`: validates inputs and returns either
+  - `mode=workflow` with missing fields and validation issues, or
+  - `mode=fallback` with clarification prompts.
+  - `required_documents` that merge:
+    - `mandatory_system_documents` from blueprint, and
+    - additional law-driven documents from laws connectors / legal updates (`law_required_documents`).
+  - global optional step `global_entity_screening` with consent prompt when screening is requested/suggested.
+  - automatic screening intent detection from question text (e.g., Slovak request `Over mi jana hraska`).
+  - structured screening task prompt (`screening_task_prompt`) with company/person template in English for cross-country use.
+
+## Built-in Slovakia examples
+
+- `sk.company.add_co_owner.v1`: add co-owner/shareholder workflow where ORSR verification is the **first step**, followed by constraints checks and document bundle generation.
+- The blueprint stores only stable mandatory system documents (`decision_of_general_meeting`, `general_meeting_minutes`).
+- Any new legal requirement introduced by law updates is appended dynamically via `law_required_documents`.
+- `sk.company.verify_orsr.v1`: standalone company verification workflow for verification-only requests.
+
+## Testing different workflows and case variants
+
+Use a matrix approach:
+
+1. **Workflow routing tests** – verify that different intents select different workflows (`add_co_owner` vs `verify_orsr`).
+2. **Missing input tests** – for each workflow verify generated clarification questions for absent required fields.
+3. **Validation tests** – invalid identifiers/formats (e.g., invalid IČO).
+4. **Law-change tests** – inject `law_required_documents` and verify required document merge behavior.
+5. **Conflict resolution tests** – compare user input with external registry facts and verify confirmation questions are generated.
+6. **Global screening tests** – verify `global_entity_screening` is included for user-requested or model-suggested screening.
+7. **Natural language screening intent tests** – verify Slovak phrasing auto-triggers screening and extracts entity.
+
+Example conflict case:
+
+- Workflow: `sk.company.add_co_owner.v1`
+- User input: `current_owner_name=Peter Novak`
+- ORSR fact: `current_owner_name=Martin Novak`
+- Expected behavior: add a clarification/confirmation question asking which value is legally valid before continuing.
+
+## Testing strategy
+
+The test suite covers:
+
+1. Workflow selection for add-co-owner intent.
+2. Required-input gap detection and clarification prompts.
+3. Input validation (e.g., Slovak company ID format).
+4. Dynamic merge of mandatory + law-required documents.
+5. Fact conflict detection and user confirmation prompt generation.
+6. Global screening step injection and consent prompt generation.
+7. Natural language screening intent detection.
+8. Fallback behavior when no workflow satisfies confidence threshold.
+
+## Minimal demo
+
+Run:
+
+```bash
+python examples/minimal_demo.py
+```
+
+The minimal demo now includes workflow routing examples alongside the existing end-to-end contract simulations.

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -1,4 +1,4 @@
-"""Minimal runnable demo for the repository end-to-end contract simulations.
+"""Minimal runnable demo for repository workflows and contract simulations.
 
 Run:
     python examples/minimal_demo.py
@@ -17,6 +17,7 @@ from aijurisdictionagents.e2e_workflows import (
     simulate_contract_summary_case,
     simulate_slovak_lease_review,
 )
+from aijurisdictionagents.workflows import WorkflowEngine, WorkflowRouter, create_default_registry
 
 
 if __name__ == "__main__":
@@ -24,8 +25,40 @@ if __name__ == "__main__":
     contract_outcome = simulate_contract_summary_case(output_root / "contract_summary_case")
     lease_outcome = simulate_slovak_lease_review(output_root / "slovak_lease_case")
 
+    workflow_engine = WorkflowEngine(WorkflowRouter(create_default_registry()))
+    workflow_result = workflow_engine.plan_case(
+        question="Chcem pridat noveho spolocnika do s.r.o. a pripravit dokumenty.",
+        country="SK",
+        inputs={
+            "company_id": "12345678",
+            "current_owner_name": "Peter Novak",
+            "new_co_owner_name": "Jan Novak",
+            "ownership_share_percent": "25",
+            "effective_date": "2026-04-30",
+        },
+        law_required_documents=("beneficial_owner_declaration",),
+        external_facts={"current_owner_name": "Martin Novak"},
+        model_suggested_screening=True,
+    )
+
     print("=== Contract summary scenario ===")
     print(outcome_to_json(contract_outcome))
     print()
     print("=== Slovak lease review scenario ===")
     print(outcome_to_json(lease_outcome))
+    print()
+    print("=== Workflow routing scenario ===")
+    print(f"Mode: {workflow_result.mode}")
+    print(f"Confidence: {workflow_result.confidence:.2f}")
+    print(f"Workflow: {workflow_result.workflow.workflow_id if workflow_result.workflow else 'N/A'}")
+    if workflow_result.workflow:
+        print(f"Workflow steps: {[step.step_id for step in workflow_result.workflow.steps]}")
+    print(f"Global steps: {list(workflow_result.global_steps)}")
+    print(f"Screening consent prompt: {workflow_result.screening_consent_prompt}")
+    print(f"Screening task prompt: {workflow_result.screening_task_prompt}")
+    print(f"Required documents: {list(workflow_result.required_documents)}")
+    print(f"Missing inputs: {list(workflow_result.missing_inputs)}")
+    print(f"Fact conflicts: {[{'field': c.field, 'user': c.user_value, 'registry': c.system_value} for c in workflow_result.fact_conflicts]}")
+    if workflow_result.fact_conflicts:
+        print(f"Confirmation question: {workflow_result.fact_conflicts[0].confirmation_question}")
+    print(f"Validation issues: {[issue.message for issue in workflow_result.validation_issues]}")

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260356"
+__version__ = "1.0.260363"

--- a/src/aijurisdictionagents/agents/__init__.py
+++ b/src/aijurisdictionagents/agents/__init__.py
@@ -1,5 +1,5 @@
 from .base import Agent
-from .ai_web_search import AIWebSearchAgent
+from .ai_web_search import AIWebSearchAgent, CompanySearchAgent, EntityScreeningAgent, PersonSearchAgent
 from .judge import create_judge
 from .lawyer import create_lawyer
 from .slovakia import create_lawyer_slovakia
@@ -18,6 +18,9 @@ def create_lawyer_agent(llm: LLMClient, country: str) -> Agent:
 __all__ = [
     "Agent",
     "AIWebSearchAgent",
+    "EntityScreeningAgent",
+    "CompanySearchAgent",
+    "PersonSearchAgent",
     "AIUserSimulatorAgent",
     "AIAgentsValidator",
     "ValidationReport",

--- a/src/aijurisdictionagents/agents/ai_web_search.py
+++ b/src/aijurisdictionagents/agents/ai_web_search.py
@@ -16,10 +16,10 @@ class WebSearchRecord:
 
 
 @dataclass
-class AIWebSearchAgent:
-    """Simple web-search helper that always requires user consent before use."""
+class EntityScreeningAgent:
+    """Global entity-screening helper that always requires user consent before use."""
 
-    name: str = "AIWebSearchAgent"
+    name: str = "EntityScreeningAgent"
 
     def build_screening_consent_prompt(self, *, entity_type: str, entity_value: str) -> str:
         normalized_type = (entity_type or "entity").strip().lower()
@@ -27,6 +27,32 @@ class AIWebSearchAgent:
         return (
             "Before I run internet screening, please confirm permission for this lookup: "
             f"{normalized_type} = '{normalized_value}'. Reply YES to continue or NO to skip."
+        )
+
+    def build_structured_screening_prompt(
+        self,
+        *,
+        entity_type: str,
+        entity_value: str,
+        country: str | None = None,
+    ) -> str:
+        normalized_type = (entity_type or "entity").strip().lower()
+        normalized_value = (entity_value or "").strip() or "unknown"
+        normalized_country = (country or "").strip().upper() or "N/A"
+        if normalized_type == "company":
+            return CompanySearchAgent().build_search_prompt(
+                company_reference=normalized_value,
+                country=normalized_country,
+            )
+        if normalized_type == "person":
+            return PersonSearchAgent().build_search_prompt(
+                person_reference=normalized_value,
+                country=normalized_country,
+            )
+        return (
+            "Find public information about the target entity and prepare a concise report with: "
+            "address, related companies/associations, debt exposure (social/health/financial), and web findings. "
+            f"Entity: {normalized_value}. Country: {normalized_country}."
         )
 
     def search(self, *, query: str, max_results: int = 5) -> list[WebSearchRecord]:
@@ -100,6 +126,60 @@ class AIWebSearchAgent:
         with urlopen(request, timeout=15) as response:
             payload = response.read().decode("utf-8", errors="ignore")
         return _parse_duckduckgo_html_results(payload=payload, max_results=max_results)
+
+
+class AIWebSearchAgent(EntityScreeningAgent):
+    """Backward-compatible alias for EntityScreeningAgent."""
+
+    name: str = "AIWebSearchAgent"
+
+
+@dataclass
+class CompanySearchAgent(EntityScreeningAgent):
+    """Structured company screening prompt helper."""
+
+    name: str = "CompanySearchAgent"
+
+    def build_search_prompt(self, *, company_reference: str, country: str | None = None) -> str:
+        normalized_reference = (company_reference or "").strip() or "unknown company"
+        normalized_country = (country or "").strip().upper() or "N/A"
+        return (
+            "Find publicly available information about the company and prepare a summary containing:\n"
+            "1. registered address\n"
+            "2. list of companies owned by this company\n"
+            "3. list of owners or people associated with the company\n"
+            "4. list of debts or liabilities, especially in:\n"
+            "   - social insurance\n"
+            "   - health insurance\n"
+            "   - financial institutions\n"
+            "5. additional relevant web information\n"
+            f"Company reference: {normalized_reference}\n"
+            f"Country: {normalized_country}"
+        )
+
+
+@dataclass
+class PersonSearchAgent(EntityScreeningAgent):
+    """Structured person screening prompt helper."""
+
+    name: str = "PersonSearchAgent"
+
+    def build_search_prompt(self, *, person_reference: str, country: str | None = None) -> str:
+        normalized_reference = (person_reference or "").strip() or "unknown person"
+        normalized_country = (country or "").strip().upper() or "N/A"
+        return (
+            "Find publicly available information about the person and prepare a summary containing:\n"
+            "1. address\n"
+            "2. list of companies linked to the person\n"
+            "3. list of trade licenses / sole-trader businesses\n"
+            "4. list of debts or liabilities, especially in:\n"
+            "   - social insurance\n"
+            "   - health insurance\n"
+            "   - financial institutions\n"
+            "5. additional relevant web information\n"
+            f"Person reference: {normalized_reference}\n"
+            f"Country: {normalized_country}"
+        )
 
 
 def _parse_duckduckgo_html_results(*, payload: str, max_results: int) -> list[WebSearchRecord]:

--- a/src/aijurisdictionagents/workflows/__init__.py
+++ b/src/aijurisdictionagents/workflows/__init__.py
@@ -1,0 +1,25 @@
+from .engine import (
+    ValidationIssue,
+    FactConflict,
+    WorkflowBlueprint,
+    WorkflowEngine,
+    WorkflowRegistry,
+    WorkflowRouter,
+    WorkflowSelection,
+    WorkflowStep,
+    create_default_registry,
+    validate_slovak_company_id,
+)
+
+__all__ = [
+    "ValidationIssue",
+    "FactConflict",
+    "WorkflowBlueprint",
+    "WorkflowEngine",
+    "WorkflowRegistry",
+    "WorkflowRouter",
+    "WorkflowSelection",
+    "WorkflowStep",
+    "create_default_registry",
+    "validate_slovak_company_id",
+]

--- a/src/aijurisdictionagents/workflows/engine.py
+++ b/src/aijurisdictionagents/workflows/engine.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import re
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+from ..agents.ai_web_search import EntityScreeningAgent
+
+Validator = Callable[[str, Any], str | None]
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    field: str
+    message: str
+    severity: str = "error"
+
+
+@dataclass(frozen=True)
+class WorkflowStep:
+    step_id: str
+    name: str
+    description: str
+    tool_name: str | None = None
+    required_inputs: tuple[str, ...] = ()
+    output_artifacts: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class WorkflowBlueprint:
+    workflow_id: str
+    country: str
+    case_group: str
+    description: str
+    intent_keywords: tuple[str, ...]
+    required_inputs: tuple[str, ...] = ()
+    optional_inputs: tuple[str, ...] = ()
+    input_validators: Mapping[str, Validator] = field(default_factory=dict)
+    conflict_check_fields: tuple[str, ...] = ()
+    mandatory_system_documents: tuple[str, ...] = ()
+    steps: tuple[WorkflowStep, ...] = ()
+
+
+@dataclass(frozen=True)
+class WorkflowSelection:
+    mode: str
+    confidence: float
+    reason: str
+    workflow: WorkflowBlueprint | None = None
+    missing_inputs: tuple[str, ...] = ()
+    validation_issues: tuple[ValidationIssue, ...] = ()
+    clarification_questions: tuple[str, ...] = ()
+    required_documents: tuple[str, ...] = ()
+    fact_conflicts: tuple["FactConflict", ...] = ()
+    global_steps: tuple[str, ...] = ()
+    screening_consent_prompt: str | None = None
+    screening_task_prompt: str | None = None
+
+
+@dataclass(frozen=True)
+class FactConflict:
+    field: str
+    user_value: str
+    system_value: str
+    confirmation_question: str
+
+
+class WorkflowRegistry:
+    def __init__(self, workflows: Iterable[WorkflowBlueprint] | None = None) -> None:
+        self._workflows: list[WorkflowBlueprint] = []
+        if workflows is not None:
+            for workflow in workflows:
+                self.register(workflow)
+
+    def register(self, workflow: WorkflowBlueprint) -> None:
+        self._workflows.append(workflow)
+
+    def for_country(self, country: str) -> list[WorkflowBlueprint]:
+        normalized = country.strip().upper()
+        return [workflow for workflow in self._workflows if workflow.country.upper() == normalized]
+
+
+class WorkflowRouter:
+    def __init__(self, registry: WorkflowRegistry, min_confidence: float = 0.35) -> None:
+        self.registry = registry
+        self.min_confidence = min_confidence
+
+    def select(self, question: str, country: str, inputs: Mapping[str, Any]) -> tuple[WorkflowBlueprint | None, float]:
+        candidates = self.registry.for_country(country)
+        if not candidates:
+            return None, 0.0
+        lowered_question = question.lower()
+        scored: list[tuple[WorkflowBlueprint, float]] = []
+        for workflow in candidates:
+            keyword_hits = sum(1 for keyword in workflow.intent_keywords if keyword.lower() in lowered_question)
+            keyword_score = keyword_hits / max(len(workflow.intent_keywords), 1)
+            required_hits = sum(1 for field in workflow.required_inputs if field in inputs and inputs[field] not in (None, ""))
+            required_score = required_hits / max(len(workflow.required_inputs), 1)
+            if keyword_hits > 0:
+                base_intent_score = max(0.4, keyword_score)
+            else:
+                base_intent_score = 0.0
+            score = min(1.0, base_intent_score + (required_score * 0.2))
+            scored.append((workflow, score))
+
+        scored.sort(key=lambda item: item[1], reverse=True)
+        top_workflow, top_score = scored[0]
+        if top_score < self.min_confidence:
+            return None, top_score
+        return top_workflow, top_score
+
+
+class WorkflowEngine:
+    def __init__(self, router: WorkflowRouter) -> None:
+        self.router = router
+
+    def plan_case(
+        self,
+        question: str,
+        country: str,
+        inputs: Mapping[str, Any],
+        law_required_documents: Sequence[str] | None = None,
+        external_facts: Mapping[str, Any] | None = None,
+        user_requested_screening: bool = False,
+        model_suggested_screening: bool = False,
+        auto_detect_screening_intent: bool = True,
+    ) -> WorkflowSelection:
+        global_steps, screening_consent_prompt, screening_task_prompt = self._resolve_global_steps(
+            question=question,
+            country=country,
+            inputs=inputs,
+            user_requested_screening=user_requested_screening,
+            model_suggested_screening=model_suggested_screening,
+            auto_detect_screening_intent=auto_detect_screening_intent,
+        )
+        workflow, confidence = self.router.select(question, country, inputs)
+        if workflow is None:
+            return WorkflowSelection(
+                mode="fallback",
+                confidence=confidence,
+                reason="No workflow met the minimum confidence threshold.",
+                clarification_questions=(
+                    "Prosím spresnite typ právneho prípadu (napr. zmena konateľa, prevod podielu, pracovná zmluva).",
+                    "Uveďte krajinu a relevantné identifikačné údaje účastníkov.",
+                ),
+                required_documents=(),
+                fact_conflicts=(),
+                global_steps=global_steps,
+                screening_consent_prompt=screening_consent_prompt,
+                screening_task_prompt=screening_task_prompt,
+            )
+
+        missing_inputs = tuple(field for field in workflow.required_inputs if field not in inputs or inputs[field] in (None, ""))
+        validation_issues = self._validate_inputs(workflow, inputs)
+        clarification_questions = tuple(self._build_question(field) for field in missing_inputs)
+        required_documents = self._resolve_required_documents(
+            workflow=workflow,
+            law_required_documents=law_required_documents,
+        )
+        fact_conflicts = self._detect_fact_conflicts(
+            workflow=workflow,
+            inputs=inputs,
+            external_facts=external_facts,
+        )
+        if fact_conflicts:
+            clarification_questions = clarification_questions + tuple(
+                conflict.confirmation_question for conflict in fact_conflicts
+            )
+        return WorkflowSelection(
+            mode="workflow",
+            confidence=confidence,
+            reason="Matched by intent and available input coverage.",
+            workflow=workflow,
+            missing_inputs=missing_inputs,
+            validation_issues=validation_issues,
+            clarification_questions=clarification_questions,
+            required_documents=required_documents,
+            fact_conflicts=fact_conflicts,
+            global_steps=global_steps,
+            screening_consent_prompt=screening_consent_prompt,
+            screening_task_prompt=screening_task_prompt,
+        )
+
+    @staticmethod
+    def _validate_inputs(
+        workflow: WorkflowBlueprint,
+        inputs: Mapping[str, Any],
+    ) -> tuple[ValidationIssue, ...]:
+        issues: list[ValidationIssue] = []
+        for field_name, validator in workflow.input_validators.items():
+            if field_name not in inputs:
+                continue
+            value = inputs[field_name]
+            error = validator(field_name, value)
+            if error:
+                issues.append(ValidationIssue(field=field_name, message=error))
+        return tuple(issues)
+
+    @staticmethod
+    def _build_question(field_name: str) -> str:
+        return f"Prosím doplňte hodnotu pre pole '{field_name}'."
+
+    @staticmethod
+    def _resolve_required_documents(
+        workflow: WorkflowBlueprint,
+        law_required_documents: Sequence[str] | None,
+    ) -> tuple[str, ...]:
+        documents: list[str] = list(workflow.mandatory_system_documents)
+        if law_required_documents:
+            for document in law_required_documents:
+                if document not in documents:
+                    documents.append(document)
+        return tuple(documents)
+
+    @staticmethod
+    def _detect_fact_conflicts(
+        workflow: WorkflowBlueprint,
+        inputs: Mapping[str, Any],
+        external_facts: Mapping[str, Any] | None,
+    ) -> tuple[FactConflict, ...]:
+        if not external_facts:
+            return ()
+        conflicts: list[FactConflict] = []
+        for field_name in workflow.conflict_check_fields:
+            if field_name not in inputs or field_name not in external_facts:
+                continue
+            user_value = str(inputs[field_name]).strip()
+            system_value = str(external_facts[field_name]).strip()
+            if not user_value or not system_value:
+                continue
+            if user_value.casefold() != system_value.casefold():
+                conflicts.append(
+                    FactConflict(
+                        field=field_name,
+                        user_value=user_value,
+                        system_value=system_value,
+                        confirmation_question=(
+                            f"Zadaná hodnota '{field_name}' je '{user_value}', "
+                            f"ale v registri je '{system_value}'. Potvrďte, ktorá hodnota je platná."
+                        ),
+                    )
+                )
+        return tuple(conflicts)
+
+    @staticmethod
+    def _resolve_global_steps(
+        *,
+        question: str,
+        country: str,
+        inputs: Mapping[str, Any],
+        user_requested_screening: bool,
+        model_suggested_screening: bool,
+        auto_detect_screening_intent: bool,
+    ) -> tuple[tuple[str, ...], str | None, str | None]:
+        screening_required = user_requested_screening or model_suggested_screening
+        inferred_entity_type: str | None = None
+        inferred_entity_value: str | None = None
+        if auto_detect_screening_intent and not screening_required:
+            screening_required, inferred_entity_type, inferred_entity_value = _infer_screening_from_question(question)
+        if not screening_required:
+            return (), None, None
+        entity_type, entity_value = _pick_screening_entity(
+            inputs=inputs,
+            fallback_entity_type=inferred_entity_type,
+            fallback_entity_value=inferred_entity_value,
+        )
+        if not entity_value:
+            return ("global_entity_screening",), "Screening requested, but missing entity value for screening.", None
+        screening_agent = EntityScreeningAgent()
+        consent_prompt = screening_agent.build_screening_consent_prompt(
+            entity_type=entity_type,
+            entity_value=entity_value,
+        )
+        task_prompt = screening_agent.build_structured_screening_prompt(
+            entity_type=entity_type,
+            entity_value=entity_value,
+            country=country,
+        )
+        return ("global_entity_screening",), consent_prompt, task_prompt
+
+
+def _pick_screening_entity(
+    *,
+    inputs: Mapping[str, Any],
+    fallback_entity_type: str | None = None,
+    fallback_entity_value: str | None = None,
+) -> tuple[str, str]:
+    if "company_id" in inputs and str(inputs["company_id"]).strip():
+        return "company", str(inputs["company_id"]).strip()
+    if "person_name" in inputs and str(inputs["person_name"]).strip():
+        return "person", str(inputs["person_name"]).strip()
+    if "current_owner_name" in inputs and str(inputs["current_owner_name"]).strip():
+        return "person", str(inputs["current_owner_name"]).strip()
+    if fallback_entity_value:
+        return (fallback_entity_type or "entity"), fallback_entity_value
+    return "entity", ""
+
+
+def _infer_screening_from_question(question: str) -> tuple[bool, str | None, str | None]:
+    normalized = re.sub(r"\s+", " ", question.strip().lower())
+    screening_markers = ("over mi", "over", "prever", "screening", "check")
+    if not any(marker in normalized for marker in screening_markers):
+        return False, None, None
+    person_match = re.search(
+        r"(?:over mi|over|prever)\s+(?P<name>[a-záäčďéíĺľňóôŕšťúýž]+\s+[a-záäčďéíĺľňóôŕšťúýž]+)",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    if person_match:
+        return True, "person", person_match.group("name").strip().title()
+    return True, None, None
+
+
+def validate_slovak_company_id(_field_name: str, value: Any) -> str | None:
+    normalized = str(value).strip()
+    if not re.fullmatch(r"\d{8}", normalized):
+        return "IČO musí mať presne 8 číslic."
+    return None
+
+
+def create_default_registry() -> WorkflowRegistry:
+    return WorkflowRegistry(
+        workflows=[
+            WorkflowBlueprint(
+                workflow_id="sk.company.add_co_owner.v1",
+                country="SK",
+                case_group="obchodne_pravo",
+                description="Pridanie spoluvlastníka/spoločníka do s.r.o. vrátane prípravy dokumentov.",
+                intent_keywords=(
+                    "pridat spolocnika",
+                    "pridat noveho spolocnika",
+                    "novy spolocnik",
+                    "zmena spolocnika",
+                    "add co-owner",
+                    "s.r.o.",
+                ),
+                required_inputs=("company_id", "current_owner_name", "new_co_owner_name", "ownership_share_percent", "effective_date"),
+                optional_inputs=("new_co_owner_address", "purchase_price"),
+                input_validators={"company_id": validate_slovak_company_id},
+                conflict_check_fields=("current_owner_name",),
+                mandatory_system_documents=(
+                    "decision_of_general_meeting",
+                    "general_meeting_minutes",
+                ),
+                steps=(
+                    WorkflowStep(
+                        step_id="verify_company_in_orsr",
+                        name="Overenie spoločnosti v ORSR",
+                        description="Overí existenciu spoločnosti, štatutára a aktuálnu štruktúru v ORSR.",
+                        tool_name="orsr_lookup",
+                        required_inputs=("company_id",),
+                        output_artifacts=("company_verification_report",),
+                    ),
+                    WorkflowStep(
+                        step_id="check_shareholder_constraints",
+                        name="Kontrola obmedzení pre vstup nového spoločníka",
+                        description="Skontroluje interné a zákonné obmedzenia pre zmenu spoločníka.",
+                        tool_name="shareholder_structure_check",
+                        required_inputs=("company_id", "new_co_owner_name", "ownership_share_percent"),
+                        output_artifacts=("constraint_check_report",),
+                    ),
+                    WorkflowStep(
+                        step_id="prepare_document_bundle",
+                        name="Príprava balíka dokumentov",
+                        description="Vygeneruje požadované dokumenty pre zápis zmeny v obchodnom registri.",
+                        tool_name="document_bundle_generator",
+                        required_inputs=("effective_date",),
+                        output_artifacts=(
+                            "decision_of_general_meeting",
+                            "updated_articles_of_association",
+                            "general_meeting_minutes",
+                            "application_for_registry_update",
+                        ),
+                    ),
+                ),
+            ),
+            WorkflowBlueprint(
+                workflow_id="sk.company.verify_orsr.v1",
+                country="SK",
+                case_group="obchodne_pravo",
+                description="Samostatné overenie obchodnej spoločnosti v ORSR.",
+                intent_keywords=("overit firmu", "orsr", "obchodny register", "company verification"),
+                required_inputs=("company_id",),
+                input_validators={"company_id": validate_slovak_company_id},
+                mandatory_system_documents=("company_verification_report",),
+                steps=(
+                    WorkflowStep(
+                        step_id="verify_company_in_orsr",
+                        name="Overenie spoločnosti v ORSR",
+                        description="Overí základné údaje spoločnosti v ORSR.",
+                        tool_name="orsr_lookup",
+                        required_inputs=("company_id",),
+                        output_artifacts=("company_verification_report",),
+                    ),
+                ),
+            ),
+        ]
+    )

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -3,6 +3,9 @@ import re
 
 from aijurisdictionagents.agents.ai_web_search import (
     AIWebSearchAgent,
+    CompanySearchAgent,
+    EntityScreeningAgent,
+    PersonSearchAgent,
     _parse_duckduckgo_html_results,
 )
 from aijurisdictionagents.agents import AIUserSimulatorAgent, create_lawyer_agent
@@ -227,3 +230,37 @@ def test_ai_web_search_agent_falls_back_to_duckduckgo_html(monkeypatch) -> None:
 
     assert len(records) == 1
     assert records[0].url == "https://platform.openai.com/docs/models/gpt-4o-mini"
+
+
+def test_entity_screening_agent_and_ai_web_search_alias_share_consent_prompt() -> None:
+    entity_prompt = EntityScreeningAgent().build_screening_consent_prompt(
+        entity_type="company",
+        entity_value="12345678",
+    )
+    alias_prompt = AIWebSearchAgent().build_screening_consent_prompt(
+        entity_type="company",
+        entity_value="12345678",
+    )
+    assert entity_prompt == alias_prompt
+
+
+def test_company_search_agent_builds_structured_prompt_in_english() -> None:
+    prompt = CompanySearchAgent().build_search_prompt(
+        company_reference="ICO 12345678",
+        country="SK",
+    )
+    assert "registered address" in prompt
+    assert "list of companies owned by this company" in prompt
+    assert "social insurance" in prompt
+    assert "Country: SK" in prompt
+
+
+def test_person_search_agent_builds_structured_prompt_in_english() -> None:
+    prompt = PersonSearchAgent().build_search_prompt(
+        person_reference="Jana Hraska",
+        country="SK",
+    )
+    assert "list of companies linked to the person" in prompt
+    assert "list of trade licenses / sole-trader businesses" in prompt
+    assert "financial institutions" in prompt
+    assert "Person reference: Jana Hraska" in prompt

--- a/tests/test_workflow_engine.py
+++ b/tests/test_workflow_engine.py
@@ -1,0 +1,192 @@
+from aijurisdictionagents.workflows import WorkflowEngine, WorkflowRouter, create_default_registry
+
+
+def test_router_selects_add_co_owner_workflow() -> None:
+    engine = WorkflowEngine(WorkflowRouter(create_default_registry()))
+
+    result = engine.plan_case(
+        question="Chcem pridat noveho spolocnika do s.r.o. a pripravit podklady.",
+        country="SK",
+        inputs={
+            "company_id": "12345678",
+            "current_owner_name": "Peter Novak",
+            "new_co_owner_name": "Jan Novak",
+            "ownership_share_percent": "25",
+            "effective_date": "2026-04-30",
+        },
+    )
+
+    assert result.mode == "workflow"
+    assert result.workflow is not None
+    assert result.workflow.workflow_id == "sk.company.add_co_owner.v1"
+    assert result.confidence > 0.35
+    assert result.validation_issues == ()
+    assert result.workflow.steps
+    assert result.workflow.steps[0].step_id == "verify_company_in_orsr"
+    assert result.required_documents == ("decision_of_general_meeting", "general_meeting_minutes")
+    assert result.global_steps == ()
+    assert result.screening_consent_prompt is None
+    assert result.screening_task_prompt is None
+
+
+def test_router_selects_verify_company_workflow() -> None:
+    engine = WorkflowEngine(WorkflowRouter(create_default_registry()))
+
+    result = engine.plan_case(
+        question="Chcem overit firmu v ORSR podla ICO.",
+        country="SK",
+        inputs={"company_id": "12345678"},
+    )
+
+    assert result.mode == "workflow"
+    assert result.workflow is not None
+    assert result.workflow.workflow_id == "sk.company.verify_orsr.v1"
+    assert result.required_documents == ("company_verification_report",)
+
+
+def test_engine_requests_missing_required_inputs() -> None:
+    engine = WorkflowEngine(WorkflowRouter(create_default_registry()))
+
+    result = engine.plan_case(
+        question="Potrebujem pridat spolocnika v s.r.o.",
+        country="SK",
+        inputs={"company_id": "12345678"},
+    )
+
+    assert result.mode == "workflow"
+    assert result.workflow is not None
+    assert result.workflow.workflow_id == "sk.company.add_co_owner.v1"
+    assert set(result.missing_inputs) == {"current_owner_name", "new_co_owner_name", "ownership_share_percent", "effective_date"}
+    assert len(result.clarification_questions) == 4
+    assert result.required_documents == ("decision_of_general_meeting", "general_meeting_minutes")
+
+
+def test_engine_detects_invalid_company_id() -> None:
+    engine = WorkflowEngine(WorkflowRouter(create_default_registry()))
+
+    result = engine.plan_case(
+        question="Chcem pridat spolocnika a skontrolovat ORSR.",
+        country="SK",
+        inputs={"company_id": "123"},
+    )
+
+    assert result.mode == "workflow"
+    assert result.validation_issues
+    assert result.validation_issues[0].field == "company_id"
+
+
+def test_engine_merges_mandatory_and_law_required_documents() -> None:
+    engine = WorkflowEngine(WorkflowRouter(create_default_registry()))
+
+    result = engine.plan_case(
+        question="Chcem pridat noveho spolocnika do s.r.o.",
+        country="SK",
+        inputs={
+            "company_id": "12345678",
+            "current_owner_name": "Peter Novak",
+            "new_co_owner_name": "Jan Novak",
+            "ownership_share_percent": "25",
+            "effective_date": "2026-04-30",
+        },
+        law_required_documents=("beneficial_owner_declaration", "general_meeting_minutes"),
+    )
+
+    assert result.mode == "workflow"
+    assert result.required_documents == (
+        "decision_of_general_meeting",
+        "general_meeting_minutes",
+        "beneficial_owner_declaration",
+    )
+
+
+def test_engine_creates_confirmation_question_when_owner_conflicts_with_registry() -> None:
+    engine = WorkflowEngine(WorkflowRouter(create_default_registry()))
+    result = engine.plan_case(
+        question="Chcem pridat noveho spolocnika do s.r.o.",
+        country="SK",
+        inputs={
+            "company_id": "12345678",
+            "current_owner_name": "Peter Novak",
+            "new_co_owner_name": "Jan Novak",
+            "ownership_share_percent": "25",
+            "effective_date": "2026-04-30",
+        },
+        external_facts={"current_owner_name": "Martin Novak"},
+    )
+
+    assert result.mode == "workflow"
+    assert result.fact_conflicts
+    assert result.fact_conflicts[0].field == "current_owner_name"
+    assert "Potvrďte, ktorá hodnota je platná." in result.clarification_questions[-1]
+
+
+def test_engine_uses_fallback_when_no_workflow_matches() -> None:
+    engine = WorkflowEngine(WorkflowRouter(create_default_registry()))
+
+    result = engine.plan_case(
+        question="Potrebujem radu o rozvode a starostlivosti o dieta.",
+        country="SK",
+        inputs={"party_a": "Jana"},
+    )
+
+    assert result.mode == "fallback"
+    assert result.workflow is None
+    assert result.clarification_questions
+    assert result.required_documents == ()
+    assert result.fact_conflicts == ()
+    assert result.global_steps == ()
+    assert result.screening_consent_prompt is None
+    assert result.screening_task_prompt is None
+
+
+def test_engine_adds_global_screening_step_when_user_requests_it() -> None:
+    engine = WorkflowEngine(WorkflowRouter(create_default_registry()))
+    result = engine.plan_case(
+        question="Chcem pridat noveho spolocnika do s.r.o.",
+        country="SK",
+        inputs={
+            "company_id": "12345678",
+            "current_owner_name": "Peter Novak",
+            "new_co_owner_name": "Jan Novak",
+            "ownership_share_percent": "25",
+            "effective_date": "2026-04-30",
+        },
+        user_requested_screening=True,
+    )
+
+    assert result.mode == "workflow"
+    assert result.global_steps == ("global_entity_screening",)
+    assert result.screening_consent_prompt is not None
+    assert "Reply YES to continue or NO to skip." in result.screening_consent_prompt
+    assert result.screening_task_prompt is not None
+    assert "registered address" in result.screening_task_prompt
+
+
+def test_engine_adds_global_screening_step_when_model_suggests_it() -> None:
+    engine = WorkflowEngine(WorkflowRouter(create_default_registry()))
+    result = engine.plan_case(
+        question="Chcem overit firmu v ORSR podla ICO.",
+        country="SK",
+        inputs={"company_id": "12345678"},
+        model_suggested_screening=True,
+    )
+
+    assert result.mode == "workflow"
+    assert result.global_steps == ("global_entity_screening",)
+    assert result.screening_consent_prompt is not None
+    assert result.screening_task_prompt is not None
+
+
+def test_engine_auto_detects_slovak_screening_request_and_extracts_person() -> None:
+    engine = WorkflowEngine(WorkflowRouter(create_default_registry()))
+    result = engine.plan_case(
+        question="Over mi jana hraska",
+        country="SK",
+        inputs={},
+    )
+
+    assert result.global_steps == ("global_entity_screening",)
+    assert result.screening_consent_prompt is not None
+    assert "person = 'Jana Hraska'" in result.screening_consent_prompt
+    assert result.screening_task_prompt is not None
+    assert "list of trade licenses / sole-trader businesses" in result.screening_task_prompt


### PR DESCRIPTION
### Motivation
- Introduce a lightweight legal workflow routing/engine to classify client legal questions, validate inputs and select country-specific workflows with fallbacks.
- Provide a reusable global entity screening helper with structured company/person screening prompts and a backward-compatible alias for the previous web-search agent.
- Expose structured screening as a global workflow step that can be requested, suggested by the model, or auto-detected from user text (Slovak examples included).
- Update examples and documentation to demonstrate the new routing, screening, and workflow behaviors.

### Description
- Add a new `workflows` package implementing `WorkflowEngine`, `WorkflowRouter`, `WorkflowRegistry`, `WorkflowBlueprint`, `WorkflowStep`, `WorkflowSelection`, `FactConflict`, and validation utilities in `src/aijurisdictionagents/workflows/engine.py` and export them via `src/aijurisdictionagents/workflows/__init__.py`.
- Implement `EntityScreeningAgent` in `src/aijurisdictionagents/agents/ai_web_search.py`, add `CompanySearchAgent` and `PersonSearchAgent` for structured English screening prompts, and keep `AIWebSearchAgent` as a backward-compatible alias.
- Update package exports in `src/aijurisdictionagents/agents/__init__.py`, bump package `__version__` in `src/aijurisdictionagents/__init__.py`, and wire the workflow engine into the demo in `examples/minimal_demo.py`.
- Add documentation files `docs/LEGAL_WORKFLOW_ROUTING.md` and update `docs/AI_WEB_SEARCH_AGENT.md` to reflect the renamed agent and new features.
- Add comprehensive unit tests in `tests/test_workflow_engine.py` and extend `tests/test_agents.py` to cover the new screening agents and alias behavior.

### Testing
- Ran unit tests for agents and workflow engine with `pytest -q`, including `tests/test_agents.py` and `tests/test_workflow_engine.py`.
- All added and existing tests passed locally (workflow routing, validation, document merge, fact conflict detection, global screening injection, and agent prompt generation assertions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d5d5e1a083328e10e7010204b266)