### PR TITLE
Persist per-session conversation history as case documents for chat memory

### DIFF
--- a/api/aijuristiction-api/app/chat/api.py
+++ b/api/aijuristiction-api/app/chat/api.py
@@ -111,6 +111,37 @@ def _persist_case_message_if_needed(*, session: Session, role: str, content: str
     store.add_case_message(case_id=case_id, role=role, content=content, agent_name=agent_name)
 
 
+def _persist_session_history_document_if_needed(*, session: Session, session_id: UUID) -> None:
+    case_id = (session.case_id or "").strip()
+    if not case_id:
+        return
+    messages = _repository.list_messages(session_id)
+    if not messages:
+        return
+    lines: list[str] = []
+    for message in messages:
+        role = message.role.value.upper()
+        content = message.content.strip()
+        if not content:
+            continue
+        line = f"{role}: {content}"
+        if message.agent_name:
+            line = f"{line} (agent={message.agent_name})"
+        lines.append(line)
+    if not lines:
+        return
+    transcript = "\n".join(lines)
+    store = _get_store()
+    add_session_history_document = getattr(store, "add_case_session_history_document", None)
+    if callable(add_session_history_document):
+        add_session_history_document(
+            case_id=case_id,
+            session_id=str(session_id),
+            content=transcript,
+            uploaded_by_user_id=str(session.user_id) if session.user_id else None,
+        )
+
+
 def _read_case_communication_content(*, store: ApiDatabaseStore, communication: Any) -> str:
     content = str(getattr(communication, "summary", ""))
     transcript_uri = getattr(communication, "transcript_uri", None)
@@ -187,7 +218,7 @@ def _load_case_documents_for_llm(
     processed_entries: list[tuple[str, str, str, str]] = []
     processed_names_by_doc_id: dict[str, str] = {}
     for document in list_case_documents(case_id=case_id):
-        if document.kind != 'uploaded':
+        if document.kind not in {'uploaded', 'session_history'}:
             continue
         if document.processing_status == 'processed' and document.doc_id in contents_by_doc_id:
             name, text, vector = contents_by_doc_id[document.doc_id]
@@ -644,6 +675,7 @@ def reply_to_session(session_id: UUID, payload: ReplyRequest) -> Message:
         session=session,
         content=content,
     )
+    _persist_session_history_document_if_needed(session=session, session_id=session_id)
     _repository.set_result(
         session_id,
         _build_direct_reply_result(
@@ -890,6 +922,7 @@ def stream_session(session_id: UUID, payload: StartSessionStreamRequest) -> Stre
                 ),
                 metadata=metadata,
             )
+            _persist_session_history_document_if_needed(session=session, session_id=session_id)
             _repository.set_result(session_id, session_result)
             event_queue.put(("result", session_result.model_dump(mode="json")))
             event_queue.put(("done", {"session_id": str(session_id)}))
@@ -967,6 +1000,7 @@ def _stream_read_user_session(
                     messages=current_messages,
                     lawyer_message=visible_lawyer_content,
                 )
+                _persist_session_history_document_if_needed(session=session, session_id=session_id)
                 _repository.set_result(session_id, session_result)
                 event_queue.put(("result", session_result.model_dump(mode="json")))
                 event_queue.put(("done", {"session_id": str(session_id), "status": "completed"}))
@@ -3596,4 +3630,3 @@ def _pdf_circle_ops(cx: float, cy: float, r: float) -> List[str]:
         f"{cx + k:.3f} {y0:.3f} {x1:.3f} {cy - k:.3f} {x1:.3f} {cy:.3f} c",
         "h",
     ]
