### PR TITLE
Remove unused MessageRole import in Slovak chat test

### DIFF
--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -1483,7 +1483,7 @@ def test_slovakia_property_validation_preference_is_reused_after_user_confirmati
 
 def test_prepare_slovakia_direct_reply_adds_property_consent_note_for_property_contract_request() -> None:
     from app.chat.country_services import slovakia as slovakia_service
-    from app.chat.models import MessageRole, Session
+    from app.chat.models import Session
 
     session = Session(country="SK")
     current_content = "Priprav kupno predajnu zmluvu na pozemkoch nachadzajuci sa v katastri obce Kravany, na adrese ..."


### PR DESCRIPTION
### Motivation
- Fix a Ruff `F401` unused import error in `api/aijuristiction-api/tests/test_chat.py` caused by importing `MessageRole` in the Slovak direct-reply test.

### Description
- Removed `MessageRole` from the import line and kept only `Session` in `api/aijuristiction-api/tests/test_chat.py` for `test_prepare_slovakia_direct_reply_adds_property_consent_note_for_property_contract_request`.

### Testing
- Ran `ruff check api/aijuristiction-api/app api/aijuristiction-api/tests` and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e773b55e648332a72f670537ed7d9f)