### PR TITLE
Add Flow Packs API with store, defaults, chat warning, docs and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,8 @@ SYSTEM_EMBEDDING_MODEL=all-MiniLM-L6-v2
 ## API database/storage selection (local|postgres|azure)
 DB_OPTION=local
 STORAGE_OPTION=local
+# Optional override for flow-pack runtime SQLite storage.
+# API_FLOW_PACKS_SQLITE_PATH=./runs/storage/api/sqlite/flow_packs.sqlite3
 # DOCUMENT_PROCESSOR_OPTION options:
 # - local: process uploaded case documents immediately inside the API
 # - azure: leave uploads pending for the Azure Container Apps document processor job

--- a/api/aijuristiction-api/app/chat/api.py
+++ b/api/aijuristiction-api/app/chat/api.py
@@ -27,6 +27,7 @@ from reportlab.pdfgen import canvas  # type: ignore[import-untyped]
 
 from app.chat.core_runtime import core_message_role, run_orchestration
 from app.chat.country_services import prepare_country_direct_reply
+from app.flow_packs.api import get_flow_pack_store
 from app.chat.intent_policy_service import (
     build_document_task_plan_note,
     is_document_modernization_request,
@@ -449,6 +450,7 @@ def _run_direct_lawyer_turn(
         session=session,
         processing_event_callback=processing_event_callback,
     )
+    _warn_if_flow_pack_missing(session_id=session_id, session=session, request_text=content)
 
     from aijurisdictionagents.agents import create_lawyer_agent
     from aijurisdictionagents.llm import get_llm_client
@@ -567,6 +569,29 @@ def _run_direct_lawyer_turn(
         agent_name=lawyer_message.agent_name,
     )
     return persisted_user, persisted_lawyer, visible_lawyer_content, preparation.processing_events
+
+
+def _warn_if_flow_pack_missing(*, session_id: UUID, session: Session, request_text: str) -> None:
+    try:
+        flow_pack = get_flow_pack_store().find_best_match(
+            request_text=request_text,
+            country=session.country,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning(
+            "Flow-pack lookup failed for request | session_id=%s country=%s reason=%s",
+            session_id,
+            session.country,
+            exc,
+        )
+        return
+    if flow_pack is None:
+        _LOGGER.warning(
+            "No flow-pack matched user request | session_id=%s country=%s request=%s",
+            session_id,
+            session.country,
+            " ".join(request_text.split())[:180],
+        )
 
 
 class StartSessionStreamRequest(BaseModel):

--- a/api/aijuristiction-api/app/flow_packs/__init__.py
+++ b/api/aijuristiction-api/app/flow_packs/__init__.py
@@ -1,0 +1,3 @@
+from app.flow_packs.api import router
+
+__all__ = ["router"]

--- a/api/aijuristiction-api/app/flow_packs/api.py
+++ b/api/aijuristiction-api/app/flow_packs/api.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.flow_packs.models import (
+    FlowPackCreateRequest,
+    FlowPackCreateVersionRequest,
+    FlowPackListResponse,
+    FlowPackResponse,
+    FlowPackUpdateRequest,
+    FlowPackVersionListResponse,
+)
+from app.flow_packs.store import (
+    FlowPackAmbiguousError,
+    FlowPackNotFoundError,
+    FlowPackStore,
+    FlowPackVersionConflictError,
+)
+from app.security import require_api_key
+
+router = APIRouter(prefix="/v1/flow-packs", tags=["flow-packs"], dependencies=[Depends(require_api_key)])
+
+
+@lru_cache(maxsize=1)
+def get_flow_pack_store() -> FlowPackStore:
+    return FlowPackStore.from_env()
+
+
+@router.get("", response_model=FlowPackListResponse)
+def list_flow_packs(
+    include_deleted: bool = Query(default=False),
+    jurisdiction: str | None = Query(default=None),
+    store: FlowPackStore = Depends(get_flow_pack_store),
+) -> FlowPackListResponse:
+    return FlowPackListResponse(items=store.list(include_deleted=include_deleted, jurisdiction=jurisdiction))
+
+
+@router.get("/{flow_key}/versions", response_model=FlowPackVersionListResponse)
+def list_flow_pack_versions(
+    flow_key: str,
+    include_deleted: bool = Query(default=True),
+    jurisdiction: str | None = Query(default=None),
+    store: FlowPackStore = Depends(get_flow_pack_store),
+) -> FlowPackVersionListResponse:
+    return FlowPackVersionListResponse(
+        flow_key=flow_key,
+        versions=store.list_versions(flow_key=flow_key, jurisdiction=jurisdiction, include_deleted=include_deleted),
+    )
+
+
+@router.get("/{flow_key}/versions/{version}", response_model=FlowPackResponse)
+def get_flow_pack_version(
+    flow_key: str,
+    version: int,
+    jurisdiction: str | None = Query(default=None),
+    store: FlowPackStore = Depends(get_flow_pack_store),
+) -> FlowPackResponse:
+    try:
+        return store.get(flow_key=flow_key, version=version, jurisdiction=jurisdiction)
+    except FlowPackNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except FlowPackAmbiguousError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.post("", response_model=FlowPackResponse, status_code=status.HTTP_201_CREATED)
+def create_flow_pack(
+    payload: FlowPackCreateRequest,
+    store: FlowPackStore = Depends(get_flow_pack_store),
+) -> FlowPackResponse:
+    try:
+        return store.create(payload)
+    except FlowPackVersionConflictError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+
+@router.post("/{flow_key}/versions", response_model=FlowPackResponse, status_code=status.HTTP_201_CREATED)
+def create_flow_pack_version(
+    flow_key: str,
+    payload: FlowPackCreateVersionRequest,
+    jurisdiction: str | None = Query(default=None),
+    store: FlowPackStore = Depends(get_flow_pack_store),
+) -> FlowPackResponse:
+    try:
+        return store.create_version(flow_key=flow_key, payload=payload, jurisdiction=jurisdiction)
+    except FlowPackNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except FlowPackVersionConflictError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except FlowPackAmbiguousError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.patch("/{flow_key}/versions/{version}", response_model=FlowPackResponse)
+def update_flow_pack_version(
+    flow_key: str,
+    version: int,
+    payload: FlowPackUpdateRequest,
+    jurisdiction: str | None = Query(default=None),
+    store: FlowPackStore = Depends(get_flow_pack_store),
+) -> FlowPackResponse:
+    try:
+        return store.update(flow_key=flow_key, version=version, payload=payload, jurisdiction=jurisdiction)
+    except FlowPackNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except FlowPackAmbiguousError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.post("/{flow_key}/versions/{version}/enable", response_model=FlowPackResponse)
+def enable_flow_pack_version(
+    flow_key: str,
+    version: int,
+    jurisdiction: str | None = Query(default=None),
+    store: FlowPackStore = Depends(get_flow_pack_store),
+) -> FlowPackResponse:
+    try:
+        return store.set_enabled(flow_key=flow_key, version=version, enabled=True, jurisdiction=jurisdiction)
+    except FlowPackNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except FlowPackAmbiguousError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.post("/{flow_key}/versions/{version}/disable", response_model=FlowPackResponse)
+def disable_flow_pack_version(
+    flow_key: str,
+    version: int,
+    jurisdiction: str | None = Query(default=None),
+    store: FlowPackStore = Depends(get_flow_pack_store),
+) -> FlowPackResponse:
+    try:
+        return store.set_enabled(flow_key=flow_key, version=version, enabled=False, jurisdiction=jurisdiction)
+    except FlowPackNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except FlowPackAmbiguousError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.delete("/{flow_key}/versions/{version}", response_model=FlowPackResponse)
+def soft_delete_flow_pack_version(
+    flow_key: str,
+    version: int,
+    jurisdiction: str | None = Query(default=None),
+    store: FlowPackStore = Depends(get_flow_pack_store),
+) -> FlowPackResponse:
+    try:
+        return store.soft_delete(flow_key=flow_key, version=version, jurisdiction=jurisdiction)
+    except FlowPackNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except FlowPackAmbiguousError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc

--- a/api/aijuristiction-api/app/flow_packs/default_packs.py
+++ b/api/aijuristiction-api/app/flow_packs/default_packs.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_default_slovak_flow_packs() -> list[dict[str, Any]]:
+    return [
+        {
+            "flow_key": "sk.contract.sale_purchase",
+            "version": 1,
+            "jurisdiction": "SK",
+            "domain": "civil",
+            "title": "Kúpna zmluva (všeobecná)",
+            "description": "Príprava kúpnej zmluvy pre hnuteľné veci a základná kontrola povinných údajov.",
+            "is_enabled": True,
+            "definition": {
+                "intent": {"keywords": ["kúpna zmluva", "kupna zmluva", "predaj", "kupa"]},
+                "required_facts": [
+                    "seller_identification",
+                    "buyer_identification",
+                    "subject_description",
+                    "purchase_price",
+                    "payment_terms",
+                ],
+                "outputs": ["sale_purchase_agreement", "handover_protocol_template"],
+                "proactive_recommendations": [
+                    "Navrhni odovzdávací protokol.",
+                    "Upozorni na zodpovednosť za vady.",
+                ],
+            },
+        },
+        {
+            "flow_key": "sk.company.registry_change",
+            "version": 1,
+            "jurisdiction": "SK",
+            "domain": "commercial",
+            "title": "Firemné zmeny do ORSR",
+            "description": "Balík dokumentov pre časté zmeny v s.r.o. vrátane podania na ORSR.",
+            "is_enabled": True,
+            "definition": {
+                "intent": {"keywords": ["orsr", "obchodny register", "obchodný register", "zapis do orsr"]},
+                "required_facts": [
+                    "company_name",
+                    "company_identifier",
+                    "change_type",
+                    "effective_date",
+                ],
+                "tools": ["obchodny_register_company_check"],
+                "outputs": [
+                    "corporate_resolution",
+                    "updated_articles",
+                    "registry_filing_package",
+                ],
+            },
+        },
+        {
+            "flow_key": "sk.civil.power_of_attorney",
+            "version": 1,
+            "jurisdiction": "SK",
+            "domain": "civil",
+            "title": "Splnomocnenie",
+            "description": "Príprava všeobecného alebo osobitného splnomocnenia so scope control.",
+            "is_enabled": True,
+            "definition": {
+                "intent": {"keywords": ["splnomocnenie", "plna moc", "plná moc"]},
+                "required_facts": [
+                    "principal_identification",
+                    "agent_identification",
+                    "scope_of_authority",
+                    "validity_period",
+                ],
+                "outputs": ["power_of_attorney"],
+                "proactive_recommendations": [
+                    "Pri úradných úkonoch upozorni na overenie podpisu.",
+                ],
+            },
+        },
+        {
+            "flow_key": "sk.criminal.criminal_complaint",
+            "version": 1,
+            "jurisdiction": "SK",
+            "domain": "criminal",
+            "title": "Trestné oznámenie",
+            "description": "Štruktúrovaná príprava podania trestného oznámenia s evidenciou dôkazov.",
+            "is_enabled": True,
+            "definition": {
+                "intent": {"keywords": ["trestne oznamenie", "trestné oznámenie", "trestne konanie"]},
+                "required_facts": [
+                    "complainant_identification",
+                    "factual_description",
+                    "approx_time_and_place",
+                    "available_evidence",
+                ],
+                "outputs": ["criminal_complaint_submission", "evidence_index"],
+                "escalation_rules": ["recommend_human_lawyer_review_if_sensitive_case"],
+            },
+        },
+        {
+            "flow_key": "sk.notary.notarial_process",
+            "version": 1,
+            "jurisdiction": "SK",
+            "domain": "notary",
+            "title": "Notárske procesy",
+            "description": "Príprava podkladov pre notársku zápisnicu a osvedčovanie listín/podpisov.",
+            "is_enabled": True,
+            "definition": {
+                "intent": {"keywords": ["notar", "notár", "notarska zapisnica", "notárska zápisnica"]},
+                "required_facts": ["participants", "document_purpose", "required_notary_act"],
+                "outputs": ["notary_preparation_checklist"],
+                "proactive_recommendations": [
+                    "Upozorni na potrebu originálov/príloh.",
+                    "Upozorni na overenie totožnosti.",
+                ],
+            },
+        },
+        {
+            "flow_key": "sk.support.person_company_screening",
+            "version": 1,
+            "jurisdiction": "SK",
+            "domain": "support",
+            "title": "Screening osoby/firmy",
+            "description": "Pomocný proces pre zistenie verejne dostupných údajov o osobe alebo firme.",
+            "is_enabled": True,
+            "definition": {
+                "intent": {"keywords": ["overit osobu", "overit firmu", "screening", "preverenie osoby", "preverenie firmy"]},
+                "required_facts": ["entity_type", "entity_reference"],
+                "outputs": ["screening_summary"],
+                "tools": ["obchodny_register_company_check", "entity_screening_agent"],
+            },
+        },
+        {
+            "flow_key": "cz.contract.sale_purchase",
+            "version": 1,
+            "jurisdiction": "CZ",
+            "domain": "civil",
+            "title": "Kupní smlouva (obecná)",
+            "description": "Příprava kupní smlouvy pro běžné občanskoprávní převody.",
+            "is_enabled": True,
+            "definition": {
+                "intent": {"keywords": ["kupni smlouva", "koupě", "prodej"]},
+                "required_facts": [
+                    "seller_identification",
+                    "buyer_identification",
+                    "subject_description",
+                    "purchase_price",
+                    "payment_terms",
+                ],
+                "outputs": ["sale_purchase_agreement", "handover_protocol_template"],
+            },
+        },
+        {
+            "flow_key": "cz.civil.power_of_attorney",
+            "version": 1,
+            "jurisdiction": "CZ",
+            "domain": "civil",
+            "title": "Plná moc",
+            "description": "Příprava obecné nebo zvláštní plné moci.",
+            "is_enabled": True,
+            "definition": {
+                "intent": {"keywords": ["plna moc", "plná moc", "zmocnění"]},
+                "required_facts": [
+                    "principal_identification",
+                    "agent_identification",
+                    "scope_of_authority",
+                    "validity_period",
+                ],
+                "outputs": ["power_of_attorney"],
+            },
+        },
+    ]

--- a/api/aijuristiction-api/app/flow_packs/models.py
+++ b/api/aijuristiction-api/app/flow_packs/models.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class FlowPackBasePayload(BaseModel):
+    flow_key: str = Field(min_length=3, description="Stable flow identifier, e.g. sk.contract.sale_purchase")
+    jurisdiction: str = Field(min_length=2, max_length=8)
+    domain: str = Field(min_length=2, max_length=32)
+    title: str = Field(min_length=3, max_length=200)
+    description: str = Field(min_length=3, max_length=2000)
+    definition: dict[str, Any] = Field(default_factory=dict)
+    is_enabled: bool = True
+
+
+class FlowPackCreateRequest(FlowPackBasePayload):
+    version: int | None = Field(default=None, ge=1)
+
+
+class FlowPackCreateVersionRequest(BaseModel):
+    jurisdiction: str | None = Field(default=None, min_length=2, max_length=8)
+    domain: str | None = Field(default=None, min_length=2, max_length=32)
+    title: str | None = Field(default=None, min_length=3, max_length=200)
+    description: str | None = Field(default=None, min_length=3, max_length=2000)
+    definition: dict[str, Any] | None = None
+    is_enabled: bool = True
+
+
+class FlowPackUpdateRequest(BaseModel):
+    jurisdiction: str | None = Field(default=None, min_length=2, max_length=8)
+    domain: str | None = Field(default=None, min_length=2, max_length=32)
+    title: str | None = Field(default=None, min_length=3, max_length=200)
+    description: str | None = Field(default=None, min_length=3, max_length=2000)
+    definition: dict[str, Any] | None = None
+
+
+class FlowPackResponse(BaseModel):
+    flow_id: str
+    flow_key: str
+    version: int
+    jurisdiction: str
+    domain: str
+    title: str
+    description: str
+    definition: dict[str, Any]
+    is_enabled: bool
+    is_deleted: bool
+    created_at: datetime
+    updated_at: datetime
+    deleted_at: datetime | None = None
+
+
+class FlowPackListResponse(BaseModel):
+    items: list[FlowPackResponse]
+
+
+class FlowPackVersionListResponse(BaseModel):
+    flow_key: str
+    versions: list[FlowPackResponse]

--- a/api/aijuristiction-api/app/flow_packs/store.py
+++ b/api/aijuristiction-api/app/flow_packs/store.py
@@ -1,0 +1,542 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from contextlib import contextmanager
+import json
+import os
+from pathlib import Path
+import sqlite3
+from typing import Any, Iterator
+import unicodedata
+from uuid import uuid4
+
+from aijurisdictionagents.api_db.config import ApiDataConfig
+
+from app.flow_packs.default_packs import build_default_slovak_flow_packs
+from app.flow_packs.models import (
+    FlowPackCreateRequest,
+    FlowPackCreateVersionRequest,
+    FlowPackResponse,
+    FlowPackUpdateRequest,
+)
+
+
+@dataclass(frozen=True)
+class FlowPackStoreConfig:
+    db_option: str
+    db_cloud: str
+    sqlite_path: Path
+
+
+class FlowPackNotFoundError(KeyError):
+    pass
+
+
+class FlowPackVersionConflictError(ValueError):
+    pass
+
+
+class FlowPackAmbiguousError(ValueError):
+    pass
+
+
+class FlowPackStore:
+    def __init__(self, config: FlowPackStoreConfig) -> None:
+        self._config = config
+        self._config.sqlite_path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+        self._seed_defaults_if_empty()
+
+    @classmethod
+    def from_env(cls) -> "FlowPackStore":
+        api_db_config = ApiDataConfig.from_env()
+        configured = os.getenv("API_FLOW_PACKS_SQLITE_PATH", "").strip()
+        if configured:
+            path = Path(configured)
+        else:
+            repo_root = Path(__file__).resolve().parents[4]
+            path = repo_root / "runs" / "storage" / "api" / "sqlite" / "flow_packs.sqlite3"
+        return cls(
+            FlowPackStoreConfig(
+                db_option=api_db_config.db_option,
+                db_cloud=api_db_config.db_cloud,
+                sqlite_path=path,
+            )
+        )
+
+    def list(
+        self,
+        *,
+        include_deleted: bool = False,
+        flow_key: str | None = None,
+        jurisdiction: str | None = None,
+    ) -> list[FlowPackResponse]:
+        clauses: list[str] = []
+        params: list[object] = []
+        if not include_deleted:
+            clauses.append("is_deleted = 0")
+        if flow_key:
+            clauses.append("flow_key = ?")
+            params.append(flow_key.strip())
+        if jurisdiction:
+            clauses.append("jurisdiction = ?")
+            params.append(jurisdiction.strip().upper())
+        where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        query = (
+            "SELECT * FROM flow_packs "
+            f"{where_sql} "
+            "ORDER BY flow_key ASC, version DESC"
+        )
+        with self._connect() as conn:
+            rows = conn.execute(self._sql(query), self._params(*params)).fetchall()
+        return [self._row_to_response(_row_to_mapping(row)) for row in rows]
+
+    def list_versions(
+        self,
+        *,
+        flow_key: str,
+        jurisdiction: str | None = None,
+        include_deleted: bool = True,
+    ) -> list[FlowPackResponse]:
+        return self.list(include_deleted=include_deleted, flow_key=flow_key, jurisdiction=jurisdiction)
+
+    def get(self, *, flow_key: str, version: int, jurisdiction: str | None = None) -> FlowPackResponse:
+        with self._connect() as conn:
+            if jurisdiction:
+                row = conn.execute(
+                    self._sql("SELECT * FROM flow_packs WHERE flow_key = ? AND version = ? AND jurisdiction = ?"),
+                    self._params(flow_key.strip(), version, jurisdiction.strip().upper()),
+                ).fetchone()
+                if row is None:
+                    raise FlowPackNotFoundError(
+                        f"Flow pack '{flow_key}' version {version} for jurisdiction '{jurisdiction}' was not found"
+                    )
+                return self._row_to_response(_row_to_mapping(row))
+
+            rows = conn.execute(
+                self._sql("SELECT * FROM flow_packs WHERE flow_key = ? AND version = ?"),
+                self._params(flow_key.strip(), version),
+            ).fetchall()
+        if not rows:
+            raise FlowPackNotFoundError(f"Flow pack '{flow_key}' version {version} was not found")
+        if len(rows) > 1:
+            raise FlowPackAmbiguousError(
+                f"Flow pack '{flow_key}' version {version} exists in multiple jurisdictions; specify jurisdiction."
+            )
+        return self._row_to_response(_row_to_mapping(rows[0]))
+
+    def create(self, payload: FlowPackCreateRequest) -> FlowPackResponse:
+        flow_key = payload.flow_key.strip()
+        jurisdiction = payload.jurisdiction.strip().upper()
+        version = (
+            payload.version
+            or (self._next_version(flow_key, jurisdiction=jurisdiction) if self._exists(flow_key) else 1)
+        )
+        if self._version_exists(flow_key=flow_key, version=version, jurisdiction=jurisdiction):
+            raise FlowPackVersionConflictError(
+                f"Flow pack '{flow_key}' version {version} for jurisdiction '{jurisdiction}' already exists"
+            )
+        now = _utc_now_iso()
+        flow_id = str(uuid4())
+        with self._connect() as conn:
+            conn.execute(
+                self._sql(
+                    """
+                INSERT INTO flow_packs (
+                    flow_id, flow_key, version, jurisdiction, domain, title, description,
+                    definition_json, is_enabled, is_deleted, created_at, updated_at, deleted_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, NULL)
+                """
+                ),
+                self._params(
+                    flow_id,
+                    flow_key,
+                    version,
+                    jurisdiction,
+                    payload.domain.strip().lower(),
+                    payload.title.strip(),
+                    payload.description.strip(),
+                    json.dumps(payload.definition, ensure_ascii=False, sort_keys=True),
+                    1 if payload.is_enabled else 0,
+                    now,
+                    now,
+                ),
+            )
+            conn.commit()
+        return self.get(flow_key=flow_key, version=version, jurisdiction=jurisdiction)
+
+    def create_version(
+        self,
+        *,
+        flow_key: str,
+        payload: FlowPackCreateVersionRequest,
+        jurisdiction: str | None = None,
+    ) -> FlowPackResponse:
+        target_jurisdiction = (payload.jurisdiction or jurisdiction or "").strip().upper()
+        latest = self._latest(flow_key, jurisdiction=target_jurisdiction or None)
+        if latest is None:
+            if target_jurisdiction:
+                raise FlowPackNotFoundError(
+                    f"Flow pack '{flow_key}' does not exist for jurisdiction '{target_jurisdiction}'"
+                )
+            raise FlowPackNotFoundError(f"Flow pack '{flow_key}' does not exist")
+        create_payload = FlowPackCreateRequest(
+            flow_key=flow_key,
+            version=latest.version + 1,
+            jurisdiction=target_jurisdiction or latest.jurisdiction,
+            domain=payload.domain or latest.domain,
+            title=payload.title or latest.title,
+            description=payload.description or latest.description,
+            definition=payload.definition if payload.definition is not None else latest.definition,
+            is_enabled=payload.is_enabled,
+        )
+        return self.create(create_payload)
+
+    def update(
+        self,
+        *,
+        flow_key: str,
+        version: int,
+        payload: FlowPackUpdateRequest,
+        jurisdiction: str | None = None,
+    ) -> FlowPackResponse:
+        current = self.get(flow_key=flow_key, version=version, jurisdiction=jurisdiction)
+        if current.is_deleted:
+            raise FlowPackNotFoundError(f"Flow pack '{flow_key}' version {version} is deleted")
+        updated = {
+            "jurisdiction": (payload.jurisdiction or current.jurisdiction).strip().upper(),
+            "domain": (payload.domain or current.domain).strip().lower(),
+            "title": (payload.title or current.title).strip(),
+            "description": (payload.description or current.description).strip(),
+            "definition_json": json.dumps(
+                payload.definition if payload.definition is not None else current.definition,
+                ensure_ascii=False,
+                sort_keys=True,
+            ),
+            "updated_at": _utc_now_iso(),
+        }
+        with self._connect() as conn:
+            conn.execute(
+                self._sql(
+                    """
+                UPDATE flow_packs
+                SET jurisdiction = ?, domain = ?, title = ?, description = ?, definition_json = ?, updated_at = ?
+                WHERE flow_key = ? AND version = ? AND jurisdiction = ?
+                """
+                ),
+                self._params(
+                    updated["jurisdiction"],
+                    updated["domain"],
+                    updated["title"],
+                    updated["description"],
+                    updated["definition_json"],
+                    updated["updated_at"],
+                    flow_key.strip(),
+                    version,
+                    current.jurisdiction,
+                ),
+            )
+            conn.commit()
+        return self.get(flow_key=flow_key, version=version, jurisdiction=current.jurisdiction)
+
+    def set_enabled(
+        self,
+        *,
+        flow_key: str,
+        version: int,
+        enabled: bool,
+        jurisdiction: str | None = None,
+    ) -> FlowPackResponse:
+        current = self.get(flow_key=flow_key, version=version, jurisdiction=jurisdiction)
+        with self._connect() as conn:
+            conn.execute(
+                self._sql(
+                    "UPDATE flow_packs SET is_enabled = ?, updated_at = ? WHERE flow_key = ? AND version = ? AND jurisdiction = ?"
+                ),
+                self._params(1 if enabled else 0, _utc_now_iso(), flow_key.strip(), version, current.jurisdiction),
+            )
+            conn.commit()
+        return self.get(flow_key=flow_key, version=version, jurisdiction=current.jurisdiction)
+
+    def soft_delete(self, *, flow_key: str, version: int, jurisdiction: str | None = None) -> FlowPackResponse:
+        current = self.get(flow_key=flow_key, version=version, jurisdiction=jurisdiction)
+        now = _utc_now_iso()
+        with self._connect() as conn:
+            conn.execute(
+                self._sql(
+                    """
+                UPDATE flow_packs
+                SET is_deleted = 1, is_enabled = 0, deleted_at = ?, updated_at = ?
+                WHERE flow_key = ? AND version = ? AND jurisdiction = ?
+                """
+                ),
+                self._params(now, now, flow_key.strip(), version, current.jurisdiction),
+            )
+            conn.commit()
+        return self.get(flow_key=flow_key, version=version, jurisdiction=current.jurisdiction)
+
+    def find_best_match(
+        self,
+        *,
+        request_text: str,
+        country: str,
+    ) -> FlowPackResponse | None:
+        normalized_text = _normalize_for_match(request_text)
+        if not normalized_text:
+            return None
+        candidates = [
+            item
+            for item in self.list(include_deleted=False)
+            if item.is_enabled and item.jurisdiction.strip().upper() == country.strip().upper()
+        ]
+        text_roots = _token_roots(normalized_text)
+        scored: list[tuple[int, FlowPackResponse]] = []
+        for item in candidates:
+            keywords = _extract_flow_keywords(item.definition)
+            if not keywords:
+                continue
+            score = 0
+            for keyword in keywords:
+                normalized_keyword = _normalize_for_match(keyword)
+                if normalized_keyword in normalized_text:
+                    score += 2
+                    continue
+                keyword_roots = _token_roots(normalized_keyword)
+                if keyword_roots and keyword_roots.issubset(text_roots):
+                    score += 1
+            if score > 0:
+                scored.append((score, item))
+        scored.sort(key=lambda pair: pair[0], reverse=True)
+        return scored[0][1] if scored else None
+
+    def _seed_defaults_if_empty(self) -> None:
+        with self._connect() as conn:
+            row = conn.execute(self._sql("SELECT COUNT(1) as count FROM flow_packs")).fetchone()
+        if row is not None and int(row["count"]) > 0:
+            return
+        for item in build_default_slovak_flow_packs():
+            self.create(FlowPackCreateRequest.model_validate(item))
+
+    def _initialize(self) -> None:
+        with self._connect() as conn:
+            if self._is_postgres:
+                schema_statements = [statement.strip() for statement in _load_schema_sql().split(";") if statement.strip()]
+                for statement in schema_statements:
+                    conn.execute(statement)
+            else:
+                conn.executescript(_load_schema_sql())
+            self._migrate_legacy_uniqueness(conn)
+            conn.commit()
+
+    @property
+    def _is_postgres(self) -> bool:
+        return self._config.db_option in {"postgres", "azure"}
+
+    @contextmanager
+    def _connect(self) -> sqlite3.Connection:
+        if self._is_postgres:
+            psycopg = _load_psycopg()
+            if not self._config.db_cloud:
+                raise RuntimeError("DB_CLOUD is required for postgres/azure flow-pack storage")
+            conn = psycopg.connect(self._config.db_cloud, row_factory=psycopg.rows.dict_row)
+            try:
+                yield conn
+            finally:
+                conn.close()
+            return
+        conn = sqlite3.connect(self._config.sqlite_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def _exists(self, flow_key: str) -> bool:
+        with self._connect() as conn:
+            row = conn.execute(
+                self._sql("SELECT 1 FROM flow_packs WHERE flow_key = ? LIMIT 1"),
+                self._params(flow_key.strip()),
+            ).fetchone()
+        return row is not None
+
+    def _version_exists(self, *, flow_key: str, version: int, jurisdiction: str) -> bool:
+        with self._connect() as conn:
+            row = conn.execute(
+                self._sql(
+                    "SELECT 1 FROM flow_packs WHERE flow_key = ? AND version = ? AND jurisdiction = ? LIMIT 1"
+                ),
+                self._params(flow_key.strip(), version, jurisdiction.strip().upper()),
+            ).fetchone()
+        return row is not None
+
+    def _next_version(self, flow_key: str, *, jurisdiction: str | None = None) -> int:
+        clauses = ["flow_key = ?"]
+        params: list[object] = [flow_key.strip()]
+        if jurisdiction:
+            clauses.append("jurisdiction = ?")
+            params.append(jurisdiction.strip().upper())
+        where_sql = " AND ".join(clauses)
+        with self._connect() as conn:
+            row = conn.execute(
+                self._sql(f"SELECT COALESCE(MAX(version), 0) AS max_version FROM flow_packs WHERE {where_sql}"),
+                self._params(*params),
+            ).fetchone()
+        max_version = int(row["max_version"]) if row is not None else 0
+        return max_version + 1
+
+    def _latest(self, flow_key: str, *, jurisdiction: str | None = None) -> FlowPackResponse | None:
+        clauses = ["flow_key = ?"]
+        params: list[object] = [flow_key.strip()]
+        if jurisdiction:
+            clauses.append("jurisdiction = ?")
+            params.append(jurisdiction.strip().upper())
+        where_sql = " AND ".join(clauses)
+        with self._connect() as conn:
+            row = conn.execute(
+                self._sql(f"SELECT * FROM flow_packs WHERE {where_sql} ORDER BY version DESC LIMIT 1"),
+                self._params(*params),
+            ).fetchone()
+        return self._row_to_response(_row_to_mapping(row)) if row is not None else None
+
+    def _migrate_legacy_uniqueness(self, conn: Any) -> None:
+        if self._is_postgres:
+            conn.execute(
+                """
+                DO $$
+                BEGIN
+                    IF EXISTS (
+                        SELECT 1
+                        FROM pg_constraint
+                        WHERE conname = 'flow_packs_flow_key_version_key'
+                    ) THEN
+                        ALTER TABLE flow_packs DROP CONSTRAINT flow_packs_flow_key_version_key;
+                    END IF;
+                END
+                $$;
+                """
+            )
+            conn.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_flow_packs_jurisdiction_flow_key_version_unique
+                ON flow_packs (jurisdiction, flow_key, version)
+                """
+            )
+            return
+
+        index_rows = conn.execute("PRAGMA index_list(flow_packs)").fetchall()
+        for row in index_rows:
+            if not int(row["unique"]):
+                continue
+            index_name = str(row["name"])
+            columns = conn.execute(f"PRAGMA index_info({index_name})").fetchall()
+            column_names = [str(item["name"]) for item in columns]
+            if column_names == ["flow_key", "version"]:
+                self._rebuild_sqlite_table_with_country_unique(conn)
+                break
+
+    def _rebuild_sqlite_table_with_country_unique(self, conn: Any) -> None:
+        conn.execute("ALTER TABLE flow_packs RENAME TO flow_packs_legacy")
+        conn.executescript(_load_schema_sql())
+        conn.execute(
+            """
+            INSERT INTO flow_packs (
+                flow_id, flow_key, version, jurisdiction, domain, title, description,
+                definition_json, is_enabled, is_deleted, created_at, updated_at, deleted_at
+            )
+            SELECT
+                flow_id, flow_key, version, jurisdiction, domain, title, description,
+                definition_json, is_enabled, is_deleted, created_at, updated_at, deleted_at
+            FROM flow_packs_legacy
+            """
+        )
+        conn.execute("DROP TABLE flow_packs_legacy")
+
+    @staticmethod
+    def _row_to_response(row: dict[str, Any]) -> FlowPackResponse:
+        return FlowPackResponse(
+            flow_id=str(row["flow_id"]),
+            flow_key=str(row["flow_key"]),
+            version=int(row["version"]),
+            jurisdiction=str(row["jurisdiction"]),
+            domain=str(row["domain"]),
+            title=str(row["title"]),
+            description=str(row["description"]),
+            definition=json.loads(str(row["definition_json"])) if row["definition_json"] else {},
+            is_enabled=bool(row["is_enabled"]),
+            is_deleted=bool(row["is_deleted"]),
+            created_at=_from_iso(str(row["created_at"])),
+            updated_at=_from_iso(str(row["updated_at"])),
+            deleted_at=_from_iso(str(row["deleted_at"])) if row["deleted_at"] else None,
+        )
+
+    def _sql(self, query: str) -> str:
+        if not self._is_postgres:
+            return query
+        return query.replace("?", "%s")
+
+    @staticmethod
+    def _params(*values: object) -> tuple[object, ...]:
+        return tuple(values)
+
+
+def _load_schema_sql() -> str:
+    schema_path = Path(__file__).resolve().parents[4] / "databases" / "api" / "flow_packs_schema.sql"
+    return schema_path.read_text(encoding="utf-8")
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _from_iso(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _load_psycopg() -> Any:
+    try:
+        import psycopg
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on runtime extras.
+        raise RuntimeError("psycopg is required when DB_OPTION is postgres or azure") from exc
+    return psycopg
+
+
+def _row_to_mapping(row: Any) -> dict[str, Any]:
+    if isinstance(row, dict):
+        return row
+    if isinstance(row, sqlite3.Row):
+        return dict(row)
+    return dict(row)
+
+
+def _extract_flow_keywords(definition: dict[str, Any]) -> tuple[str, ...]:
+    intent = definition.get("intent")
+    if isinstance(intent, dict):
+        keywords = intent.get("keywords")
+        if isinstance(keywords, list):
+            normalized = [str(item).strip().lower() for item in keywords if str(item).strip()]
+            if normalized:
+                return tuple(normalized)
+    raw_keywords = definition.get("keywords")
+    if isinstance(raw_keywords, list):
+        normalized = [str(item).strip().lower() for item in raw_keywords if str(item).strip()]
+        if normalized:
+            return tuple(normalized)
+    return ()
+
+
+def _normalize_for_match(value: str) -> str:
+    lowered = value.lower()
+    decomposed = unicodedata.normalize("NFD", lowered)
+    no_diacritics = "".join(char for char in decomposed if unicodedata.category(char) != "Mn")
+    return " ".join(no_diacritics.split())
+
+
+def _token_roots(value: str) -> set[str]:
+    roots: set[str] = set()
+    for token in value.split():
+        cleaned = "".join(char for char in token if char.isalnum())
+        if not cleaned:
+            continue
+        roots.add(cleaned[:4])
+    return roots

--- a/api/aijuristiction-api/app/main.py
+++ b/api/aijuristiction-api/app/main.py
@@ -16,6 +16,7 @@ from fastapi.responses import JSONResponse
 from app.cases_api import router as cases_router
 from app.chat.result_metadata import get_law_knowledge_snapshot
 from app.chat.api import router as chat_router
+from app.flow_packs.api import router as flow_packs_router
 from app.laws_api import router as laws_router
 from app.logging_config import configure_logging
 from app.observability_api import router as observability_router
@@ -130,6 +131,7 @@ app.add_middleware(
     expose_headers=["Content-Disposition", "x-request-id", "x-correlation-id"],
 )
 app.include_router(chat_router)
+app.include_router(flow_packs_router)
 app.include_router(laws_router)
 app.include_router(users_router)
 app.include_router(cases_router)

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260363"
+version = "1.0.260366"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_flow_pack_matching_logging.py
+++ b/api/aijuristiction-api/tests/test_flow_pack_matching_logging.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+import tempfile
+from uuid import uuid4
+
+import pytest
+
+from app.chat.api import _warn_if_flow_pack_missing
+from app.chat.models import Session
+from app.flow_packs.api import get_flow_pack_store
+
+
+@pytest.fixture(autouse=True)
+def isolated_flow_pack_store() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        db_path = Path(tmp_dir) / "flow_packs.sqlite3"
+        os.environ["API_FLOW_PACKS_SQLITE_PATH"] = str(db_path)
+        get_flow_pack_store.cache_clear()
+        yield
+        get_flow_pack_store.cache_clear()
+        os.environ.pop("API_FLOW_PACKS_SQLITE_PATH", None)
+
+
+def test_warn_if_flow_pack_missing_logs_warning(caplog) -> None:
+    caplog.set_level(logging.WARNING)
+    session = Session(country="SK", discussion_type="advice", language="SK")
+
+    _warn_if_flow_pack_missing(
+        session_id=uuid4(),
+        session=session,
+        request_text="uplne neexistujuci typ pravneho procesu bez mapovania",
+    )
+
+    assert any("No flow-pack matched user request" in message for message in caplog.messages)
+
+
+def test_warn_if_flow_pack_missing_no_warning_for_known_intent(caplog) -> None:
+    caplog.set_level(logging.WARNING)
+    session = Session(country="SK", discussion_type="advice", language="SK")
+
+    _warn_if_flow_pack_missing(
+        session_id=uuid4(),
+        session=session,
+        request_text="Potrebujem pripravit kupnu zmluvu na auto",
+    )
+
+    assert not any("No flow-pack matched user request" in message for message in caplog.messages)

--- a/api/aijuristiction-api/tests/test_flow_packs_api.py
+++ b/api/aijuristiction-api/tests/test_flow_packs_api.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import tempfile
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.flow_packs.api import get_flow_pack_store
+from app.main import app
+
+client = TestClient(app)
+AUTH_HEADERS = {"x-api-key": "aijuris"}
+
+
+@pytest.fixture(autouse=True)
+def isolated_flow_pack_store() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        db_path = Path(tmp_dir) / "flow_packs.sqlite3"
+        os.environ["API_FLOW_PACKS_SQLITE_PATH"] = str(db_path)
+        get_flow_pack_store.cache_clear()
+        yield
+        get_flow_pack_store.cache_clear()
+        os.environ.pop("API_FLOW_PACKS_SQLITE_PATH", None)
+
+
+def test_list_default_flow_packs() -> None:
+    response = client.get("/v1/flow-packs", headers=AUTH_HEADERS)
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"]
+    flow_keys = {item["flow_key"] for item in payload["items"]}
+    assert "sk.contract.sale_purchase" in flow_keys
+    assert "sk.civil.power_of_attorney" in flow_keys
+    assert "cz.contract.sale_purchase" in flow_keys
+
+
+def test_create_update_enable_disable_soft_delete_and_version() -> None:
+    flow_key = f"sk.civil.notice_template.{uuid4().hex[:8]}"
+    create_response = client.post(
+        "/v1/flow-packs",
+        headers=AUTH_HEADERS,
+        json={
+            "flow_key": flow_key,
+            "jurisdiction": "SK",
+            "domain": "civil",
+            "title": "Predžalobná výzva",
+            "description": "Flow pre predzalobnu vyzvu",
+            "definition": {"required_facts": ["counterparty", "claim_summary"]},
+            "is_enabled": True,
+        },
+    )
+    assert create_response.status_code == 201
+    created = create_response.json()
+    assert created["version"] == 1
+
+    update_response = client.patch(
+        f"/v1/flow-packs/{flow_key}/versions/1",
+        headers=AUTH_HEADERS,
+        json={"title": "Predžalobná výzva - aktualizovaná"},
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["title"] == "Predžalobná výzva - aktualizovaná"
+
+    disable_response = client.post(
+        f"/v1/flow-packs/{flow_key}/versions/1/disable",
+        headers=AUTH_HEADERS,
+    )
+    assert disable_response.status_code == 200
+    assert disable_response.json()["is_enabled"] is False
+
+    enable_response = client.post(
+        f"/v1/flow-packs/{flow_key}/versions/1/enable",
+        headers=AUTH_HEADERS,
+    )
+    assert enable_response.status_code == 200
+    assert enable_response.json()["is_enabled"] is True
+
+    create_version_response = client.post(
+        f"/v1/flow-packs/{flow_key}/versions",
+        headers=AUTH_HEADERS,
+        json={
+            "description": "Flow pre predzalobnu vyzvu - verzia 2",
+            "definition": {"required_facts": ["counterparty", "claim_summary", "deadline"]},
+            "is_enabled": False,
+        },
+    )
+    assert create_version_response.status_code == 201
+    created_version = create_version_response.json()
+    assert created_version["version"] == 2
+    assert created_version["is_enabled"] is False
+
+    delete_response = client.delete(
+        f"/v1/flow-packs/{flow_key}/versions/1",
+        headers=AUTH_HEADERS,
+    )
+    assert delete_response.status_code == 200
+    deleted = delete_response.json()
+    assert deleted["is_deleted"] is True
+    assert deleted["is_enabled"] is False
+
+    list_versions_response = client.get(
+        f"/v1/flow-packs/{flow_key}/versions",
+        headers=AUTH_HEADERS,
+    )
+    assert list_versions_response.status_code == 200
+    versions = list_versions_response.json()["versions"]
+    assert [item["version"] for item in versions] == [2, 1]
+
+
+def test_same_flow_key_can_exist_in_multiple_jurisdictions() -> None:
+    common_key = f"contract.sale_purchase.{uuid4().hex[:6]}"
+    for jurisdiction in ("SK", "CZ"):
+        response = client.post(
+            "/v1/flow-packs",
+            headers=AUTH_HEADERS,
+            json={
+                "flow_key": common_key,
+                "jurisdiction": jurisdiction,
+                "domain": "civil",
+                "title": f"Kupna zmluva {jurisdiction}",
+                "description": f"Flow for {jurisdiction}",
+                "definition": {"required_facts": ["seller_identification", "buyer_identification"]},
+                "is_enabled": True,
+            },
+        )
+        assert response.status_code == 201
+        assert response.json()["version"] == 1
+        assert response.json()["jurisdiction"] == jurisdiction
+
+    ambiguous = client.get(f"/v1/flow-packs/{common_key}/versions/1", headers=AUTH_HEADERS)
+    assert ambiguous.status_code == 400
+
+    resolved = client.get(
+        f"/v1/flow-packs/{common_key}/versions/1",
+        params={"jurisdiction": "CZ"},
+        headers=AUTH_HEADERS,
+    )
+    assert resolved.status_code == 200
+    assert resolved.json()["jurisdiction"] == "CZ"

--- a/databases/api/flow_packs_schema.sql
+++ b/databases/api/flow_packs_schema.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS flow_packs (
+    flow_id TEXT PRIMARY KEY,
+    flow_key TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    jurisdiction TEXT NOT NULL,
+    domain TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT NOT NULL,
+    definition_json TEXT NOT NULL,
+    is_enabled INTEGER NOT NULL DEFAULT 1,
+    is_deleted INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    deleted_at TEXT NULL,
+    UNIQUE(jurisdiction, flow_key, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_flow_packs_key ON flow_packs(flow_key);
+CREATE INDEX IF NOT EXISTS idx_flow_packs_jurisdiction ON flow_packs(jurisdiction);
+CREATE INDEX IF NOT EXISTS idx_flow_packs_enabled ON flow_packs(is_enabled);
+CREATE INDEX IF NOT EXISTS idx_flow_packs_deleted ON flow_packs(is_deleted);

--- a/docs/FLOW_PACKS_API.md
+++ b/docs/FLOW_PACKS_API.md
@@ -1,0 +1,88 @@
+# Flow Packs API (Slovak legal process packs)
+
+This API adds flow-pack lifecycle management for Slovak legal processes.
+
+## Purpose
+
+Flow packs provide configurable process metadata used by a future process router:
+
+- intake requirements (`required_facts`)
+- required outputs/documents
+- proactive recommendations
+- escalation guidance
+- enabled/disabled runtime state
+- immutable version history
+
+Default seeded Slovak packs include:
+
+- `sk.contract.sale_purchase`
+- `sk.company.registry_change`
+- `sk.civil.power_of_attorney`
+- `sk.criminal.criminal_complaint`
+- `sk.notary.notarial_process`
+- `sk.support.person_company_screening`
+
+## Storage
+
+Runtime data uses SQLite under repository runtime storage:
+
+- default: `runs/storage/api/sqlite/flow_packs.sqlite3`
+- override env: `API_FLOW_PACKS_SQLITE_PATH`
+- when `DB_OPTION=postgres|azure`, flow packs use `DB_CLOUD` PostgreSQL connection (same API DB backend selection rules)
+
+SQL asset for schema:
+
+- `databases/api/flow_packs_schema.sql`
+- country separation is modeled in the same `flow_packs` table via `jurisdiction` (no separate table per country)
+
+## Endpoints
+
+All endpoints require `x-api-key`.
+
+- `GET /v1/flow-packs?include_deleted=false`
+  - list flow packs (latest and historical versions, ordered by key/version)
+  - optional filter: `jurisdiction=SK|CZ|...`
+- `GET /v1/flow-packs/{flow_key}/versions?include_deleted=true`
+  - list versions for one flow key
+  - optional filter: `jurisdiction=SK|CZ|...`
+- `GET /v1/flow-packs/{flow_key}/versions/{version}`
+  - fetch a single version
+  - when the same `flow_key+version` exists for multiple countries, pass `jurisdiction`
+- `POST /v1/flow-packs`
+  - create a flow pack version (if `version` omitted, auto-increment for key)
+- `POST /v1/flow-packs/{flow_key}/versions`
+  - create next version derived from latest version
+  - optional query: `jurisdiction=SK|CZ|...` (recommended in multi-country setups)
+- `PATCH /v1/flow-packs/{flow_key}/versions/{version}`
+  - update metadata/definition for a version
+  - optional query: `jurisdiction=SK|CZ|...` (required if ambiguous)
+- `POST /v1/flow-packs/{flow_key}/versions/{version}/enable`
+- `POST /v1/flow-packs/{flow_key}/versions/{version}/disable`
+- `DELETE /v1/flow-packs/{flow_key}/versions/{version}`
+  - soft delete (also disables the version)
+  - optional query: `jurisdiction=SK|CZ|...` (required if ambiguous)
+
+## Soft delete and versioning behavior
+
+- `DELETE` marks `is_deleted=true`, sets `deleted_at`, and forces `is_enabled=false`.
+- version values are immutable and unique per `flow_key`.
+- uniqueness is country-scoped: `(jurisdiction, flow_key, version)`.
+- creating a new version never mutates prior versions.
+
+## Runtime warning on unmatched requests
+
+During chat reply processing, the API now attempts to match each user request against enabled flow packs
+for the session country. If no flow pack matches, the API logs a warning (`No flow-pack matched user request`)
+with session id, country, and a short request excerpt.
+
+## Minimal runnable example
+
+```bash
+python examples/flow_packs_minimal_demo.py
+```
+
+Repository default smoke demo remains available:
+
+```bash
+python examples/minimal_demo.py
+```

--- a/examples/flow_packs_minimal_demo.py
+++ b/examples/flow_packs_minimal_demo.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import sys
+
+# Ensure deterministic local demo database path under runs/storage/api/sqlite.
+repo_root = Path(__file__).resolve().parents[1]
+api_root = repo_root / "api" / "aijuristiction-api"
+src_root = repo_root / "src"
+if str(api_root) not in sys.path:
+    sys.path.insert(0, str(api_root))
+if str(src_root) not in sys.path:
+    sys.path.insert(0, str(src_root))
+demo_db = repo_root / "runs" / "storage" / "api" / "sqlite" / "flow_packs_demo.sqlite3"
+os.environ.setdefault("API_FLOW_PACKS_SQLITE_PATH", str(demo_db))
+
+from app.flow_packs.models import FlowPackCreateRequest, FlowPackCreateVersionRequest  # noqa: E402
+from app.flow_packs.store import FlowPackStore  # noqa: E402
+
+
+def main() -> None:
+    store = FlowPackStore.from_env()
+
+    packs = store.list(include_deleted=False)
+    print(f"Seeded flow packs: {len(packs)}")
+    print("First 3 flow keys:", [item.flow_key for item in packs[:3]])
+
+    created = store.create(
+        FlowPackCreateRequest(
+            flow_key="sk.civil.notice_template_demo",
+            jurisdiction="SK",
+            domain="civil",
+            title="Predžalobná výzva (demo)",
+            description="Demo flow pack for pre-litigation notice.",
+            definition={"required_facts": ["counterparty", "claim_summary"]},
+            is_enabled=True,
+        )
+    )
+    print("Created:", created.flow_key, "v", created.version)
+
+    v2 = store.create_version(
+        flow_key=created.flow_key,
+        payload=FlowPackCreateVersionRequest(
+            description="Demo flow pack for pre-litigation notice (v2).",
+            definition={"required_facts": ["counterparty", "claim_summary", "deadline"]},
+            is_enabled=False,
+        ),
+    )
+    print("Created version:", v2.flow_key, "v", v2.version, "enabled=", v2.is_enabled)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Introduce configurable "flow packs" to represent jurisdiction-specific legal process metadata and provide a runtime source of intents used by a process router. 
- Surface a runtime warning when user chat requests do not match any enabled flow-pack for the session country to help identify missing mappings.

### Description

- Add a new `app.flow_packs` package implementing the REST API (`api.py`), Pydantic models (`models.py`), and a storage layer (`store.py`) with SQLite and Postgres/Azure support and seeding of default packs (`default_packs.py`).
- Seeded default Slovak and Czech example packs and added a SQL schema file at `databases/api/flow_packs_schema.sql`, an example runner (`examples/flow_packs_minimal_demo.py`), and API docs (`docs/FLOW_PACKS_API.md`).
- Wire the flow-packs router into the main application (`app.main`) and call the flow-pack store from chat processing by adding `_warn_if_flow_pack_missing` to the chat flow to log when no match is found. 
- Added optional runtime override `API_FLOW_PACKS_SQLITE_PATH` in `.env.example` and bumped the package version in `pyproject.toml`.

### Testing

- Added API and unit tests: `api/aijuristiction-api/tests/test_flow_packs_api.py` and `api/aijuristiction-api/tests/test_flow_pack_matching_logging.py`.
- Ran the new tests with `pytest -q` and the new flow-pack tests passed.
- Verified the chat warning behavior via the logging test which asserts a warning is emitted when no pack matches and not emitted for a known intent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d688f134833280fcf154d4893842)