### PR TITLE
Follow-up: Slovak PDF export header and Liberation font fallbacks

### DIFF
--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -495,9 +495,11 @@ python examples/law_citation_resolution_demo.py
 ```
 - When the laws database has no import timestamp yet, `knowledge_last_updated_at` falls back to the cached `MODEL_KNOWLEDGE_CUTOFF_DATE` value while `last_law_update_date` remains empty.
 - For Slovak and other Central European locales, the exporter uses a Unicode TrueType font when available so characters such as `á`, `č`, `ľ`, `ô`, and `ž` render correctly in the generated PDF.
+- For Slovakia (`country=SK` or language `sk-*`), document PDFs now include a Slovak legal-document profile header (`Jurisdikcia: Slovenská republika`, `Typ dokumentu: právny návrh`) to make exports closer to expected local legal formatting.
 
 Additional PDF font notes:
 - The API container installs `fonts-dejavu-core` and the exporter prefers `DejaVu Serif` on Linux, so Azure deployments do not fall back to Helvetica for Slovak or German PDFs.
+- If DejaVu is unavailable on Linux, the exporter now falls back to `Liberation Serif` / `Liberation Sans` before trying platform-default fonts.
 - On Windows, the exporter prefers `Times New Roman` and then `Arial` for Central European PDF exports.
 
 ## Version bump workflow

--- a/api/aijuristiction-api/app/chat/api.py
+++ b/api/aijuristiction-api/app/chat/api.py
@@ -63,6 +63,10 @@ _LINUX_DEJAVU_FONT_DIRS = (
     Path("/usr/share/fonts/truetype/dejavu"),
     Path("/usr/share/fonts/dejavu"),
 )
+_LINUX_LIBERATION_FONT_DIRS = (
+    Path("/usr/share/fonts/truetype/liberation"),
+    Path("/usr/share/fonts/truetype/liberation2"),
+)
 _REGISTERED_PDF_FONT_FAMILIES: set[str] = set()
 
 
@@ -1905,10 +1909,19 @@ def _build_simple_pdf(
     title_font_size = 14.0
     footer_font_size = 9.0
 
+    prefers_slovak_profile = _prefers_slovak_legal_pdf_profile(country=country, language=language)
     header_lines: list[str] = []
     if header_line:
         header_lines.append(header_line)
         header_lines.append("")
+    if prefers_slovak_profile:
+        header_lines.extend(
+            [
+                "Jurisdikcia: Slovenská republika",
+                "Typ dokumentu: právny návrh",
+                "",
+            ]
+        )
 
     title_block: list[str] = [title, "----------------"] if include_title_block else []
     prepared_lines = header_lines + title_block + _wrap_pdf_lines(lines)
@@ -3534,6 +3547,21 @@ def _resolve_pdf_fonts(*, country: str, language: str | None) -> tuple[str, str]
                     ),
                 ]
             )
+        for font_dir in _LINUX_LIBERATION_FONT_DIRS:
+            font_candidates.extend(
+                [
+                    (
+                        "AIJLiberationSerif",
+                        font_dir / "LiberationSerif-Regular.ttf",
+                        font_dir / "LiberationSerif-Bold.ttf",
+                    ),
+                    (
+                        "AIJLiberationSans",
+                        font_dir / "LiberationSans-Regular.ttf",
+                        font_dir / "LiberationSans-Bold.ttf",
+                    ),
+                ]
+            )
         font_candidates.extend(
             [
                 (
@@ -3557,6 +3585,12 @@ def _resolve_pdf_fonts(*, country: str, language: str | None) -> tuple[str, str]
             if family is not None:
                 return family
     return ("Helvetica", "Helvetica-Bold")
+
+
+def _prefers_slovak_legal_pdf_profile(*, country: str, language: str | None) -> bool:
+    normalized_country = (country or "").strip().upper()
+    normalized_language = (language or "").strip().lower()
+    return normalized_country == "SK" or normalized_language.startswith("sk")
 
 
 def _register_ttf_font_family(

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260370"
+version = "1.0.260371"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -1783,6 +1783,7 @@ def test_build_simple_pdf_preserves_slovak_and_german_characters() -> None:
     assert "ubom" in normalized_extracted or "lubom" in normalized_extracted
     assert "deutsch" in normalized_extracted
     assert "deutsch" in normalized_extracted and ("kundigung" in normalized_extracted or "kndigung" in normalized_extracted)
+    assert "jurisdikcia: slovensk" in normalized_extracted and "republika" in normalized_extracted
 
 def test_create_message_returns_404_for_unknown_session() -> None:
     response = client.post(

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -66,3 +66,9 @@ if __name__ == "__main__":
     if workflow_result.fact_conflicts:
         print(f"Confirmation question: {workflow_result.fact_conflicts[0].confirmation_question}")
     print(f"Validation issues: {[issue.message for issue in workflow_result.validation_issues]}")
+    print()
+    print("=== PDF export UX note ===")
+    print(
+        "For Slovakia-focused document exports, the API PDF builder now uses "
+        "a Slovak legal header profile and Central-European font preferences."
+    )


### PR DESCRIPTION
### Motivation
- Improve PDF exports for Slovak jurisdiction flows so generated documents look closer to local legal expectations and reliably render Slovak diacritics across environments.
- Provide a stronger font fallback chain on Linux to avoid falling back to non-Unicode fonts when DejaVu is missing.
- Surface a minimal Slovakia-specific document header in exported PDFs to make document purpose and jurisdiction explicit for downstream reviewers.

### Description
- Inject a Slovak legal-document header (`Jurisdikcia: Slovenská republika`, `Typ dokumentu: právny návrh`) into `_build_simple_pdf` when `country == "SK"` or `language` starts with `sk` by adding `_prefers_slovak_legal_pdf_profile` and prepending header lines.
- Add Liberation font search locations (`/usr/share/fonts/truetype/liberation*`) and include Liberation Serif/Sans as fallbacks in `_resolve_pdf_fonts` so the exporter tries DejaVu, then Liberation, then Windows fonts before defaulting to Helvetica.
- Add `_prefers_slovak_legal_pdf_profile` helper and keep existing TTF registration logic via `_register_ttf_font_family` unchanged.
- Update `api/aijuristiction-api/pyproject.toml` version revision to reflect API code changes, update `api` README to document the Slovakia header and Liberation fallback, and add a short note to `examples/minimal_demo.py` about the PDF UX change.
- Add/adjust a unit assertion in `api/aijuristiction-api/tests/test_chat.py` to validate the Slovak jurisdiction header appears in extracted PDF text.

### Testing
- Ran targeted pytest selection against `api/aijuristiction-api/tests/test_chat.py` for PDF/export-related checks and the targeted tests passed (`2 passed`, other tests deselected).
- Executed the minimal runnable demo `python examples/minimal_demo.py` as a smoke test and it completed successfully, producing the example run outputs and generated PDF artifacts (with existing PDF-parsing fallbacks exercised for simulated PDFs).
- All automated test runs listed above succeeded after updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d613bf3c833297743002c58ffe8a)