### PR TITLE
Add chat-simulator flow-pack coverage: seeds, tests, docs, and demo

### DIFF
--- a/api/aijuristiction-api/app/flow_packs/default_packs.py
+++ b/api/aijuristiction-api/app/flow_packs/default_packs.py
@@ -23,6 +23,12 @@ def build_default_slovak_flow_packs() -> list[dict[str, Any]]:
                     "payment_terms",
                 ],
                 "outputs": ["sale_purchase_agreement", "handover_protocol_template"],
+                "steps": [
+                    "collect_parties_and_subject",
+                    "validate_price_and_payment_terms",
+                    "generate_documents",
+                ],
+                "delivery": {"single_document": "sale_purchase_agreement", "multi_document_bundle": "zip"},
                 "proactive_recommendations": [
                     "Navrhni odovzdávací protokol.",
                     "Upozorni na zodpovednosť za vady.",
@@ -38,7 +44,16 @@ def build_default_slovak_flow_packs() -> list[dict[str, Any]]:
             "description": "Balík dokumentov pre časté zmeny v s.r.o. vrátane podania na ORSR.",
             "is_enabled": True,
             "definition": {
-                "intent": {"keywords": ["orsr", "obchodny register", "obchodný register", "zapis do orsr"]},
+                "intent": {
+                    "keywords": [
+                        "orsr",
+                        "obchodny register",
+                        "obchodný register",
+                        "zapis do orsr",
+                        "pridanie vlastnika firmy",
+                        "novy vlastnik firmy",
+                    ]
+                },
                 "required_facts": [
                     "company_name",
                     "company_identifier",
@@ -51,6 +66,111 @@ def build_default_slovak_flow_packs() -> list[dict[str, Any]]:
                     "updated_articles",
                     "registry_filing_package",
                 ],
+                "steps": [
+                    "collect_company_and_change_facts",
+                    "verify_company_in_register",
+                    "prepare_registry_documents",
+                ],
+                "delivery": {"single_document": None, "multi_document_bundle": "zip"},
+            },
+        },
+        {
+            "flow_key": "sk.company.owner_transfer",
+            "version": 1,
+            "jurisdiction": "SK",
+            "domain": "commercial",
+            "title": "Prevod obchodného podielu (nový vlastník firmy)",
+            "description": "Postup a dokumentácia pre pridanie/prevod nového vlastníka v s.r.o.",
+            "is_enabled": True,
+            "definition": {
+                "intent": {
+                    "keywords": [
+                        "novy vlastnik firmy",
+                        "dalsi vlastnik",
+                        "prevod obchodneho podielu",
+                        "pridanie noveho vlastnika",
+                    ]
+                },
+                "required_facts": [
+                    "company_name",
+                    "transferor_details",
+                    "transferee_details",
+                    "transfer_share_scope",
+                    "effective_date",
+                ],
+                "tools": ["obchodny_register_company_check"],
+                "outputs": [
+                    "share_transfer_agreement",
+                    "corporate_resolution",
+                    "registry_filing_package",
+                ],
+                "steps": [
+                    "collect_transfer_facts",
+                    "confirm_transferor_from_orsr",
+                    "generate_transfer_documents",
+                ],
+                "delivery": {"single_document": None, "multi_document_bundle": "zip"},
+            },
+        },
+        {
+            "flow_key": "sk.civil.lease_advisory",
+            "version": 1,
+            "jurisdiction": "SK",
+            "domain": "civil",
+            "title": "Prenájom bytu (poradenstvo a zmluva)",
+            "description": "Checklist pravidiel prenájmu + návrh nájomnej zmluvy.",
+            "is_enabled": True,
+            "definition": {
+                "intent": {
+                    "keywords": [
+                        "prenajom bytu",
+                        "najomna zmluva",
+                        "podnajomnik",
+                        "vypovedat zmluvu",
+                    ]
+                },
+                "required_facts": [
+                    "property_identification",
+                    "landlord_identification",
+                    "tenant_identification",
+                    "rent_terms",
+                ],
+                "outputs": ["lease_advisory_checklist", "lease_agreement_draft"],
+                "steps": [
+                    "collect_lease_context",
+                    "assess_termination_and_damage_risks",
+                    "generate_lease_documents",
+                ],
+                "delivery": {"single_document": None, "multi_document_bundle": "zip"},
+            },
+        },
+        {
+            "flow_key": "sk.probate.inheritance_proceeding",
+            "version": 1,
+            "jurisdiction": "SK",
+            "domain": "civil",
+            "title": "Dedičské konanie",
+            "description": "Príprava podkladov a kontrolný postup pre dedičské konanie.",
+            "is_enabled": True,
+            "definition": {
+                "intent": {
+                    "keywords": [
+                        "deditske konanie",
+                        "dedičské konanie",
+                        "dedicia",
+                    ]
+                },
+                "required_facts": [
+                    "decedent_identification",
+                    "heirs",
+                    "estate_assets",
+                ],
+                "outputs": ["inheritance_case_brief"],
+                "steps": [
+                    "collect_decedent_and_heir_data",
+                    "prepare_inheritance_case_summary",
+                ],
+                "delivery": {"single_document": "inheritance_case_brief", "multi_document_bundle": "zip"},
             },
         },
         {
@@ -122,10 +242,26 @@ def build_default_slovak_flow_packs() -> list[dict[str, Any]]:
             "description": "Pomocný proces pre zistenie verejne dostupných údajov o osobe alebo firme.",
             "is_enabled": True,
             "definition": {
-                "intent": {"keywords": ["overit osobu", "overit firmu", "screening", "preverenie osoby", "preverenie firmy"]},
+                "intent": {
+                    "keywords": [
+                        "overit osobu",
+                        "overit firmu",
+                        "screening",
+                        "preverenie osoby",
+                        "preverenie firmy",
+                        "vyhladaj informacie o firme",
+                        "vyhladaj informacie o osobe",
+                    ]
+                },
                 "required_facts": ["entity_type", "entity_reference"],
                 "outputs": ["screening_summary"],
                 "tools": ["obchodny_register_company_check", "entity_screening_agent"],
+                "steps": [
+                    "collect_target_entity",
+                    "run_screening_tools",
+                    "prepare_summary_document",
+                ],
+                "delivery": {"single_document": "screening_summary", "multi_document_bundle": "zip"},
             },
         },
         {

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260369"
+version = "1.0.260370"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_chat_simulator_flowpack_coverage.py
+++ b/api/aijuristiction-api/tests/test_chat_simulator_flowpack_coverage.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.flow_packs.store import FlowPackStore, FlowPackStoreConfig
+
+
+def _extract_instruction(testcase_path: Path) -> str:
+    raw = testcase_path.read_text(encoding="utf-8").strip()
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+    if not isinstance(parsed, dict):
+        return raw
+    return str(parsed.get("CaseDescription") or parsed.get("CaseDescripton") or "")
+
+
+def _build_store(tmp_path: Path) -> FlowPackStore:
+    return FlowPackStore(
+        FlowPackStoreConfig(
+            db_option="sqlite",
+            db_cloud="",
+            sqlite_path=tmp_path / "flow_packs.sqlite3",
+        )
+    )
+
+
+def test_each_chat_simulator_testcase_has_matching_flowpack(tmp_path: Path) -> None:
+    store = _build_store(tmp_path)
+    testcase_dir = Path(__file__).resolve().parents[2] / "chat-simulator-app" / "testcases"
+
+    missing: list[str] = []
+    for testcase_path in sorted(testcase_dir.glob("*.txt")):
+        instruction = _extract_instruction(testcase_path)
+        matched = store.find_best_match(request_text=instruction, country="SK")
+        if matched is None:
+            missing.append(testcase_path.name)
+
+    assert not missing, f"Missing flow pack match for: {', '.join(missing)}"
+
+
+def test_matched_flowpacks_include_steps_and_document_delivery_contract(tmp_path: Path) -> None:
+    store = _build_store(tmp_path)
+    testcase_dir = Path(__file__).resolve().parents[2] / "chat-simulator-app" / "testcases"
+
+    for testcase_path in sorted(testcase_dir.glob("*.txt")):
+        instruction = _extract_instruction(testcase_path)
+        matched = store.find_best_match(request_text=instruction, country="SK")
+        assert matched is not None, f"Expected a flow pack for {testcase_path.name}"
+
+        definition = matched.definition
+        steps = definition.get("steps")
+        outputs = definition.get("outputs")
+        delivery = definition.get("delivery")
+
+        assert isinstance(steps, list) and steps, f"Flow {matched.flow_key} must declare steps"
+        assert isinstance(outputs, list) and outputs, f"Flow {matched.flow_key} must declare outputs"
+        assert isinstance(delivery, dict), f"Flow {matched.flow_key} must declare delivery policy"
+
+        if len(outputs) > 1:
+            assert delivery.get("multi_document_bundle") == "zip", (
+                f"Flow {matched.flow_key} must produce zip bundle for multiple outputs"
+            )
+        else:
+            assert isinstance(delivery.get("single_document"), str) and delivery.get("single_document"), (
+                f"Flow {matched.flow_key} must produce one document for single-output flows"
+            )

--- a/databases/api/seeds/001_chat_simulator_flow_packs.sql
+++ b/databases/api/seeds/001_chat_simulator_flow_packs.sql
@@ -1,0 +1,101 @@
+-- Seed flow packs required by chat-simulator testcases.
+-- Idempotent: inserts only when (jurisdiction, flow_key, version) does not already exist.
+
+INSERT INTO flow_packs (
+    flow_id,
+    flow_key,
+    version,
+    jurisdiction,
+    domain,
+    title,
+    description,
+    definition_json,
+    is_enabled,
+    is_deleted,
+    created_at,
+    updated_at,
+    deleted_at
+)
+SELECT
+    'seed-sk-company-owner-transfer-v1',
+    'sk.company.owner_transfer',
+    1,
+    'SK',
+    'commercial',
+    'Prevod obchodného podielu (nový vlastník firmy)',
+    'Postup a dokumentácia pre pridanie/prevod nového vlastníka v s.r.o.',
+    '{"intent":{"keywords":["novy vlastnik firmy","dalsi vlastnik","prevod obchodneho podielu","pridanie noveho vlastnika"]},"required_facts":["company_name","transferor_details","transferee_details","transfer_share_scope","effective_date"],"outputs":["share_transfer_agreement","corporate_resolution","registry_filing_package"],"steps":["collect_transfer_facts","confirm_transferor_from_orsr","generate_transfer_documents"],"delivery":{"single_document":null,"multi_document_bundle":"zip"}}',
+    1,
+    0,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM flow_packs WHERE flow_key = 'sk.company.owner_transfer' AND version = 1 AND jurisdiction = 'SK'
+);
+
+INSERT INTO flow_packs (
+    flow_id,
+    flow_key,
+    version,
+    jurisdiction,
+    domain,
+    title,
+    description,
+    definition_json,
+    is_enabled,
+    is_deleted,
+    created_at,
+    updated_at,
+    deleted_at
+)
+SELECT
+    'seed-sk-civil-lease-advisory-v1',
+    'sk.civil.lease_advisory',
+    1,
+    'SK',
+    'civil',
+    'Prenájom bytu (poradenstvo a zmluva)',
+    'Checklist pravidiel prenájmu + návrh nájomnej zmluvy.',
+    '{"intent":{"keywords":["prenajom bytu","najomna zmluva","podnajomnik","vypovedat zmluvu"]},"required_facts":["property_identification","landlord_identification","tenant_identification","rent_terms"],"outputs":["lease_advisory_checklist","lease_agreement_draft"],"steps":["collect_lease_context","assess_termination_and_damage_risks","generate_lease_documents"],"delivery":{"single_document":null,"multi_document_bundle":"zip"}}',
+    1,
+    0,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM flow_packs WHERE flow_key = 'sk.civil.lease_advisory' AND version = 1 AND jurisdiction = 'SK'
+);
+
+INSERT INTO flow_packs (
+    flow_id,
+    flow_key,
+    version,
+    jurisdiction,
+    domain,
+    title,
+    description,
+    definition_json,
+    is_enabled,
+    is_deleted,
+    created_at,
+    updated_at,
+    deleted_at
+)
+SELECT
+    'seed-sk-probate-inheritance-v1',
+    'sk.probate.inheritance_proceeding',
+    1,
+    'SK',
+    'civil',
+    'Dedičské konanie',
+    'Príprava podkladov a kontrolný postup pre dedičské konanie.',
+    '{"intent":{"keywords":["deditske konanie","dedičské konanie","dedicia"]},"required_facts":["decedent_identification","heirs","estate_assets"],"outputs":["inheritance_case_brief"],"steps":["collect_decedent_and_heir_data","prepare_inheritance_case_summary"],"delivery":{"single_document":"inheritance_case_brief","multi_document_bundle":"zip"}}',
+    1,
+    0,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM flow_packs WHERE flow_key = 'sk.probate.inheritance_proceeding' AND version = 1 AND jurisdiction = 'SK'
+);