-

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260368"
+version = "1.0.260369"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -2120,6 +2120,81 @@ def test_existing_case_history_falls_back_to_summary_when_transcript_missing(mon
     assert conversation[1].content == "New follow-up question"
 
 
+def test_reply_persists_session_history_document_to_case(monkeypatch) -> None:
+    from app.chat.repository import InMemoryChatRepository
+    import app.chat.api as chat_api
+
+    persisted_history: list[dict[str, str | None]] = []
+
+    class _FakeStore:
+        def list_case_communications(self, *, case_id: str, limit=None, offset: int = 0):
+            return []
+
+        def add_case_message(self, *, case_id: str, role: str, content: str, agent_name: str | None = None):
+            return "comm-id"
+
+        def add_case_session_history_document(
+            self,
+            *,
+            case_id: str,
+            session_id: str,
+            content: str,
+            uploaded_by_user_id: str | None = None,
+        ) -> str:
+            persisted_history.append(
+                {
+                    "case_id": case_id,
+                    "session_id": session_id,
+                    "content": content,
+                    "uploaded_by_user_id": uploaded_by_user_id,
+                }
+            )
+            return "doc-history"
+
+    class _FakeLawyer:
+        system_prompt = "fake-system"
+
+        def respond(self, *, conversation, documents, sources, system_prompt_override):
+            return SimpleNamespace(
+                content="Stored response for conversation memory.",
+                agent_name="LawyerSlovakia",
+            )
+
+    monkeypatch.setattr(chat_api, "_repository", InMemoryChatRepository())
+    monkeypatch.setattr(chat_api, "_get_store", lambda: _FakeStore())
+    monkeypatch.setattr(
+        "aijurisdictionagents.agents.create_lawyer_agent",
+        lambda llm, country: _FakeLawyer(),
+    )
+    monkeypatch.setattr("aijurisdictionagents.llm.get_llm_client", lambda: object())
+
+    session_response = client.post(
+        "/v1/chat/sessions",
+        json={
+            "country": "SK",
+            "discussion_type": "advice",
+            "language": "SK",
+            "case_id": "case-123",
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert session_response.status_code == 200
+    session_id = session_response.json()["id"]
+
+    reply_response = client.post(
+        f"/v1/chat/sessions/{session_id}/reply",
+        json={"content": "Please save this discussion for later reuse."},
+        headers=AUTH_HEADERS,
+    )
+    assert reply_response.status_code == 200
+    assert len(persisted_history) == 1
+    assert persisted_history[0]["case_id"] == "case-123"
+    assert persisted_history[0]["session_id"] == session_id
+    persisted_transcript = str(persisted_history[0]["content"])
+    assert "USER: Please save this discussion for later reuse. (agent=User)" in persisted_transcript
+    assert "ASSISTANT: Stored response for conversation memory. (agent=LawyerSlovakia)" in persisted_transcript
+
+
 def test_reply_endpoint_respects_session_language_sk() -> None:
     session_response = client.post(
         "/v1/chat/sessions",

--- a/docs/API_ARCHITECTURE_RFC.md
+++ b/docs/API_ARCHITECTURE_RFC.md
@@ -47,6 +47,9 @@ Accepted (initial implementation baseline)
 - Minimal rewrite risk.
 - Faster delivery of backend API with typing/tests.
 - Straightforward containerization for Azure Container Apps.
+- Conversation continuity across sessions: completed chat sessions are persisted as a
+  `session_history` case document (one document per chat session), then processed by
+  the document processor for retrieval in future sessions tied to the same case.
 
 ### Trade-offs
 - SSE is server-to-client only; client-to-server remains normal HTTP.

--- a/examples/conversation_memory_minimal_demo.py
+++ b/examples/conversation_memory_minimal_demo.py
@@ -1,0 +1,33 @@
+"""Minimal runnable demo of session transcript persistence formatting.
+
+Run:
+    python examples/conversation_memory_minimal_demo.py
+"""
+
+from __future__ import annotations
+
+
+def build_session_history_document(messages: list[dict[str, str]]) -> str:
+    lines: list[str] = []
+    for message in messages:
+        role = message["role"].strip().upper()
+        content = message["content"].strip()
+        agent_name = message.get("agent_name", "").strip()
+        line = f"{role}: {content}"
+        if agent_name:
+            line = f"{line} (agent={agent_name})"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    sample_messages = [
+        {"role": "user", "content": "Please review my rental contract.", "agent_name": "User"},
+        {
+            "role": "assistant",
+            "content": "Sure. Upload the document and I will extract key clauses.",
+            "agent_name": "LawyerSlovakia",
+        },
+        {"role": "user", "content": "I uploaded it.", "agent_name": "User"},
+    ]
+    print(build_session_history_document(sample_messages))

--- a/src/aijurisdictionagents/api_db/store.py
+++ b/src/aijurisdictionagents/api_db/store.py
@@ -906,6 +906,46 @@ class ApiDatabaseStore:
             uploaded_by_user_id=uploaded_by_user_id,
         )
 
+    def add_case_session_history_document(
+        self,
+        *,
+        case_id: str,
+        session_id: str,
+        content: str,
+        uploaded_by_user_id: str | None = None,
+    ) -> str:
+        filename = f"session-{session_id}.txt"
+        with self._connect() as conn:
+            existing = self._fetchone(
+                conn,
+                """
+                SELECT doc_id FROM case_documents
+                WHERE case_id = ? AND kind = 'session_history' AND original_filename = ?
+                LIMIT 1
+                """,
+                (case_id, filename),
+            )
+            if existing is not None:
+                return str(existing[0])
+            row = self._fetchone(
+                conn,
+                """
+                SELECT COALESCE(MAX(version), 0)
+                FROM case_documents
+                WHERE case_id = ? AND kind = 'session_history'
+                """,
+                (case_id,),
+            )
+        next_version = int(row[0]) + 1 if row else 1
+        return self.add_case_document(
+            case_id=case_id,
+            kind="session_history",
+            version=next_version,
+            original_filename=filename,
+            payload=content.encode("utf-8"),
+            uploaded_by_user_id=uploaded_by_user_id,
+        )
+
     def add_case_document(
         self,
         *,
@@ -1032,7 +1072,7 @@ class ApiDatabaseStore:
                 SELECT doc_id, case_id, kind, version, storage_uri, original_filename, uploaded_by_user_id,
                        processing_status, processing_error, processed_at, created_at
                 FROM case_documents
-                WHERE kind = 'uploaded' AND processing_status IN ('uploaded', 'failed')
+                WHERE kind IN ('uploaded', 'session_history') AND processing_status IN ('uploaded', 'failed')
                 ORDER BY created_at ASC
                 LIMIT ?
                 """,


### PR DESCRIPTION
### Motivation
- Enable conversation memory so all user and assistant messages from a chat session are persisted and can be reused as context for future sessions tied to the same case. 
- Ensure persisted session transcripts are discoverable by the document processor and LLM retrieval pipeline by storing them as case documents that can be vectorized.

### Description
- Added an idempotent store helper `add_case_session_history_document(case_id, session_id, content, ...)` to create a `session_history` case document (one file per session) in `src/aijurisdictionagents/api_db/store.py`.
- Included `session_history` documents in the document processing queue by changing `list_unprocessed_case_documents` to return `kind IN ('uploaded', 'session_history')` and updated LLM retrieval to include `session_history` in `_load_case_documents_for_llm` in `api/aijuristiction-api/app/chat/api.py`.
- Implemented `_persist_session_history_document_if_needed(session, session_id)` to format and persist a session transcript built from in-memory messages and invoked it after reply completion and when streaming sessions finish in `api/aijuristiction-api/app/chat/api.py`.
- Added regression test `test_reply_persists_session_history_document_to_case` to `api/aijuristiction-api/tests/test_chat.py`, a minimal runnable example `examples/conversation_memory_minimal_demo.py`, and documented the change in `docs/API_ARCHITECTURE_RFC.md`.
- Bumped the API package revision in `api/aijuristiction-api/pyproject.toml` following project versioning rules.

### Testing
- Ran the targeted pytest command `python -m pytest api/aijuristiction-api/tests/test_chat.py -k "existing_case_history or persists_session_history_document"` and the tests completed successfully (`3 passed, 62 deselected`).
- Executed the minimal demo `python examples/conversation_memory_minimal_demo.py` which produced the expected formatted transcript output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4810000708332a4fbf6a5f6470a04)