### PR TITLE
Fix document package exports and template previews

### DIFF
--- a/api/aijuristiction-api/app/chat/api.py
+++ b/api/aijuristiction-api/app/chat/api.py
@@ -1125,7 +1125,7 @@ def _is_explicit_document_request(normalized: str) -> bool:
         "law",
         "laws",
         "predzalob",
-        "predÅ¾alob",
+        "predžalob",
         "vzor",
         "dokument",
     )
@@ -1160,7 +1160,7 @@ def _is_explicit_document_request(normalized: str) -> bool:
 def _is_affirmative_reply(normalized: str) -> bool:
     affirmatives = (
         "ano",
-        "Ã¡no",
+        "áno",
         "yes",
         "sure",
         "ok",
@@ -1180,9 +1180,9 @@ def _assistant_requests_document_confirmation(content: str) -> bool:
         "do you want",
         "would you like",
         "chcete",
-        "mÃ¡m pripraviÅ¥",
+        "mám pripraviť",
         "mam pripravit",
-        "pripraviÅ¥",
+        "pripraviť",
         "pripravit",
     )
     return (
@@ -1212,7 +1212,7 @@ def _document_generation_progress_events(
     lowered_visible = visible_text.lower()
     if not _document_export_ready(messages) and not any(
         marker in lowered_visible
-        for marker in ("pripravil som", "pripravila som", "prepared", "ready", "hotove", "hotovÃ½")
+        for marker in ("pripravil som", "pripravila som", "prepared", "ready", "hotove", "hotový")
     ):
         return []
     return [
@@ -1271,6 +1271,8 @@ def _extract_document_titles_from_text(content: str) -> list[str]:
         line = raw_line.strip()
         if not line:
             continue
+        if line.startswith("[") and line.endswith("]"):
+            continue
         normalized = re.sub(r"^\d+\.\s*", "", line)
         normalized = normalized.strip("* ").strip()
         if ":" in normalized:
@@ -1290,6 +1292,11 @@ def _looks_like_document_title(value: str) -> bool:
     lowered = _canonicalize_document_text(value)
     document_prefixes = (
         "zmluva",
+        "inventarny zoznam",
+        "inventar",
+        "odovzdavaci protokol",
+        "preberaci protokol",
+        "potvrdenie",
         "zapisnica",
         "rozhodnutie",
         "aktualizacia",
@@ -1303,6 +1310,13 @@ def _looks_like_document_title(value: str) -> bool:
         "founding deed",
     )
     document_phrases = (
+        "inventarny zoznam",
+        "zoznam vybavenia",
+        "odovzdanie bytu",
+        "prevzatie bytu",
+        "potvrdenie o prevzati",
+        "protokol o odovzdani",
+        "protokol o prevzati",
         "spolocenska zmluva",
         "spolocenskej zmluvy",
         "zakladatelska listina",
@@ -1325,6 +1339,9 @@ def _looks_like_document_title(value: str) -> bool:
         "poznamka",
         "podklady",
         "prilohy",
+        "potvrdzuje",
+        "prenajima",
+        "prenajíma",
         "zmluvne strany",
         "predmet zmluvy",
         "doba najmu",
@@ -1341,6 +1358,13 @@ def _looks_like_document_title(value: str) -> bool:
         ("prevode", "podiel"),
         ("pisnica", "rozhodnut"),
         ("aktualiz", "zmluv"),
+        ("inventar", "zoznam"),
+        ("zoznam", "vybaven"),
+        ("potvrdenie", "prevzati"),
+        ("odovzd", "byt"),
+        ("prevzat", "byt"),
+        ("protokol", "odovzd"),
+        ("protokol", "prevzat"),
         ("spolocensk", "zmluv"),
         ("spoloensk", "zmluv"),
         ("zakladatelsk", "listin"),
@@ -1707,7 +1731,7 @@ def _document_export_ready(messages: list[Message]) -> bool:
         "draft is ready",
         "navrh zmluvy",
         "predzalobna vyzva",
-        "predÅ¾alobnÃ¡ vÃ½zva",
+        "predžalobná výzva",
         "legal summary",
         "pravne zhrnutie",
     )
@@ -1776,7 +1800,7 @@ def _looks_like_technical_visible_line(normalized_line: str) -> bool:
         "case_update_json",
     )
     technical_fragments = (
-        "json pre uchovanie prÃ­padu",
+        "json pre uchovanie prípadu",
         "json pre uchovanie pripadu",
         "json for case persistence",
         "json for storing the case",
@@ -1792,11 +1816,11 @@ def _looks_like_fake_download_intro(normalized_line: str) -> bool:
     if not normalized_line:
         return False
     markers = (
-        "mÃ´Å¾ete si ich stiahnuÅ¥ pomocou nasledujÃºcich odkazov",
+        "môžete si ich stiahnuť pomocou nasledujúcich odkazov",
         "mozete si ich stiahnut pomocou nasledujucich odkazov",
-        "mÃ´Å¾ete si ich stiahnuÅ¥ na nasledujÃºcich odkazoch",
+        "môžete si ich stiahnuť na nasledujúcich odkazoch",
         "mozete si ich stiahnut na nasledujucich odkazoch",
-        "nasledujÃºce odkazy na stiahnutie",
+        "nasledujúce odkazy na stiahnutie",
         "nasledujuce odkazy na stiahnutie",
         "download using the following links",
         "download them using the following links",
@@ -2687,6 +2711,13 @@ def _fallback_document_entries_for_export(
 
 def _fallback_document_entry_type(*, title: str, document_kind: str) -> str:
     lowered = _canonicalize_document_text(title)
+    if document_kind == "rental_agreement":
+        if "zmluv" in lowered and ("najom" in lowered or "najm" in lowered or "lease" in lowered):
+            return "contract"
+        if "inventar" in lowered or "zoznam vybaven" in lowered:
+            return "inventory"
+        if any(token in lowered for token in ("prevzati", "odovzdani", "preberaci", "odovzdavaci")):
+            return "handover_protocol"
     if document_kind == "share_transfer" or any(
         token in lowered for token in ("podiel", "rozhodnut", "spolocensk", "spoloensk", "zakladatels", "orsr")
     ):
@@ -2702,6 +2733,15 @@ def _fallback_document_entry_type(*, title: str, document_kind: str) -> str:
 
 
 def _fallback_document_entry_filename(title: str, *, document_kind: str, entry_type: str) -> str:
+    if document_kind == "rental_agreement":
+        known_filenames = {
+            "contract": "Najomna_zmluva.pdf",
+            "inventory": "Inventarny_zoznam.pdf",
+            "handover_protocol": "Protokol_o_odovzdani_a_prevzati_bytu.pdf",
+        }
+        known_filename = known_filenames.get(entry_type)
+        if known_filename is not None:
+            return known_filename
     if document_kind == "share_transfer" or entry_type in {"contract", "minutes", "articles", "registry_filing"}:
         known_filenames = {
             "contract": "Zmluva_o_prevode_podielu.pdf",
@@ -2775,7 +2815,7 @@ def _build_document_export_content(
     if country.strip().upper() == "SK" and document_kind == "share_transfer":
         from app.chat.country_services.slovakia import build_slovak_share_transfer_export_lines
 
-        title = f"GenerovanÃƒÂ½ Dokument {session_id}"
+        title = f"Generovaný dokument {session_id}"
         export_lines = build_slovak_share_transfer_export_lines(
             messages=messages,
             normalize_document_lines=_normalize_document_lines,
@@ -2790,7 +2830,7 @@ def _build_document_export_content(
             )
 
     if (language or "").strip().lower().startswith("sk"):
-        title = f"GenerovanÃ½ Dokument {session_id}"
+        title = f"Generovaný dokument {session_id}"
         if document_kind == "rental_agreement":
             lines = _build_standard_slovak_agreement_lines(facts)
             return title, _append_document_law_citations(lines=lines, citations=law_citation_lines, language=language)
@@ -2826,7 +2866,7 @@ def _append_document_law_citations(
     if not citations:
         return lines
     prefers_slovak = (language or "").strip().lower().startswith("sk")
-    heading = "PrÃ¡vne citÃ¡cie" if prefers_slovak else "Legal citations"
+    heading = "Právne citácie" if prefers_slovak else "Legal citations"
     return [*lines, "", heading, *citations]
 
 
@@ -2915,6 +2955,15 @@ def _build_document_asset_content(
     law_citation_lines: list[str],
     fallback_index: int,
 ) -> tuple[str, list[str]]:
+    if document_kind == "rental_agreement":
+        return _build_rental_document_asset_content(
+            entry=entry,
+            facts=facts,
+            country=country,
+            language=language,
+            law_citation_lines=law_citation_lines,
+            fallback_index=fallback_index,
+        )
     if document_kind == "share_transfer":
         return _build_share_transfer_document_asset_content(
             entry=entry,
@@ -2948,6 +2997,49 @@ def _document_asset_title(
     if prefers_slovak:
         return f"Dokument {fallback_index}"
     return f"Document {fallback_index}"
+
+
+def _build_rental_document_asset_content(
+    *,
+    entry: dict[str, Any],
+    facts: dict[str, str],
+    country: str,
+    language: str | None,
+    law_citation_lines: list[str],
+    fallback_index: int,
+) -> tuple[str, list[str]]:
+    prefers_slovak = country.strip().upper() == "SK" or (language or "").strip().lower().startswith("sk")
+    asset_kind = _classify_rental_document_asset(entry)
+    if prefers_slovak:
+        if asset_kind == "inventory":
+            title = "Inventárny zoznam"
+            lines = _build_slovak_rental_inventory_lines(facts)
+        elif asset_kind == "handover_protocol":
+            title = "Protokol o odovzdaní a prevzatí bytu"
+            lines = _build_slovak_rental_handover_lines(facts)
+        else:
+            title = "Nájomná zmluva"
+            lines = _build_standard_slovak_agreement_lines(facts)
+    else:
+        title = _document_asset_title(entry=entry, language=language, fallback_index=fallback_index)
+        lines = _build_standard_english_agreement_lines(facts)
+    return title, _append_document_law_citations(lines=lines, citations=law_citation_lines, language=language)
+
+
+def _classify_rental_document_asset(
+    entry: dict[str, Any]
+) -> Literal["agreement", "inventory", "handover_protocol"]:
+    raw_name = _canonicalize_document_text(
+        " ".join(str(entry.get(key) or "").strip() for key in ("filename", "path", "type"))
+    )
+    if "inventar" in raw_name or "zoznam vybaven" in raw_name or "inventory" in raw_name:
+        return "inventory"
+    if any(
+        token in raw_name
+        for token in ("prevzati", "odovzdani", "preberaci", "odovzdavaci", "handover", "takeover")
+    ):
+        return "handover_protocol"
+    return "agreement"
 
 
 def _build_share_transfer_document_asset_content(
@@ -3064,7 +3156,7 @@ def _extract_document_facts(
     source_lines: List[str],
     case_update: dict[str, Any] | None = None,
 ) -> dict[str, str]:
-    text = " ".join(source_lines)
+    text = _repair_common_mojibake(" ".join(source_lines))
     case = case_update.get("case", {}) if isinstance(case_update, dict) else {}
     next_discussion = case.get("next_discussion", {}) if isinstance(case, dict) else {}
 
@@ -3090,18 +3182,30 @@ def _extract_document_facts(
     najomca = _capture(r"najomca\s*([^,.;]+)", "Najomca [doplnit udaje]")
     if parties_line and "doplnit" in prenajimatel.lower():
         prenajimatel = parties_line
-    predmet = _capture(r"predmet najmu:\s*(.+?)(?:\s+\d+\)|$)", "Byt [adresa a identifikacia]")
-    doba = _capture(r"doba najmu:\s*(.+?)(?:\s+\d+\)|$)", "Na dobu urcitu 1 rok")
-    najomne = _capture(r"najomne:\s*(.+?)(?:\s+\d+\)|$)", "850 EUR mesacne, splatne do 5. dna v mesiaci")
-    advance = _capture(r"platba vopred:\s*(.+?)(?:\s+\d+\)|$)", "2 mesacne najomne vopred")
-    deposit = _capture(r"kaucia:\s*(.+?)(?:\s+\d+\)|$)", "1 mesacne najomne")
-    notice = _capture(r"(vypovedna lehota[^.]+)", "Vypovedna lehota 1 mesiac, dorucenie pisomne aj emailom")
+    predmet = _capture(
+        r"(?:predmet\s+n[áa]jmu|adresa\s+bytu|byt\s+na\s+adrese)\s*:?\s*(.+?)(?:\.|\s+\d+\)|$)",
+        "Byt [adresa a identifikácia]",
+    )
+    doba = _capture(
+        r"(?:doba\s+n[áa]jmu|zmluva\s+sa\s+uzatv[áa]ra\s+na\s+dobu)\s*:?\s*(.+?)(?:\.|\s+\d+\)|$)",
+        "Na dobu určitú 1 rok",
+    )
+    najomne = _capture(
+        r"(?:n[áa]jomn[ée]|v[ýy][šs]ka\s+n[áa]jmu|mesa[čc]n[ýy]\s+n[áa]jom)\s*(?:je\s+stanoven[ýy]\s+na|je|:)?\s*([0-9\s]+(?:[.,][0-9]{1,2})?\s*(?:eur|eu|€)(?:\s+mesa[čc]ne)?)",
+        "Nájomné [doplniť sumu], splatné do 5. dňa v mesiaci",
+    )
+    advance = _capture(r"platba vopred:\s*(.+?)(?:\s+\d+\)|$)", "2 mesačné nájomné vopred")
+    deposit = _capture(r"kaucia:\s*(.+?)(?:\s+\d+\)|$)", "1 mesačné nájomné")
+    notice = _capture(
+        r"((?:v[ýy]povedn[áa]\s+lehota|v[ýy]povednou\s+lehotou|vypovedou|v[ýy]pove[ďd]ou)[^.]+)",
+        "Výpovedná lehota 1 mesiac, doručenie písomne aj emailom",
+    )
 
     client_name = _case_text(("case", "parties", "client", "name"), "Klient")
     opponent_name = _case_text(("case", "parties", "opponent", "name"), "Protistrana")
     topic = _case_text(("case", "matter", "topic"), "pravny_problem")
-    facts_summary = _case_text(("case", "matter", "facts_summary"), "PrÃ¡vny problÃ©m podÄ¾a diskusie.")
-    client_goal = _case_text(("case", "matter", "client_goal"), "DosiahnuÅ¥ primeranÃ© prÃ¡vne rieÅ¡enie.")
+    facts_summary = _case_text(("case", "matter", "facts_summary"), "Právny problém podľa diskusie.")
+    client_goal = _case_text(("case", "matter", "client_goal"), "Dosiahnuť primerané právne riešenie.")
     scheduled_for = _case_text(("case", "next_discussion", "scheduled_for"), "")
     agenda_items = next_discussion.get("agenda", []) if isinstance(next_discussion, dict) else []
     agenda = ", ".join(str(item).strip() for item in agenda_items if str(item).strip())
@@ -3148,7 +3252,7 @@ def _extract_document_facts(
         "facts_summary": facts_summary,
         "client_goal": client_goal,
         "scheduled_for": scheduled_for,
-        "agenda": agenda or "DoplniÅ¥ ÄalÅ¡Ã­ postup podÄ¾a vÃ½voja komunikÃ¡cie.",
+        "agenda": agenda or "Doplniť ďalší postup podľa vývoja komunikácie.",
         "company_name": company_name,
         "company_seat": company_seat,
         "company_identifier": company_identifier,
@@ -3163,39 +3267,87 @@ def _extract_document_facts(
 
 def _build_standard_slovak_agreement_lines(facts: dict[str, str]) -> List[str]:
     return [
-        "NÃ¡jomnÃ¡ zmluva",
-        "uzatvorenÃ¡ podÄ¾a paragrafu 663 a nasl. ObÄianskeho zÃ¡konnÃ­ka",
+        "Nájomná zmluva",
+        "uzatvorená podľa § 663 a nasl. Občianskeho zákonníka",
         "",
-        "ÄŒl. I - ZmluvnÃ© strany",
-        f"PrenajÃ­mateÄ¾: {facts['prenajimatel']}",
-        f"NÃ¡jomca: {facts['najomca']}",
+        "Čl. I - Zmluvné strany",
+        f"Prenajímateľ: {facts['prenajimatel']}",
+        f"Nájomca: {facts['najomca']}",
         "",
-        "ÄŒl. II - Predmet nÃ¡jmu",
+        "Čl. II - Predmet nájmu",
         _with_period(facts["predmet"]),
         "",
-        "ÄŒl. III - Doba nÃ¡jmu",
+        "Čl. III - Doba nájmu",
         _with_period(facts["doba"]),
         "",
-        "ÄŒl. IV - NÃ¡jomnÃ© a platobnÃ© podmienky",
-        f"NÃ¡jomnÃ©: {_with_period(facts['najomne'])}",
+        "Čl. IV - Nájomné a platobné podmienky",
+        f"Nájomné: {_with_period(facts['najomne'])}",
         f"Platba vopred: {_with_period(facts['advance'])}",
         f"Kaucia: {_with_period(facts['deposit'])}",
         "",
-        "ÄŒl. V - PrÃ¡va a povinnosti zmluvnÃ½ch strÃ¡n",
-        "NÃ¡jomca je povinnÃ½ uÅ¾Ã­vaÅ¥ predmet nÃ¡jmu riadne, Å¡etrne a v sÃºlade so zmluvou.",
-        "PrenajÃ­mateÄ¾ je povinnÃ½ odovzdaÅ¥ predmet nÃ¡jmu spÃ´sobilÃ½ na dohodnutÃ© uÅ¾Ã­vanie.",
+        "Čl. V - Práva a povinnosti zmluvných strán",
+        "Nájomca je povinný užívať predmet nájmu riadne, šetrne a v súlade so zmluvou.",
+        "Prenajímateľ je povinný odovzdať predmet nájmu spôsobilý na dohodnuté užívanie.",
         "",
-        "ÄŒl. VI - SkonÄenie nÃ¡jmu",
+        "Čl. VI - Skončenie nájmu",
         _with_period(facts["notice"]),
         "",
-        "ÄŒl. VII - ZÃ¡vereÄnÃ© ustanovenia",
-        "Zmluva nadobÃºda platnosÅ¥ dÅˆom podpisu oboma zmluvnÃ½mi stranami.",
-        "Zmeny zmluvy je moÅ¾nÃ© vykonaÅ¥ len pÃ­somnÃ½m dodatkom.",
+        "Čl. VII - Záverečné ustanovenia",
+        "Zmluva nadobúda platnosť dňom podpisu oboma zmluvnými stranami.",
+        "Zmeny zmluvy je možné vykonať len písomným dodatkom.",
         "",
-        "V [mesto], dna [datum]",
+        "V [mesto], dňa [dátum]",
         "",
-        "Podpis prenajÃ­mateÄ¾a: ____________________________",
-        "Podpis nÃ¡jomcu: _________________________________",
+        "Podpis prenajímateľa: ____________________________",
+        "Podpis nájomcu: _________________________________",
+    ]
+
+
+def _build_slovak_rental_inventory_lines(facts: dict[str, str]) -> List[str]:
+    return [
+        "Inventárny zoznam bytu",
+        "",
+        f"Byt: {_with_period(facts['predmet'])}",
+        f"Prenajímateľ: {facts['prenajimatel']}",
+        f"Nájomca: {facts['najomca']}",
+        "",
+        "Vybavenie a stav pri odovzdaní:",
+        "1. Kuchyňa a spotrebiče: [doplniť stav a príslušenstvo].",
+        "2. Kúpeľňa a sanita: [doplniť stav].",
+        "3. Nábytok a zariadenie izieb: [doplniť položky].",
+        "4. Kľúče, čipy a ovládače: [doplniť počet].",
+        "5. Počiatočné stavy meračov: elektrina [ ], voda [ ], plyn [ ].",
+        "",
+        "Nájomca potvrdzuje, že inventárny zoznam zodpovedá skutočnému stavu bytu pri prevzatí.",
+        "",
+        "Podpis prenajímateľa: ____________________________",
+        "Podpis nájomcu: _________________________________",
+    ]
+
+
+def _build_slovak_rental_handover_lines(facts: dict[str, str]) -> List[str]:
+    return [
+        "Protokol o odovzdaní a prevzatí bytu",
+        "",
+        f"Predmet odovzdania: {_with_period(facts['predmet'])}",
+        f"Prenajímateľ: {facts['prenajimatel']}",
+        f"Nájomca: {facts['najomca']}",
+        "",
+        "Stav bytu pri odovzdaní:",
+        "Byt sa odovzdáva v stave spôsobilom na riadne užívanie, s výhradami uvedenými nižšie:",
+        "[doplniť vady, poškodenia alebo poznámky]",
+        "",
+        "Odovzdané položky:",
+        "1. Kľúče / čipy / ovládače: [doplniť].",
+        "2. Inventárny zoznam: tvorí prílohu tohto protokolu.",
+        "3. Fotodokumentácia stavu bytu: [áno/nie].",
+        "",
+        "Nájomca prevzatím potvrdzuje, že bol oboznámený so stavom bytu, vybavením a pravidlami užívania.",
+        "",
+        "V [mesto], dňa [dátum]",
+        "",
+        "Podpis prenajímateľa: ____________________________",
+        "Podpis nájomcu: _________________________________",
     ]
 
 
@@ -3610,27 +3762,27 @@ def _build_english_share_transfer_registry_filing_lines(facts: dict[str, str]) -
 
 def _build_generic_slovak_case_document_lines(facts: dict[str, str]) -> List[str]:
     return [
-        "PrÃ¡vne zhrnutie a nÃ¡vrh ÄalÅ¡ieho postupu",
+        "Právne zhrnutie a návrh ďalšieho postupu",
         "",
         f"Klient: {facts['client_name']}",
         f"Protistrana: {facts['opponent_name']}",
-        f"TÃ©ma: {facts['topic']}",
+        f"Téma: {facts['topic']}",
         "",
-        "SkutkovÃ½ stav:",
+        "Skutkový stav:",
         _with_period(facts["facts_summary"]),
         "",
-        "CieÄ¾ klienta:",
+        "Cieľ klienta:",
         _with_period(facts["client_goal"]),
         "",
-        "OdporÃºÄanÃ½ postup:",
-        "1. ZabezpeÄiÅ¥ a usporiadaÅ¥ vÅ¡etky relevantnÃ© listiny a komunikÃ¡ciu.",
-        "2. PÃ­somne vyzvaÅ¥ protistranu na dobrovoÄ¾nÃ© rieÅ¡enie.",
-        "3. VyhodnotiÅ¥ potrebu predÅ¾alobnej vÃ½zvy alebo nÃ¡vrhu na sÃºdnu ochranu.",
+        "Odporúčaný postup:",
+        "1. Zabezpečiť a usporiadať všetky relevantné listiny a komunikáciu.",
+        "2. Písomne vyzvať protistranu na dobrovoľné riešenie.",
+        "3. Vyhodnotiť potrebu predžalobnej výzvy alebo návrhu na súdnu ochranu.",
         "",
-        "ÄŽalÅ¡ia konzultÃ¡cia:",
+        "Ďalšia konzultácia:",
         _with_period(facts["agenda"]),
         "",
-        "Podpis klienta / zÃ¡stupcu: ____________________________",
+        "Podpis klienta / zástupcu: ____________________________",
     ]
 
 

--- a/api/aijuristiction-api/app/document_templates/__init__.py
+++ b/api/aijuristiction-api/app/document_templates/__init__.py
@@ -1,2 +1,2 @@
-from app.document_templates.api import router
+from app.document_templates.api import router as router
 

--- a/api/aijuristiction-api/app/document_templates/api.py
+++ b/api/aijuristiction-api/app/document_templates/api.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 from functools import lru_cache
+import re
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import Response
 
+from app.document_templates.catalog import render_template
 from app.document_templates.models import (
     DocumentTemplateCreateRequest,
+    DocumentTemplateDefinition,
     DocumentTemplateListResponse,
     DocumentTemplateMatchResponse,
     DocumentTemplateResponse,
@@ -63,6 +67,57 @@ def get_document_template(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     except DocumentTemplateAmbiguousError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.get("/{template_key}/preview/pdf")
+def preview_document_template_pdf(
+    template_key: str,
+    jurisdiction: str | None = Query(default=None),
+    store: DocumentTemplateStore = Depends(get_document_template_store),
+) -> Response:
+    try:
+        template = store.get(template_key=template_key, jurisdiction=jurisdiction)
+    except DocumentTemplateNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except DocumentTemplateAmbiguousError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    rendered = render_template(
+        template=template,
+        facts=_template_preview_facts(),
+        country=template.jurisdiction,
+        language=template.language,
+    )
+    lines = rendered.lines or _metadata_only_preview_lines(template)
+    if rendered.unresolved_fields:
+        lines.extend(
+            [
+                "",
+                "Nevyriešené polia náhľadu:",
+                *[f"- {field}" for field in rendered.unresolved_fields],
+            ]
+        )
+
+    # Import lazily so the template API can be tested standalone while still using
+    # the production chat PDF renderer for visual quality checks.
+    from app.chat.api import _build_simple_pdf
+
+    pdf_content = _build_simple_pdf(
+        title=rendered.title or template.title,
+        lines=lines,
+        country=template.jurisdiction,
+        language=template.language,
+        header_line=f"AI Jurisdicta Template Preview | Template: {template.template_key}",
+        footer_line=f"AIJ | Template preview | {template.template_key}",
+        draw_logo_mark=True,
+        include_title_block=True,
+    )
+    filename = _template_preview_filename(template)
+    return Response(
+        content=pdf_content,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 @router.post("", response_model=DocumentTemplateResponse, status_code=status.HTTP_201_CREATED)
@@ -126,4 +181,52 @@ def match_document_template(
         score=score,
         template=DocumentTemplateResponse.from_definition(matched) if matched is not None else None,
     )
+
+
+def _template_preview_facts() -> dict[str, str]:
+    return {
+        "prenajimatel": "Ján Novák, trvale bytom Hlavná 12, 058 01 Poprad",
+        "najomca": "Mária Kováčová, trvale bytom Dunajská 8, 811 08 Bratislava",
+        "predmet": "Byt č. 12 na adrese Ludvíka Svobodu 2953/50, Poprad",
+        "doba": "Na dobu určitú od 01.05.2026 do 30.04.2027",
+        "najomne": "600 EUR mesačne, splatné do 5. dňa príslušného mesiaca",
+        "deposit": "600 EUR",
+        "notice": "Výpovedná lehota 1 mesiac; pri podstatnom porušení zmluvy okamžité skončenie",
+        "client_name": "Ján Novák",
+        "opponent_name": "Mária Kováčová",
+        "topic": "nájom bytu",
+        "company_name": "ESolutions SK s.r.o.",
+        "company_identifier": "12345678",
+        "company_seat": "Pribinova 10, 811 09 Bratislava",
+        "transferor_name": "Peter Horváth, trvale bytom Kvetná 4, Žilina",
+        "transferee_name": "Jana Černá, trvale bytom Horská 7, Košice",
+        "transfer_share": "50 %",
+        "transfer_price": "5 000 EUR",
+        "estimated_timeline": "spravidla niekoľko pracovných dní až týždňov",
+    }
+
+
+def _metadata_only_preview_lines(template: DocumentTemplateDefinition) -> list[str]:
+    lines = [
+        template.title,
+        "",
+        "Táto šablóna zatiaľ nemá uložené telo dokumentu.",
+        "PDF náhľad zobrazuje metadáta šablóny, aby bolo možné otestovať typografiu a export.",
+        "",
+        f"Jurisdikcia: {template.jurisdiction}",
+        f"Jazyk: {template.language or '[neuvedené]'}",
+        f"Kategória: {template.category}",
+        f"Typ šablóny: {template.template_kind}",
+        f"Zdroj: {template.source_url}",
+    ]
+    if template.description:
+        lines.extend(["", "Popis:", template.description])
+    if template.placeholders:
+        lines.extend(["", "Očakávané polia:", *[f"- {field}" for field in template.placeholders]])
+    return lines
+
+
+def _template_preview_filename(template: DocumentTemplateDefinition) -> str:
+    stem = re.sub(r"[^A-Za-z0-9._-]+", "_", template.template_key).strip("._-")
+    return f"{stem or 'document_template'}-preview.pdf"
 

--- a/api/aijuristiction-api/app/document_templates/store.py
+++ b/api/aijuristiction-api/app/document_templates/store.py
@@ -228,7 +228,7 @@ class DocumentTemplateStore:
                 ),
             )
             conn.commit()
-        return self.get(template_key=template_key, jurisdiction=updated["jurisdiction"])
+        return self.get(template_key=template_key, jurisdiction=str(updated["jurisdiction"]))
 
     def soft_delete(self, *, template_key: str, jurisdiction: str | None = None) -> DocumentTemplateDefinition:
         current = self.get(template_key=template_key, jurisdiction=jurisdiction)

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260375"
+version = "1.0.260376"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260374"
+version = "1.0.260375"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260372"
+version = "1.0.260374"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -345,6 +345,88 @@ def test_fallback_document_entries_ignore_single_contract_section_headings() -> 
     ) == []
 
 
+def test_document_export_returns_zip_for_visible_slovak_rental_package() -> None:
+    from app.chat.models import Message, MessageRole, Session, SessionResult
+    from app.chat.repository import InMemoryChatRepository
+    import app.chat.api as chat_api
+
+    repository = InMemoryChatRepository()
+    original_repository = chat_api._repository
+    chat_api._repository = repository
+    try:
+        session = repository.create_session(Session(country="SK", discussion_type="advice", language="sk-SK"))
+        content = (
+            "Kompletný balík dokumentov je pripravený na export.\n\n"
+            "---\n\n"
+            "**Zmluva o nájme bytu**\n\n"
+            "Prenajímateľ prenajíma nájomcovi byt na adrese: Ludvíka Svobodu 2953/50, Poprad.\n\n"
+            "---\n\n"
+            "**Inventárny zoznam:**\n\n"
+            "[Zoznam vybavenia a stavu bytu]\n\n"
+            "---\n\n"
+            "**Potvrdenie o prevzatí bytu:**\n\n"
+            "Nájomca potvrdzuje prevzatie bytu v dohodnutom stave."
+        )
+        repository.add_message(
+            Message(
+                session_id=session.id,
+                role=MessageRole.ASSISTANT,
+                agent_name="LawyerSlovakia",
+                content=content,
+            )
+        )
+        repository.set_result(
+            session.id,
+            SessionResult(
+                final_recommendation=content,
+                judge_rationale="Direct lawyer reply prepared for session export.",
+                metadata={},
+            ),
+        )
+
+        response = client.get(
+            f"/v1/chat/sessions/{session.id}/export?format=pdf&kind=document",
+            headers=AUTH_HEADERS,
+        )
+    finally:
+        chat_api._repository = original_repository
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/zip")
+    with ZipFile(BytesIO(response.content)) as archive:
+        names = sorted(archive.namelist())
+        assert names == [
+            "Inventarny_zoznam.pdf",
+            "Najomna_zmluva.pdf",
+            "Protokol_o_odovzdani_a_prevzati_bytu.pdf",
+        ]
+        for name in names:
+            assert archive.read(name).startswith(b"%PDF")
+
+
+def test_slovak_rental_export_lines_do_not_contain_mojibake() -> None:
+    from app.chat.api import _build_standard_slovak_agreement_lines
+
+    facts = {
+        "prenajimatel": "Prenajímateľ [doplniť údaje]",
+        "najomca": "Nájomca [doplniť údaje]",
+        "predmet": "Byt na adrese Ludvíka Svobodu 2953/50, Poprad",
+        "doba": "Na dobu určitú 1 rok",
+        "najomne": "600 EUR mesačne",
+        "advance": "2 mesačné nájomné vopred",
+        "deposit": "1 mesačné nájomné",
+        "notice": "Výpovedná lehota 1 mesiac",
+    }
+
+    text = "\n".join(_build_standard_slovak_agreement_lines(facts))
+
+    assert "Nájomná zmluva" in text
+    assert "Čl. I - Zmluvné strany" in text
+    assert "Prenajímateľ" in text
+    assert "600 EUR mesačne" in text
+    assert not any(marker in text for marker in ("Ã", "Â", "Ä", "Å", "â"))
+
+
 def test_document_export_for_easement_case_is_not_lease_template() -> None:
     from app.chat.api import _build_document_export_content, _build_simple_pdf
     from app.chat.models import Message, MessageRole

--- a/api/aijuristiction-api/tests/test_document_templates.py
+++ b/api/aijuristiction-api/tests/test_document_templates.py
@@ -141,6 +141,15 @@ def test_document_template_api_crud_and_match_endpoints(tmp_path: Path) -> None:
     assert match_response.json()["matched"] is True
     assert match_response.json()["template"]["template_key"] == "sk.custom.loan_agreement"
 
+    preview_response = client.get(
+        "/v1/document-templates/sk.real_estate.lease_agreement/preview/pdf",
+        params={"jurisdiction": "SK"},
+    )
+    assert preview_response.status_code == 200
+    assert preview_response.headers["content-type"].startswith("application/pdf")
+    assert "sk.real_estate.lease_agreement-preview.pdf" in preview_response.headers["content-disposition"]
+    assert preview_response.content.startswith(b"%PDF")
+
     delete_response = client.delete("/v1/document-templates/sk.custom.loan_agreement?jurisdiction=SK")
     assert delete_response.status_code == 200
     assert delete_response.json()["is_deleted"] is True

--- a/api/chat-simulator-app/README.md
+++ b/api/chat-simulator-app/README.md
@@ -34,6 +34,7 @@ The simulator now supports:
 - loading the selected case history from `GET /v1/cases/{case_id}/history` so you can review the existing conversation before continuing
 - showing the selected case documents immediately after case selection, including document metadata/status from the API
 - previewing selected existing case documents inline in the simulator (`PDF` iframe preview for PDFs, text preview for text-based files, open/download fallback for binary files)
+- listing API document templates in the **Document Templates** panel and generating a preview PDF from each template through `GET /v1/document-templates/{template_key}/preview/pdf`
 - deleting all persisted cases for the active simulator user with one button when the API reaches the active-case limit (`Maximum number of cases reached (5)`)
   - this action now runs through the internal simulator backend, so it does not depend on browser-side cross-origin delete requests
 - inspecting persisted document debug data from the API, including stored vectors, chunk counts, and the exact prompt chunks selected for the current query

--- a/api/chat-simulator-app/app/main.py
+++ b/api/chat-simulator-app/app/main.py
@@ -21,7 +21,7 @@ SIMULATOR_PACKAGE = "chat-simulator-app"
 
 app = FastAPI(
     title="AI Juristiction Chat Simulator App",
-    version="0.1.21",
+    version="0.1.22",
     description="Standalone chat simulator application for validating core chat APIs.",
 )
 

--- a/api/chat-simulator-app/pyproject.toml
+++ b/api/chat-simulator-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chat-simulator-app"
-version = "0.1.21"
+version = "0.1.22"
 description = "Standalone chat simulator UI for testing aijuristiction-api chat endpoints"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/chat-simulator-app/static/index.html
+++ b/api/chat-simulator-app/static/index.html
@@ -143,6 +143,16 @@
           </section>
 
           <section class="row">
+            <h2>Document Templates</h2>
+            <div class="template-toolbar">
+              <button id="refreshDocumentTemplates" class="secondary" type="button">Refresh Templates</button>
+            </div>
+            <div id="documentTemplatesList" class="document-templates-list">
+              <p class="empty-state">No document templates loaded yet.</p>
+            </div>
+          </section>
+
+          <section class="row">
             <label for="instruction">Case instruction</label>
             <textarea id="instruction" placeholder="Describe your case and request legal support..."></textarea>
           </section>

--- a/api/chat-simulator-app/static/simulator.css
+++ b/api/chat-simulator-app/static/simulator.css
@@ -198,6 +198,7 @@ pre {
 }
 
 .case-documents-list,
+.document-templates-list,
 .document-viewer {
   border: 1px solid #1e293b;
   border-radius: 12px;
@@ -208,6 +209,13 @@ pre {
 .case-documents-list {
   display: grid;
   gap: 0.75rem;
+}
+
+.document-templates-list {
+  display: grid;
+  gap: 0.75rem;
+  max-height: 380px;
+  overflow-y: auto;
 }
 
 .case-document-card {
@@ -222,7 +230,26 @@ pre {
   font-size: 0.98rem;
 }
 
+.document-template-card {
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 0.85rem;
+  background: #0b1222;
+}
+
+.document-template-card h3 {
+  margin: 0 0 0.45rem;
+  font-size: 0.98rem;
+}
+
 .case-document-meta {
+  margin: 0;
+  color: #cbd5e1;
+  white-space: pre-wrap;
+  line-height: 1.4;
+}
+
+.document-template-meta {
   margin: 0;
   color: #cbd5e1;
   white-space: pre-wrap;
@@ -233,6 +260,17 @@ pre {
   display: flex;
   gap: 0.6rem;
   margin-top: 0.75rem;
+}
+
+.template-toolbar {
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: 0.75rem;
+}
+
+.template-toolbar button {
+  width: auto;
+  min-width: 160px;
 }
 
 .case-document-actions button {
@@ -276,6 +314,7 @@ pre {
     flex-direction: column;
   }
 
+  .template-toolbar button,
   .case-document-actions button {
     width: 100%;
   }

--- a/api/chat-simulator-app/static/simulator.js
+++ b/api/chat-simulator-app/static/simulator.js
@@ -40,6 +40,8 @@ const clearSessionButton = document.getElementById("clearSession");
 const caseHistoryEl = document.getElementById("caseHistory");
 const caseDocumentsListEl = document.getElementById("caseDocumentsList");
 const documentViewerEl = document.getElementById("documentViewer");
+const documentTemplatesListEl = document.getElementById("documentTemplatesList");
+const refreshDocumentTemplatesButton = document.getElementById("refreshDocumentTemplates");
 const defaultsUrl = "/static/default-inputs.json";
 const defaultLanguageCode = "SK";
 const MESSAGE_PREVIEW_LIMIT = 256;
@@ -65,6 +67,7 @@ let preparedCases = [];
 let persistedCases = [];
 let currentCaseHistoryMessages = [];
 let currentCaseDocuments = [];
+let documentTemplates = [];
 let activeDocumentViewUrl = null;
 let processingStatusTimerId = null;
 let processingStatusBaseMessage = "";
@@ -264,6 +267,65 @@ function setDocumentViewerPlaceholder(message = "Select View on a case document 
   placeholder.className = "empty-state";
   placeholder.textContent = String(message || "").trim();
   documentViewerEl.appendChild(placeholder);
+}
+
+function setDocumentTemplatesPlaceholder(message = "No document templates loaded yet.") {
+  if (!documentTemplatesListEl) return;
+  documentTemplatesListEl.innerHTML = "";
+  const placeholder = document.createElement("p");
+  placeholder.className = "empty-state";
+  placeholder.textContent = String(message || "").trim();
+  documentTemplatesListEl.appendChild(placeholder);
+}
+
+function renderDocumentTemplates(templates) {
+  documentTemplates = Array.isArray(templates) ? templates : [];
+  if (!documentTemplatesListEl) return;
+  documentTemplatesListEl.innerHTML = "";
+  if (!documentTemplates.length) {
+    setDocumentTemplatesPlaceholder("No document templates returned by the API.");
+    return;
+  }
+
+  for (const template of documentTemplates) {
+    const card = document.createElement("article");
+    card.className = "document-template-card";
+
+    const title = document.createElement("h3");
+    title.textContent = String(template?.title || template?.template_key || "Template").trim();
+
+    const meta = document.createElement("p");
+    meta.className = "document-template-meta";
+    meta.textContent = [
+      `Key: ${String(template?.template_key || "").trim() || "n/a"}`,
+      `Kind: ${String(template?.template_kind || "").trim() || "n/a"}`,
+      `Category: ${String(template?.category || "").trim() || "n/a"}`,
+      `Jurisdiction: ${String(template?.jurisdiction || "").trim() || "n/a"}`,
+      `Language: ${String(template?.language || "").trim() || "n/a"}`,
+    ].join("\n");
+
+    const actions = document.createElement("div");
+    actions.className = "case-document-actions";
+
+    const generateButton = document.createElement("button");
+    generateButton.type = "button";
+    generateButton.className = "secondary";
+    generateButton.textContent = "Generate PDF";
+    generateButton.addEventListener("click", async () => {
+      try {
+        await generateTemplatePdf(template);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        appendStream(`error: ${message}`);
+        setWorkflowWarning(message);
+        finishProcessingStatus(`Error: ${message}`);
+      }
+    });
+
+    actions.append(generateButton);
+    card.append(title, meta, actions);
+    documentTemplatesListEl.appendChild(card);
+  }
 }
 
 function renderCaseDocuments(documents) {
@@ -964,6 +1026,43 @@ async function downloadCaseDocument(docId) {
   triggerBlobDownload({ blob, filename });
   appendStream(`case_document_downloaded: ${filename}`);
   finishProcessingStatus(`Document downloaded: ${filename}`);
+}
+
+async function refreshDocumentTemplates() {
+  const country = String(countryInput?.value || "SK").trim() || "SK";
+  const params = new URLSearchParams({
+    include_deleted: "false",
+    jurisdiction: country,
+  });
+  const response = await fetch(`${getBaseUrl()}/v1/document-templates?${params.toString()}`, {
+    headers: requestHeaders(false),
+  });
+  const body = await parseResponse(response);
+  renderDocumentTemplates(Array.isArray(body?.items) ? body.items : []);
+  appendStream(`document_templates_loaded: ${documentTemplates.length}`);
+}
+
+async function generateTemplatePdf(template) {
+  const templateKey = String(template?.template_key || "").trim();
+  if (!templateKey) {
+    throw new Error("Document template key is required.");
+  }
+  const jurisdiction = String(template?.jurisdiction || countryInput?.value || "SK").trim() || "SK";
+  const params = new URLSearchParams({ jurisdiction });
+  const url = `${getBaseUrl()}/v1/document-templates/${encodeURIComponent(templateKey)}/preview/pdf?${params.toString()}`;
+  const response = await fetch(url, {
+    headers: requestHeaders(false),
+  });
+  if (!response.ok) {
+    const body = await safeParseJson(response);
+    throw new Error(JSON.stringify(body));
+  }
+  const blob = await response.blob();
+  const filename = extractFilenameFromContentDisposition(response.headers.get("Content-Disposition"))
+    || `${templateKey.replace(/[^A-Za-z0-9._-]+/g, "_")}-preview.pdf`;
+  triggerBlobDownload({ blob, filename });
+  appendStream(`template_pdf_generated: ${filename}`);
+  finishProcessingStatus(`Template PDF generated: ${filename}`);
 }
 
 function updateCaseStatus(payload) {
@@ -1794,6 +1893,7 @@ bind("inspectCaseDocuments", inspectCaseDocuments);
 bind("refreshExistingCases", async () => {
   await refreshExistingCases({ preserveSelection: true });
 });
+bind("refreshDocumentTemplates", refreshDocumentTemplates);
 bind("deleteAllCases", deleteAllCases);
 bind("startStream", startStream);
 bind("refreshMessages", refreshMessages);
@@ -1844,11 +1944,19 @@ async function initializeSimulator() {
   userSimulationModeInput.value = "ReadUser";
   updateExistingCaseStatus();
   resetLoadedCaseData();
+  setDocumentTemplatesPlaceholder();
   renderWelcomeMessage();
   clearWorkflowWarning();
   finishProcessingStatus("Idle.");
   refreshReplyControls();
   refreshPersistedCaseControls();
+  try {
+    await refreshDocumentTemplates();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    setDocumentTemplatesPlaceholder("Document templates could not be loaded.");
+    appendStream(`document_templates_error: ${message}`);
+  }
 }
 
 if (preparedCaseInput) {

--- a/api/chat-simulator-app/tests/test_app.py
+++ b/api/chat-simulator-app/tests/test_app.py
@@ -20,16 +20,16 @@ def test_version() -> None:
     assert response.status_code == 200
     assert response.json() == {
         'service': 'chat-simulator-app',
-        'version': '0.1.21',
-        'simulator_version': '0.1.21',
+        'version': '0.1.22',
+        'simulator_version': '0.1.22',
     }
 
 
 def test_simulator_page_and_assets() -> None:
     page = client.get('/chat-simulator')
     assert page.status_code == 200
-    assert '/static/simulator.js?v=0.1.21' in page.text
-    assert '/static/simulator.css?v=0.1.21' in page.text
+    assert '/static/simulator.js?v=0.1.22' in page.text
+    assert '/static/simulator.css?v=0.1.22' in page.text
     assert 'Start Stream' in page.text
     assert 'Upload documents' in page.text
     assert 'Persisted Case Debug' in page.text
@@ -46,6 +46,9 @@ def test_simulator_page_and_assets() -> None:
     assert 'novalidate' in page.text
     assert 'id="preparedCase"' in page.text
     assert 'id="preparedCasesData"' in page.text
+    assert 'Document Templates' in page.text
+    assert 'id="refreshDocumentTemplates"' in page.text
+    assert 'id="documentTemplatesList"' in page.text
     assert 'sample_case_prenajom' in page.text
     assert 'sample_case_prenajom_contract' in page.text
     assert 'sample_case_vlastnik_fimy' in page.text
@@ -109,6 +112,13 @@ def test_simulator_page_and_assets() -> None:
     assert 'refreshPersistedCaseControls' in js.text
     assert '/internal/delete-user-cases' in js.text
     assert 'continue the session or ask for document status' in js.text
+    assert 'refreshDocumentTemplates' in js.text
+    assert 'generateTemplatePdf' in js.text
+    assert '/v1/document-templates' in js.text
+    assert '/preview/pdf' in js.text
+    assert 'Generate PDF' in js.text
+    assert 'template_pdf_generated' in js.text
+    assert 'document-template-card' in css.text
 
 
 def test_internal_delete_user_cases_route(monkeypatch) -> None:

--- a/docs/DOCUMENT_TEMPLATES_API.md
+++ b/docs/DOCUMENT_TEMPLATES_API.md
@@ -48,6 +48,7 @@ All endpoints require `x-api-key`.
 - `PATCH /v1/document-templates/{template_key}?jurisdiction=SK`
 - `DELETE /v1/document-templates/{template_key}?jurisdiction=SK`
 - `GET /v1/document-templates/match/search?request_text=...&country=SK&template_kind=rental_agreement`
+- `GET /v1/document-templates/{template_key}/preview/pdf?jurisdiction=SK`
 
 ## Match behavior
 
@@ -63,6 +64,33 @@ This is intended as the selection layer for future contract rendering:
 1. detect the client request intent
 2. find the best template candidate
 3. render a concrete draft by filling placeholders from extracted facts
+
+## Chat Export Behavior
+
+The chat document export endpoint (`GET /v1/chat/sessions/{session_id}/export?format=pdf&kind=document`)
+now recognizes visible Slovak rental-package sections such as:
+
+- `Zmluva o nájme bytu`
+- `Inventárny zoznam`
+- `Potvrdenie o prevzatí bytu` / odovzdávací protokol
+
+When at least two separate package documents are detected, the endpoint returns a ZIP archive instead of
+collapsing the package into one PDF. Slovak rental export text is generated with UTF-8 Slovak literals and the
+Central-European PDF font profile, so headings such as `Nájomná zmluva`, `Čl. I`, `prenajímateľ`, and
+`nájomca` render without mojibake.
+
+If a chat run only asks for a single rental contract, the endpoint still returns one PDF.
+
+## PDF Preview
+
+The template preview endpoint renders one template directly through the same PDF builder used by chat document
+exports. It fills known placeholders with realistic sample data, returns `application/pdf`, and uses a
+`Content-Disposition` filename ending in `-preview.pdf`.
+
+The chat simulator now includes a **Document Templates** panel. Use **Refresh Templates** to load templates from
+the selected API base URL and **Generate PDF** on any row to download that template preview. This is intended for
+quick visual checks of Slovak characters, typography, spacing, and final PDF quality before using a template in a
+real chat flow.
 
 ## Source download
 

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -70,5 +70,8 @@ if __name__ == "__main__":
     print("=== PDF export UX note ===")
     print(
         "For Slovakia-focused document exports, the API PDF builder now uses "
-        "a Slovak legal header profile and Central-European font preferences."
+        "a Slovak legal header profile and Central-European font preferences. "
+        "Rental packages with sections such as Nájomná zmluva, Inventárny zoznam, "
+        "and Protokol o odovzdaní a prevzatí bytu export as a ZIP package. "
+        "Document templates can also be previewed as PDFs from the chat simulator."
     )


### PR DESCRIPTION
## Summary
- fix Slovak rental package export detection so multi-document packages download as ZIPs
- repair Slovak rental PDF text and add rental inventory/handover PDF assets
- add document-template PDF preview endpoint and chat simulator template panel with Generate PDF action
- bump API to 1.0.260374 and chat simulator to 0.1.22

## Tests
- .\\conda\\python.exe -m pytest api\\aijuristiction-api\\tests\\test_document_templates.py
- .\\conda\\python.exe -m pytest api\\chat-simulator-app\\tests\\test_app.py
- .\\conda\\python.exe examples\\minimal_demo.py