--- a/docs/FLOW_PACKS_API.md
+++ b/docs/FLOW_PACKS_API.md
@@ -17,6 +17,9 @@ Default seeded Slovak packs include:
 
 - `sk.contract.sale_purchase`
 - `sk.company.registry_change`
+- `sk.company.owner_transfer`
+- `sk.civil.lease_advisory`
+- `sk.probate.inheritance_proceeding`
 - `sk.civil.power_of_attorney`
 - `sk.criminal.criminal_complaint`
 - `sk.notary.notarial_process`
@@ -33,7 +36,9 @@ Runtime data uses SQLite under repository runtime storage:
 SQL asset for schema:
 
 - `databases/api/flow_packs_schema.sql`
+- chat-simulator seed additions: `databases/api/seeds/001_chat_simulator_flow_packs.sql`
 - country separation is modeled in the same `flow_packs` table via `jurisdiction` (no separate table per country)
+- seed SQL is idempotent (`WHERE NOT EXISTS`) so existing rows are not overridden and duplicates are not created.
 
 ## Endpoints
 
@@ -75,10 +80,21 @@ During chat reply processing, the API now attempts to match each user request ag
 for the session country. If no flow pack matches, the API logs a warning (`No flow-pack matched user request`)
 with session id, country, and a short request excerpt.
 
