### PR TITLE
Add Slovak address validation agent with registeradries mapping and consent memory

### DIFF
--- a/api/aijuristiction-api/app/chat/country_services/slovakia.py
+++ b/api/aijuristiction-api/app/chat/country_services/slovakia.py
@@ -42,6 +42,11 @@ def prepare_slovakia_direct_reply(
     if session.country.strip().upper() != "SK":
         return DirectReplyPreparation(supplemental_documents=[])
 
+    address_prompt_note = _build_slovak_address_validation_prompt_note(
+        current_content=current_content,
+        prior_messages=prior_messages,
+    )
+
     asks_company_registry_info = _looks_like_company_registry_information_question(current_content)
     looks_like_company_document = _looks_like_company_document_matter(
         current_content=current_content,
@@ -52,6 +57,8 @@ def prepare_slovakia_direct_reply(
         prior_messages=prior_messages,
     )
     if not asks_company_registry_info and not looks_like_company_document and not asks_share_transfer:
+        if address_prompt_note:
+            return DirectReplyPreparation(supplemental_documents=[], prompt_note=address_prompt_note)
         return DirectReplyPreparation(supplemental_documents=[])
 
     analysis_message = (
@@ -68,7 +75,7 @@ def prepare_slovakia_direct_reply(
 
     company_query = _extract_slovak_company_query(messages=messages, current_content=current_content)
     if not company_query:
-        return DirectReplyPreparation(supplemental_documents=[])
+        return DirectReplyPreparation(supplemental_documents=[], prompt_note=address_prompt_note)
 
     emit_processing_event(
         events=processing_events,
@@ -139,6 +146,7 @@ def prepare_slovakia_direct_reply(
             company_query=company_query,
             company_record=company_record,
         )
+        prompt_note = _merge_prompt_notes(prompt_note, address_prompt_note)
         return DirectReplyPreparation(
             supplemental_documents=supplemental_documents,
             prompt_note=prompt_note,
@@ -150,6 +158,7 @@ def prepare_slovakia_direct_reply(
             company_query=company_query,
             company_record=company_record,
         )
+        prompt_note = _merge_prompt_notes(prompt_note, address_prompt_note)
         return DirectReplyPreparation(
             supplemental_documents=supplemental_documents,
             prompt_note=prompt_note,
@@ -265,12 +274,123 @@ def prepare_slovakia_direct_reply(
         conflicts=conflicts,
         user_confirmed_document_generation=user_confirmed_document_generation,
     )
+    prompt_note = _merge_prompt_notes(prompt_note, address_prompt_note)
     return DirectReplyPreparation(
         supplemental_documents=supplemental_documents,
         prompt_note=prompt_note,
         processing_events=processing_events,
     )
 
+
+
+
+def _merge_prompt_notes(primary: str, secondary: str) -> str:
+    if primary and secondary:
+        return f"{primary}\n\n{secondary}"
+    return primary or secondary
+
+
+def _build_slovak_address_validation_prompt_note(*, current_content: str, prior_messages: list[Message]) -> str:
+    if not _looks_like_address_relevant_context(current_content=current_content, prior_messages=prior_messages):
+        return ""
+
+    preference = _resolve_address_validation_preference(prior_messages=prior_messages)
+    if preference == "yes":
+        return "\n".join(
+            [
+                "SLOVAK ADDRESS VALIDATION MODE:",
+                "- User already opted in to address validation for this case.",
+                "- When address text is present, run registeradries_address_validate and map fields: kraj, okres, city, street, house_number, psc.",
+                "- Reuse the remembered consent and do not ask for the same confirmation again unless the user changes preference.",
+            ]
+        )
+    if preference == "no":
+        return "\n".join(
+            [
+                "SLOVAK ADDRESS VALIDATION MODE:",
+                "- User declined address validation for this case.",
+                "- Do not run registeradries_address_validate unless the user explicitly changes their decision.",
+            ]
+        )
+
+    return "\n".join(
+        [
+            "SLOVAK ADDRESS VALIDATION MODE:",
+            "- This turn likely requires an address.",
+            "- Before using address validation tools, ask exactly one concise consent question whether the user wants address validation via registeradries.sk.",
+            "- After the user answers yes/no, remember that choice for the rest of this case.",
+        ]
+    )
+
+
+def _looks_like_address_relevant_context(*, current_content: str, prior_messages: list[Message]) -> bool:
+    combined = " ".join(current_content.lower().split())
+    address_tokens = (
+        "adresa",
+        "adresu",
+        "bydlisko",
+        "sidlo",
+        "sídlo",
+        "ulica",
+        "psc",
+        "psč",
+        "okres",
+        "kraj",
+        "mesto",
+        "obec",
+        "nehnutelnost",
+        "nehnuteľnosť",
+    )
+    if any(token in combined for token in address_tokens):
+        return True
+    if re.search(r"\b\d{3}\s?\d{2}\b", combined):
+        return True
+    for message in reversed(prior_messages[-8:]):
+        if message.role != MessageRole.ASSISTANT:
+            continue
+        lowered = message.content.lower()
+        if "adresa" in lowered and "?" in lowered:
+            return True
+    return False
+
+
+def _resolve_address_validation_preference(*, prior_messages: list[Message]) -> str | None:
+    for index in range(len(prior_messages) - 1, -1, -1):
+        user_message = prior_messages[index]
+        if user_message.role != MessageRole.USER:
+            continue
+        user_text = " ".join(user_message.content.lower().split())
+        if any(token in user_text for token in ("chcem overit adresu", "chcem validovat adresu", "overit adresu", "validovat adresu")):
+            return "yes"
+        if any(token in user_text for token in ("nechcem overit adresu", "nechcem validovat adresu", "neoverovat adresu")):
+            return "no"
+        if not _is_affirmative_or_negative_reply(user_text):
+            continue
+        previous_assistant = _nearest_previous_assistant(prior_messages=prior_messages, before_index=index)
+        if not previous_assistant:
+            continue
+        assistant_text = previous_assistant.lower()
+        if "over" not in assistant_text or "adres" not in assistant_text:
+            continue
+        return "yes" if _is_affirmative_short_reply(user_text) else "no"
+    return None
+
+
+def _is_affirmative_or_negative_reply(normalized_content: str) -> bool:
+    if _is_affirmative_short_reply(normalized_content):
+        return True
+    cleaned = re.sub(r"[^0-9a-záäčďéíĺľňóôŕšťúýž]+", " ", normalized_content.lower()).strip()
+    if not cleaned:
+        return False
+    return cleaned.split()[0] in {"nie", "no", "nein"}
+
+
+def _nearest_previous_assistant(*, prior_messages: list[Message], before_index: int) -> str:
+    for idx in range(before_index - 1, -1, -1):
+        message = prior_messages[idx]
+        if message.role == MessageRole.ASSISTANT:
+            return message.content
+    return ""
 
 def _looks_like_company_document_matter(*, current_content: str, prior_messages: list[Message]) -> bool:
     combined = " ".join(current_content.lower().split())

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260372"
+version = "1.0.260373"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -1319,6 +1319,45 @@ def test_apply_company_record_share_transfer_defaults_keeps_specific_transferor_
     assert merged["transferor_details"] == "vlastnik firmy, Mar Mat, Testova 30, Poprad"
 
 
+def test_slovakia_address_validation_prompt_note_requires_consent_when_preference_unknown() -> None:
+    from app.chat.country_services import slovakia as slovakia_service
+
+    note = slovakia_service._build_slovak_address_validation_prompt_note(
+        current_content="Moja adresa je Námestie slobody 1, 811 06 Bratislava.",
+        prior_messages=[],
+    )
+
+    assert "consent question" in note.lower()
+    assert "registeradries.sk" in note
+
+
+def test_slovakia_address_validation_preference_is_reused_after_user_confirmation() -> None:
+    from app.chat.country_services import slovakia as slovakia_service
+    from app.chat.models import Message, MessageRole
+
+    session_id = uuid4()
+    prior_messages = [
+        Message(
+            session_id=session_id,
+            role=MessageRole.ASSISTANT,
+            content="Chcete overiť adresu cez registeradries.sk?",
+        ),
+        Message(
+            session_id=session_id,
+            role=MessageRole.USER,
+            content="Áno, overte adresu.",
+        ),
+    ]
+
+    note = slovakia_service._build_slovak_address_validation_prompt_note(
+        current_content="Adresa pre zmluvu: Námestie slobody 1, 811 06 Bratislava.",
+        prior_messages=prior_messages,
+    )
+
+    assert "already opted in" in note
+    assert "registeradries_address_validate" in note
+
+
 def test_reply_endpoint_share_transfer_uses_single_current_stakeholder_as_transferor(monkeypatch) -> None:
     from app.chat.repository import InMemoryChatRepository
     import app.chat.api as chat_api

--- a/docs/AI_ADDRESS_VALIDATOR_AGENT.md
+++ b/docs/AI_ADDRESS_VALIDATOR_AGENT.md
@@ -1,0 +1,29 @@
+# AIAddressValidatorAgent
+
+`AIAddressValidatorAgent` maps Slovak address text into a structured payload suitable for `registeradries.sk` lookups.
+
+## What it does
+
+- detects address-like text from a user message
+- extracts and normalizes core fields:
+  - `kraj`
+  - `okres`
+  - `city`
+  - `street`
+  - `house_number`
+  - `postal_code`
+- prepares a ready-to-open `registeradries.sk` lookup URL
+
+## Consent and memory behavior
+
+For Slovak chat flows, when address data is relevant, the assistant should:
+
+1. ask once whether the user wants address validation via `registeradries.sk`
+2. remember the answer (`yes` / `no`) for the rest of the case
+3. reuse that preference without repeatedly asking
+
+## Minimal runnable example
+
+```bash
+python examples/address_validation_minimal_demo.py
+```

--- a/examples/address_validation_minimal_demo.py
+++ b/examples/address_validation_minimal_demo.py
@@ -1,0 +1,26 @@
+"""Minimal runnable demo for AIAddressValidatorAgent.
+
+Run:
+    python examples/address_validation_minimal_demo.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from aijurisdictionagents.agents import AIAddressValidatorAgent
+
+
+if __name__ == "__main__":
+    agent = AIAddressValidatorAgent()
+    sample_text = "Doručovaciu adresu nastavte na Námestie slobody 1, 811 06 Bratislava."
+    result = agent.validate_from_text(sample_text)
+
+    print("Input:", sample_text)
+    print("Result OK:", result["ok"])
+    print("Mapping:", result["mapping"])
+    print("Lookup URL:", result["lookup_url"])

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -17,6 +17,7 @@ from aijurisdictionagents.e2e_workflows import (
     simulate_contract_summary_case,
     simulate_slovak_lease_review,
 )
+from aijurisdictionagents.agents import AIAddressValidatorAgent
 from aijurisdictionagents.workflows import WorkflowEngine, WorkflowRouter, create_default_registry
 
 
@@ -72,3 +73,9 @@ if __name__ == "__main__":
         "For Slovakia-focused document exports, the API PDF builder now uses "
         "a Slovak legal header profile and Central-European font preferences."
     )
+    print()
+    print("=== Address validation mapping demo ===")
+    address_result = AIAddressValidatorAgent().validate_from_text(
+        "Námestie slobody 1, 811 06 Bratislava",
+    )
+    print(address_result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aijurisdictionagents"
-version = "1.0.260356"
+version = "1.0.260364"
 description = "Multi-agent legal discussion scaffold."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260363"
+__version__ = "1.0.260364"

--- a/src/aijurisdictionagents/address_validation.py
+++ b/src/aijurisdictionagents/address_validation.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any
+from urllib.parse import urlencode
+
+
+@dataclass(frozen=True)
+class AddressMapping:
+    original_text: str
+    street: str
+    house_number: str
+    postal_code: str
+    city: str
+    okres: str
+    kraj: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "original_text": self.original_text,
+            "street": self.street,
+            "house_number": self.house_number,
+            "postal_code": self.postal_code,
+            "city": self.city,
+            "okres": self.okres,
+            "kraj": self.kraj,
+        }
+
+
+class AIAddressValidatorAgent:
+    """Extract Slovak address candidates and prepare registeradries lookup mapping."""
+
+    name: str = "AIAddressValidatorAgent"
+    base_lookup_url: str = "https://registeradries.sk/"
+
+    _POSTAL_CITY_RE = re.compile(
+        r"\b(?P<postal>\d{3}\s?\d{2})\s+(?P<city>[A-Za-zÁÄČĎÉÍĹĽŇÓÔŔŠŤÚÝŽáäčďéíĺľňóôŕšťúýž\- ]{2,})\b"
+    )
+    _STREET_NUMBER_RE = re.compile(
+        r"(?P<street>[A-Za-zÁÄČĎÉÍĹĽŇÓÔŔŠŤÚÝŽáäčďéíĺľňóôŕšťúýž0-9\.\- ]+?)\s+(?P<number>\d+[A-Za-z]?/?\d*)"
+    )
+
+    _CITY_TO_KRAJ_OKRES: dict[str, tuple[str, str]] = {
+        "bratislava": ("Bratislavský kraj", "Bratislava"),
+        "kosice": ("Košický kraj", "Košice"),
+        "žilina": ("Žilinský kraj", "Žilina"),
+        "zilina": ("Žilinský kraj", "Žilina"),
+        "trnava": ("Trnavský kraj", "Trnava"),
+        "nitra": ("Nitriansky kraj", "Nitra"),
+        "trenčín": ("Trenčiansky kraj", "Trenčín"),
+        "trencin": ("Trenčiansky kraj", "Trenčín"),
+        "banská bystrica": ("Banskobystrický kraj", "Banská Bystrica"),
+        "banska bystrica": ("Banskobystrický kraj", "Banská Bystrica"),
+        "prešov": ("Prešovský kraj", "Prešov"),
+        "presov": ("Prešovský kraj", "Prešov"),
+    }
+
+    def extract_mapping(self, text: str) -> AddressMapping | None:
+        candidate = " ".join(text.strip().split())
+        if not candidate:
+            return None
+
+        postal_match = self._POSTAL_CITY_RE.search(candidate)
+        postal_code = ""
+        city = ""
+        if postal_match is not None:
+            postal_code = postal_match.group("postal").replace(" ", "")
+            city = postal_match.group("city").strip(" ,.;")
+
+        street_match = self._STREET_NUMBER_RE.search(candidate)
+        street = ""
+        house_number = ""
+        if street_match is not None:
+            street = street_match.group("street").strip(" ,.;")
+            house_number = street_match.group("number").strip(" ,.;")
+            street = re.sub(
+                r"^(?:doručovaciu|dorucovaciu|moju|moja|adresu|adresa|nastavte|na)\s+",
+                "",
+                street,
+                flags=re.IGNORECASE,
+            ).strip(" ,.;")
+
+        if not city:
+            parts = [part.strip() for part in re.split(r",|;", candidate) if part.strip()]
+            if parts:
+                city = parts[-1]
+
+        kraj, okres = self._resolve_region(city)
+        if not any((street, house_number, postal_code, city)):
+            return None
+
+        return AddressMapping(
+            original_text=text.strip(),
+            street=street,
+            house_number=house_number,
+            postal_code=postal_code,
+            city=city,
+            okres=okres,
+            kraj=kraj,
+        )
+
+    def build_registeradries_lookup_url(self, mapping: AddressMapping) -> str:
+        params = {
+            "q": mapping.original_text,
+            "kraj": mapping.kraj,
+            "okres": mapping.okres,
+            "city": mapping.city,
+            "street": mapping.street,
+            "house_number": mapping.house_number,
+            "psc": mapping.postal_code,
+        }
+        cleaned = {key: value for key, value in params.items() if value}
+        if not cleaned:
+            return self.base_lookup_url
+        return f"{self.base_lookup_url}?{urlencode(cleaned)}"
+
+    def validate_from_text(self, text: str) -> dict[str, Any]:
+        mapping = self.extract_mapping(text)
+        if mapping is None:
+            return {
+                "ok": False,
+                "message": "No Slovak address candidate detected in text.",
+                "mapping": {},
+                "lookup_url": self.base_lookup_url,
+            }
+        return {
+            "ok": True,
+            "message": "Address candidate mapped for registeradries lookup.",
+            "mapping": mapping.as_dict(),
+            "lookup_url": self.build_registeradries_lookup_url(mapping),
+        }
+
+    def _resolve_region(self, city: str) -> tuple[str, str]:
+        normalized_city = " ".join(city.lower().split())
+        return self._CITY_TO_KRAJ_OKRES.get(normalized_city, ("", ""))

--- a/src/aijurisdictionagents/agents/__init__.py
+++ b/src/aijurisdictionagents/agents/__init__.py
@@ -1,4 +1,5 @@
 from .base import Agent
+from .address_validator import AIAddressValidatorAgent
 from .ai_web_search import AIWebSearchAgent, CompanySearchAgent, EntityScreeningAgent, PersonSearchAgent
 from .judge import create_judge
 from .lawyer import create_lawyer
@@ -17,6 +18,7 @@ def create_lawyer_agent(llm: LLMClient, country: str) -> Agent:
 
 __all__ = [
     "Agent",
+    "AIAddressValidatorAgent",
     "AIWebSearchAgent",
     "EntityScreeningAgent",
     "CompanySearchAgent",

--- a/src/aijurisdictionagents/agents/address_validator.py
+++ b/src/aijurisdictionagents/agents/address_validator.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from ..address_validation import AIAddressValidatorAgent
+
+__all__ = ["AIAddressValidatorAgent"]

--- a/src/aijurisdictionagents/agents/slovakia.py
+++ b/src/aijurisdictionagents/agents/slovakia.py
@@ -54,6 +54,14 @@ def create_lawyer_slovakia(llm: LLMClient) -> Agent:
         - Až po výslovnom potvrdení používateľa prepni do drafting režimu a priprav finálny text vhodný na export do PDF.
         - Po potvrdení používateľa už nežiadaj ďalšie potvrdenie PDF, ale priprav výsledný návrh.
 
+
+
+        ADDRESS-VALIDATION POLICY (Slovakia)
+        - Keď používateľ uvedie adresu alebo prípad vyžaduje adresné údaje (bydlisko/sídlo/nehnuteľnosť), najprv sa opýtaj, či chce overiť adresu cez registeradries.sk.
+        - Odpoveď používateľa (áno/nie) si zapamätaj a použi ju aj pre ďalšie otázky v rovnakom prípade; nepýtaj sa opakovane bez dôvodu.
+        - Ak používateľ súhlasí a je dostupný nástroj registeradries_address_validate, použi ho na mapovanie adresy minimálne na: kraj, okres, city/obec, ulica, súpisné-orientačné číslo, PSČ.
+        - Po overení stručne ukáž mapovanie a prípadné nejasnosti, ktoré treba doplniť.
+
         COMPANY-CHECK POLICY (Slovakia)
         - Ak používateľ žiada pripraviť zmluvu s firmou alebo uvádza firemného partnera, pred draftingom skontroluj, či je dostupný nástroj na overenie firmy (najmä Obchodný register).
         - Ak máš k dispozícii dostatok identifikačných údajov firmy, použi tento nástroj ako prvý krok a používateľa sa nepýtaj na údaje, ktoré vieš overiť automaticky.

--- a/src/aijurisdictionagents/tools/__init__.py
+++ b/src/aijurisdictionagents/tools/__init__.py
@@ -1,4 +1,5 @@
 from .base import ToolDefinition, ToolResult
+from .address_validator import RegisterAdriesAddressValidatorTool
 from .company_checks import answer_slovak_company_seat_question
 from .registry import ToolRegistry, build_default_tool_registry
 
@@ -6,6 +7,7 @@ __all__ = [
     "ToolDefinition",
     "ToolResult",
     "ToolRegistry",
+    "RegisterAdriesAddressValidatorTool",
     "build_default_tool_registry",
     "answer_slovak_company_seat_question",
 ]

--- a/src/aijurisdictionagents/tools/address_validator.py
+++ b/src/aijurisdictionagents/tools/address_validator.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..address_validation import AIAddressValidatorAgent
+from .base import ToolDefinition, ToolResult
+
+
+class RegisterAdriesAddressValidatorTool:
+    """Map Slovak address-like text into registeradries.sk lookup fields."""
+
+    def __init__(self, *, agent: AIAddressValidatorAgent | None = None) -> None:
+        self._agent = agent or AIAddressValidatorAgent()
+
+    @property
+    def definition(self) -> ToolDefinition:
+        return ToolDefinition(
+            name="registeradries_address_validate",
+            purpose=(
+                "Validate Slovak address candidates for registeradries.sk and map fields "
+                "(kraj, okres, city, street, house_number, postal code)."
+            ),
+            input_fields=("address_text",),
+            requires_explicit_user_confirmation=True,
+        )
+
+    def run(self, **kwargs: Any) -> ToolResult:
+        address_text = str(kwargs.get("address_text") or "").strip()
+        if not address_text:
+            return ToolResult(
+                tool_name=self.definition.name,
+                ok=False,
+                records=(),
+                message="address_text is required.",
+            )
+
+        result = self._agent.validate_from_text(address_text)
+        if not result["ok"]:
+            return ToolResult(
+                tool_name=self.definition.name,
+                ok=False,
+                records=(),
+                message=str(result.get("message") or "Address validation failed."),
+            )
+
+        return ToolResult(
+            tool_name=self.definition.name,
+            ok=True,
+            records=(
+                {
+                    "address_text": address_text,
+                    "mapping": result.get("mapping", {}),
+                    "lookup_url": result.get("lookup_url", self._agent.base_lookup_url),
+                },
+            ),
+            message=str(result.get("message") or "Address mapped."),
+        )

--- a/src/aijurisdictionagents/tools/registry.py
+++ b/src/aijurisdictionagents/tools/registry.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from .base import Tool, ToolDefinition, ToolResult
+from .address_validator import RegisterAdriesAddressValidatorTool
 from .obchodnyregister import ObchodnyRegisterTool
 
 
@@ -32,5 +33,6 @@ class ToolRegistry:
 def build_default_tool_registry() -> ToolRegistry:
     tools: dict[str, Tool] = {
         "obchodny_register_company_check": ObchodnyRegisterTool(),
+        "registeradries_address_validate": RegisterAdriesAddressValidatorTool(),
     }
     return ToolRegistry(_tools=tools)

--- a/tests/test_address_validator_tool.py
+++ b/tests/test_address_validator_tool.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from aijurisdictionagents.tools.address_validator import RegisterAdriesAddressValidatorTool
+
+
+def test_registeradries_address_validator_tool_maps_address() -> None:
+    tool = RegisterAdriesAddressValidatorTool()
+
+    result = tool.run(address_text="Námestie slobody 1, 811 06 Bratislava")
+
+    assert result.ok is True
+    assert result.records
+    record = result.records[0]
+    mapping = record["mapping"]
+    assert mapping["city"] == "Bratislava"
+    assert mapping["kraj"] == "Bratislavský kraj"
+    assert mapping["okres"] == "Bratislava"
+    assert "registeradries.sk" in record["lookup_url"]
+
+
+def test_registeradries_address_validator_tool_requires_input() -> None:
+    tool = RegisterAdriesAddressValidatorTool()
+
+    result = tool.run(address_text="")
+
+    assert result.ok is False
+    assert "required" in result.message

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -8,7 +8,7 @@ from aijurisdictionagents.agents.ai_web_search import (
     PersonSearchAgent,
     _parse_duckduckgo_html_results,
 )
-from aijurisdictionagents.agents import AIUserSimulatorAgent, create_lawyer_agent
+from aijurisdictionagents.agents import AIAddressValidatorAgent, AIUserSimulatorAgent, create_lawyer_agent
 from aijurisdictionagents.llm import MockLLMClient
 from aijurisdictionagents.schemas import Document, Message
 
@@ -264,3 +264,15 @@ def test_person_search_agent_builds_structured_prompt_in_english() -> None:
     assert "list of trade licenses / sole-trader businesses" in prompt
     assert "financial institutions" in prompt
     assert "Person reference: Jana Hraska" in prompt
+
+
+def test_ai_address_validator_agent_extracts_slovak_mapping_and_lookup_url() -> None:
+    agent = AIAddressValidatorAgent()
+    result = agent.validate_from_text("Partizánska 665/101, 059 18 Spišské Bystré")
+
+    assert result["ok"] is True
+    mapping = result["mapping"]
+    assert mapping["street"].startswith("Partiz")
+    assert mapping["house_number"] == "665/101"
+    assert mapping["postal_code"] == "05918"
+    assert "registeradries.sk" in result["lookup_url"]


### PR DESCRIPTION
### Motivation
- Provide a focused Slovak address validation capability that extracts address candidates from free text and maps them into fields usable by registeradries.sk lookups. 
- Ensure the system asks a single consent question when address data is needed and remembers the user’s yes/no preference for the lifetime of the case to avoid repeated prompts.

### Description
- Added `AIAddressValidatorAgent` which extracts/normalizes Slovak address fields (`kraj`, `okres`, `city`, `street`, `house_number`, `postal_code`) and builds a `registeradries.sk` lookup URL (new file `src/aijurisdictionagents/address_validation.py` and agent shim `src/aijurisdictionagents/agents/address_validator.py`).
- Implemented `RegisterAdriesAddressValidatorTool` that wraps the agent for runtime tooling and registered it in the default tool registry as `registeradries_address_validate` (new file `src/aijurisdictionagents/tools/address_validator.py` and registry update in `src/aijurisdictionagents/tools/registry.py` and `src/aijurisdictionagents/tools/__init__.py`).
- Updated Slovak lawyer guidance and country orchestration: injected an address-validation policy into the Slovakia lawyer prompt, added prompt-note orchestration to detect address-relevant turns, ask one concise consent question when preference is unknown, and remember/reuse the yes/no choice across the case (changes in `src/aijurisdictionagents/agents/slovakia.py` and `api/aijuristiction-api/app/chat/country_services/slovakia.py`).
- Added helper functions to build/merge prompt notes and resolve stored consent from prior messages; added small extraction refinements for street text cleaning.
- Documentation and runnable examples: `docs/AI_ADDRESS_VALIDATOR_AGENT.md`, `examples/address_validation_minimal_demo.py`, and updated `examples/minimal_demo.py` to demonstrate mapping output.
- Tests: added `tests/test_address_validator_tool.py` and extended `tests/test_agents.py` and `api/aijuristiction-api/tests/test_chat.py` with checks for prompt-note behavior and agent mapping; bumped revision versions for core and API packages.

### Testing
- Ran unit tests: `pytest tests/test_agents.py tests/test_address_validator_tool.py tests/test_company_checks.py -q` — all tests passed.
- Ran API-focused tests for the new Slovakia prompt-note pieces: `cd api/aijuristiction-api && pytest tests/test_chat.py -q -k "address_validation"` — passed.
- Executed minimal demos: `python examples/address_validation_minimal_demo.py` and `python examples/minimal_demo.py` to verify runtime mapping output — both produced expected mapping and lookup URL.
- No automated tests failed during these runs; the added tests and targeted API checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e681cb990083328017472cd81c5e48)