+For chat-simulator coverage, flow definitions now include:
+
+- `steps`: ordered process stages each testcase flow follows.
+- `delivery`: output packaging contract:
+  - one output -> `single_document`
+  - multiple outputs -> `multi_document_bundle = "zip"`
+
 ## Minimal runnable example
 
 ```bash
 python examples/flow_packs_minimal_demo.py
+```
+
+```bash
+python examples/chat_simulator_flowpack_coverage_demo.py
 ```
 
 Repository default smoke demo remains available:

--- a/examples/chat_simulator_flowpack_coverage_demo.py
+++ b/examples/chat_simulator_flowpack_coverage_demo.py
@@ -1,0 +1,51 @@
+"""Minimal runnable demo: verify chat-simulator testcases map to seeded flow packs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+repo_root = Path(__file__).resolve().parents[1]
+api_root = repo_root / "api" / "aijuristiction-api"
+src_root = repo_root / "src"
+if str(api_root) not in sys.path:
+    sys.path.insert(0, str(api_root))
+if str(src_root) not in sys.path:
+    sys.path.insert(0, str(src_root))
+
+from app.flow_packs.store import FlowPackStore, FlowPackStoreConfig  # noqa: E402
+
+
+def _extract_instruction(testcase_path: Path) -> str:
+    raw = testcase_path.read_text(encoding="utf-8").strip()
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+    if not isinstance(parsed, dict):
+        return raw
+    return str(parsed.get("CaseDescription") or parsed.get("CaseDescripton") or "")
+
+
+def main() -> None:
+    db_path = repo_root / "runs" / "storage" / "api" / "sqlite" / "chat_simulator_flowpacks_demo.sqlite3"
+    store = FlowPackStore(FlowPackStoreConfig(db_option="sqlite", db_cloud="", sqlite_path=db_path))
+
+    testcase_dir = repo_root / "api" / "chat-simulator-app" / "testcases"
+    missing: list[str] = []
+    for testcase_path in sorted(testcase_dir.glob("*.txt")):
+        matched = store.find_best_match(request_text=_extract_instruction(testcase_path), country="SK")
+        if matched is None:
+            missing.append(testcase_path.name)
+            continue
+        print(f"{testcase_path.name} -> {matched.flow_key} (v{matched.version})")
+
+    if missing:
+        raise SystemExit(f"Missing flow pack matches: {', '.join(missing)}")
+
+    print("All chat simulator testcases have matching flow packs.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Ensure every `api/chat-simulator-app/testcases/*.txt` maps to a configured flow pack so the chat simulator scenarios are covered by process metadata.
- Provide a clear delivery contract (single document vs ZIP bundle) and explicit `steps` metadata so orchestration/tests can verify end-to-end document creation behaviour.
- Make the additions safe for existing deployments by providing an idempotent seed that does not create duplicates or override existing rows.

### Description
- Added/expanded default Slovak flow-packs and intent keywords (including `sk.company.owner_transfer`, `sk.civil.lease_advisory`, and `sk.probate.inheritance_proceeding`) and appended `steps` and `delivery` metadata to packs in `api/aijuristiction-api/app/flow_packs/default_packs.py`.
- Added an idempotent SQL seed at `databases/api/seeds/001_chat_simulator_flow_packs.sql` that inserts missing flow-packs only when `(jurisdiction, flow_key, version)` does not already exist.
- Added unit tests at `api/aijuristiction-api/tests/test_chat_simulator_flowpack_coverage.py` that assert each chat-simulator testcase matches a flow pack and that matched definitions include `steps` and correct `delivery` contract for single vs multi-output flows.
- Added a minimal runnable validation script `examples/chat_simulator_flowpack_coverage_demo.py`, updated docs in `docs/FLOW_PACKS_API.md` to reference the seeds and delivery contract, and bumped the API revision in `api/aijuristiction-api/pyproject.toml`.

### Testing
- Ran `cd api/aijuristiction-api && pytest -q tests/test_flow_packs_api.py tests/test_chat_simulator_flowpack_coverage.py` and the test suite passed (all tests green).
- Ran `python examples/chat_simulator_flowpack_coverage_demo.py` which printed mappings for each testcase and exited successfully confirming coverage.
- Seed SQL is intentionally guarded with `WHERE NOT EXISTS` so running seeds is idempotent and does not overwrite existing rows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4cf65eee483328e5c497beb526b30)