### PR TITLE
Add Jurisdicta corporate PDF template and third-party document classifier for exports

### DIFF
--- a/api/aijuristiction-api/app/chat/api.py
+++ b/api/aijuristiction-api/app/chat/api.py
@@ -21,6 +21,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel, Field
+from reportlab.lib import colors  # type: ignore[import-untyped]
 from reportlab.lib.pagesizes import A4  # type: ignore[import-untyped]
 from reportlab.pdfbase import pdfmetrics  # type: ignore[import-untyped]
 from reportlab.pdfbase.ttfonts import TTFont  # type: ignore[import-untyped]
@@ -75,6 +76,7 @@ class _DocumentExportAsset:
     filename: str
     title: str
     lines: list[str]
+    use_corporate_template: bool = False
 
 
 class CreateSessionRequest(BaseModel):
@@ -2145,6 +2147,7 @@ def export_session_result(
         title = asset.title
         lines = asset.lines
         filename = asset.filename
+        use_corporate_template = asset.use_corporate_template
     else:
         title, lines = _build_summary_export_content(
             session_id=session_id,
@@ -2154,15 +2157,20 @@ def export_session_result(
             language=session.language,
         )
         filename = _build_pdf_filename(session_id=session_id, kind="summary")
+        use_corporate_template = False
 
     pdf_content = _build_simple_pdf(
         title=title,
         lines=lines,
         country=session.country,
         language=session.language,
-        header_line=(f"AI Jurisdicta Solution | Generated: {generated_at}" if kind == "document" else None),
+        header_line=(
+            f"AI Jurisdicta Solution | Generated: {generated_at}"
+            if kind == "document" and use_corporate_template
+            else None
+        ),
         footer_line=(footer_line if kind == "document" else None),
-        draw_logo_mark=(kind == "document"),
+        draw_logo_mark=(kind == "document" and use_corporate_template),
         include_title_block=(kind != "document"),
     )
     return Response(
@@ -2192,6 +2200,13 @@ def _build_simple_pdf(
     body_line_height = 14.0
     title_font_size = 14.0
     footer_font_size = 9.0
+    use_corporate_template = draw_logo_mark and not include_title_block
+
+    if use_corporate_template:
+        margin_top = 180.0
+        title_font_size = 22.0
+        body_font_size = 10.8
+        body_line_height = 18.0
 
     prefers_slovak_profile = _prefers_slovak_legal_pdf_profile(country=country, language=language)
     header_lines: list[str] = []
@@ -2209,6 +2224,8 @@ def _build_simple_pdf(
 
     title_block: list[str] = [title, "----------------"] if include_title_block else []
     prepared_lines = header_lines + title_block + _wrap_pdf_lines(lines)
+    if use_corporate_template:
+        prepared_lines = [title, ""] + prepared_lines
     if not prepared_lines:
         prepared_lines = [title]
 
@@ -2216,7 +2233,16 @@ def _build_simple_pdf(
     pdf = canvas.Canvas(buffer, pagesize=A4, pageCompression=0)
 
     def start_page() -> float:
-        if draw_logo_mark:
+        if use_corporate_template:
+            _draw_jurisdicta_corporate_header(
+                pdf=pdf,
+                page_width=page_width,
+                page_height=page_height,
+                margin_left=margin_left,
+                regular_font=regular_font,
+                bold_font=bold_font,
+            )
+        elif draw_logo_mark:
             pdf.setFont(bold_font, 10)
             pdf.drawRightString(page_width - margin_left, page_height - 28, "AI Jurisdicta")
         return page_height - margin_top
@@ -2228,6 +2254,11 @@ def _build_simple_pdf(
 
     y = start_page()
     for index, line in enumerate(prepared_lines):
+        if index == 0 and use_corporate_template:
+            pdf.setFont(bold_font, title_font_size)
+            pdf.drawCentredString(page_width / 2.0, y, line)
+            y -= body_line_height * 1.6
+            continue
         if index == 0 and include_title_block:
             pdf.setFont(bold_font, title_font_size)
             pdf.drawString(margin_left, y, line)
@@ -2249,6 +2280,55 @@ def _build_simple_pdf(
     draw_footer()
     pdf.save()
     return buffer.getvalue()
+
+
+def _draw_jurisdicta_corporate_header(
+    *,
+    pdf: canvas.Canvas,
+    page_width: float,
+    page_height: float,
+    margin_left: float,
+    regular_font: str,
+    bold_font: str,
+) -> None:
+    logo_color = colors.HexColor("#1EA75A")
+    dark_text = colors.HexColor("#111111")
+    muted_text = colors.HexColor("#3E434A")
+    top_y = page_height - 74.0
+
+    pdf.setStrokeColor(logo_color)
+    pdf.setLineWidth(3.0)
+    pdf.line(margin_left, top_y, margin_left + 56.0, top_y)
+    pdf.line(margin_left + 22.0, top_y, margin_left + 34.0, top_y - 18.0)
+    pdf.line(margin_left + 56.0, top_y, margin_left + 34.0, top_y - 18.0)
+
+    pdf.setFillColor(dark_text)
+    pdf.setFont(bold_font, 20)
+    pdf.drawString(margin_left, top_y - 44.0, "Jurisdicta")
+
+    right_x = page_width - margin_left
+    contact_lines = (
+        "Jurisdicta Legal Technology",
+        "Orlando, FL 32801",
+        "inquire@jurisdicta.ai",
+        "+1 222 555 7777",
+        "jurisdicta.ai",
+    )
+    pdf.setFillColor(muted_text)
+    pdf.setFont(regular_font, 10)
+    line_y = top_y
+    for contact_line in contact_lines:
+        pdf.drawRightString(right_x, line_y, contact_line)
+        line_y -= 13.0
+
+    separator_x = page_width - margin_left - 94.0
+    pdf.setStrokeColor(colors.HexColor("#777777"))
+    pdf.setLineWidth(1.6)
+    pdf.line(separator_x, top_y + 4.0, separator_x, top_y - 58.0)
+
+    pdf.setStrokeColor(colors.HexColor("#D8DCE1"))
+    pdf.setLineWidth(1.0)
+    pdf.line(margin_left, top_y - 76.0, page_width - margin_left, top_y - 76.0)
 
 
 def _wrap_pdf_lines(lines: List[str], width: int = 90) -> List[str]:
@@ -2300,10 +2380,14 @@ def _build_document_export_archive(
                 lines=asset.lines,
                 country=country,
                 language=language,
-                header_line=f"AI Jurisdicta Solution | Generated: {generated_at}",
+                header_line=(
+                    f"AI Jurisdicta Solution | Generated: {generated_at}"
+                    if asset.use_corporate_template
+                    else None
+                ),
                 footer_line=footer_line,
-                draw_logo_mark=True,
-                include_title_block=True,
+                draw_logo_mark=asset.use_corporate_template,
+                include_title_block=not asset.use_corporate_template,
             )
             archive.writestr(asset.filename, pdf_content)
     return archive_buffer.getvalue()
@@ -2657,6 +2741,12 @@ def _build_document_export_assets(
                 ),
                 title=title,
                 lines=lines,
+                use_corporate_template=_is_third_party_document(
+                    document_kind=document_kind,
+                    entry=entry,
+                    title=title,
+                    lines=lines,
+                ),
             )
         ]
     return _build_multi_document_export_assets(
@@ -2928,9 +3018,49 @@ def _build_multi_document_export_assets(
                 filename=unique_filename,
                 title=title,
                 lines=lines,
+                use_corporate_template=_is_third_party_document(
+                    document_kind=document_kind,
+                    entry=entry,
+                    title=title,
+                    lines=lines,
+                ),
             )
         )
     return assets
+
+
+def _is_third_party_document(
+    *,
+    document_kind: str,
+    entry: dict[str, Any] | None,
+    title: str,
+    lines: list[str],
+) -> bool:
+    if document_kind in {"rental_agreement", "share_transfer", "easement_demand"}:
+        return True
+    entry_type = _canonicalize_document_text(str((entry or {}).get("type") or ""))
+    if entry_type in {"contract", "minutes", "articles", "registry_filing", "handover_protocol", "inventory"}:
+        return True
+    candidate_text = " ".join(
+        [
+            title,
+            str((entry or {}).get("filename") or ""),
+            str((entry or {}).get("path") or ""),
+            *(lines[:8]),
+        ]
+    )
+    lowered = _canonicalize_document_text(candidate_text)
+    if any(token in lowered for token in ("registry filing", "court filing", "contract", "agreement", "petition", "protocol")):
+        return True
+    internal_markers = (
+        "legal summary and next-step memorandum",
+        "pravne zhrnutie a navrh dalsieho postupu",
+        "recommended next steps",
+        "odporucany postup",
+    )
+    if any(marker in lowered for marker in internal_markers):
+        return False
+    return False
 
 
 def _deduplicate_export_filename(*, filename: str, used_filenames: set[str]) -> str:

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260377"
+version = "1.0.260379"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -10,6 +10,7 @@ from zipfile import ZipFile
 
 from fastapi.testclient import TestClient
 from pypdf import PdfReader
+import pytest
 
 from app.main import app
 
@@ -109,6 +110,95 @@ def test_create_session_and_messages_roundtrip() -> None:
     messages = list_response.json()
     assert len(messages) == 1
     assert messages[0]["role"] == "user"
+
+
+def test_third_party_template_classifier_marks_internal_memorandum_as_non_corporate() -> None:
+    import app.chat.api as chat_api
+
+    is_third_party = chat_api._is_third_party_document(
+        document_kind="general",
+        entry={"type": "other", "filename": "internal-memo.pdf"},
+        title="Generated internal memo",
+        lines=[
+            "Legal summary and next-step memorandum",
+            "Recommended next steps:",
+        ],
+    )
+
+    assert is_third_party is False
+
+
+def test_third_party_template_classifier_marks_contract_asset_as_corporate() -> None:
+    import app.chat.api as chat_api
+
+    is_third_party = chat_api._is_third_party_document(
+        document_kind="general",
+        entry={"type": "contract", "filename": "agreement.pdf"},
+        title="Agreement",
+        lines=["Contract between parties."],
+    )
+
+    assert is_third_party is True
+
+
+@pytest.mark.parametrize(
+    ("document_kind", "entry_type", "title", "expected"),
+    [
+        ("rental_agreement", "contract", "Nájomná zmluva", True),
+        ("rental_agreement", "inventory", "Inventárny zoznam", True),
+        ("rental_agreement", "handover_protocol", "Protokol o odovzdaní", True),
+        ("share_transfer", "minutes", "Zápisnica z rozhodnutia", True),
+        ("share_transfer", "registry_filing", "Podanie na ORSR", True),
+        ("general", "other", "Internal legal memo", False),
+    ],
+)
+def test_third_party_template_classifier_by_document_templates(
+    document_kind: str,
+    entry_type: str,
+    title: str,
+    expected: bool,
+) -> None:
+    import app.chat.api as chat_api
+
+    is_third_party = chat_api._is_third_party_document(
+        document_kind=document_kind,
+        entry={"type": entry_type, "filename": "template.pdf"},
+        title=title,
+        lines=[title, "Template content body."],
+    )
+
+    assert is_third_party is expected
+
+
+def test_pdf_builder_renders_corporate_header_only_when_template_enabled() -> None:
+    import app.chat.api as chat_api
+
+    corporate_pdf = chat_api._build_simple_pdf(
+        title="Car Rental Legal Memo",
+        lines=["Subject: Liability review", "To: Example Recipient"],
+        country="US",
+        language="en-US",
+        header_line="AI Jurisdicta Solution | Generated: 2026-04-21 10:00:00 UTC",
+        footer_line="AIJ | API 1.0 | Core 1.0",
+        draw_logo_mark=True,
+        include_title_block=False,
+    )
+    plain_pdf = chat_api._build_simple_pdf(
+        title="Internal legal summary",
+        lines=["Recommended next steps:", "1. Collect documents."],
+        country="US",
+        language="en-US",
+        footer_line="AIJ | API 1.0 | Core 1.0",
+        draw_logo_mark=False,
+        include_title_block=True,
+    )
+
+    corporate_text = _pdf_text(corporate_pdf).lower()
+    plain_text = _pdf_text(plain_pdf).lower()
+
+    assert "jurisdicta legal technology" in corporate_text
+    assert "orlando, fl 32801" in corporate_text
+    assert "jurisdicta legal technology" not in plain_text
 
 
 def test_stream_core_orchestration_and_export_json_pdf() -> None:

--- a/docs/DOCUMENT_TEMPLATES_API.md
+++ b/docs/DOCUMENT_TEMPLATES_API.md
@@ -81,6 +81,17 @@ Central-European PDF font profile, so headings such as `Nájomná zmluva`, `Čl.
 
 If a chat run only asks for a single rental contract, the endpoint still returns one PDF.
 
+For generated court-facing or third-party organization output documents, the API applies the
+Jurisdicta default corporate template:
+
+- branded Jurisdicta header block
+- right-aligned corporate contact details
+- clean divider line and centered document title
+- same API/Core export footer metadata for traceability
+
+Internal workflow-style outputs (for example legal summary / next-step memorandum style drafts) and
+discussion summaries intentionally keep the plain PDF style without the corporate template.
+
 ## PDF Preview
 
 The template preview endpoint renders one template directly through the same PDF builder used by chat document
@@ -106,9 +117,14 @@ Recommended runtime folder:
 python examples/document_templates_minimal_demo.py
 ```
 
+Generate one sample third-party corporate PDF output:
+
+```bash
+python examples/document_template_pdf_sample_demo.py
+```
+
 Repository default smoke demo remains available:
 
 ```bash
 python examples/minimal_demo.py
 ```
-

--- a/examples/document_template_pdf_sample_demo.py
+++ b/examples/document_template_pdf_sample_demo.py
@@ -1,0 +1,49 @@
+"""Generate one sample third-party corporate PDF document.
+
+Run:
+    python examples/document_template_pdf_sample_demo.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "api" / "aijuristiction-api"))
+
+from app.chat.api import _build_simple_pdf
+
+
+def main() -> None:
+    output_path = REPO_ROOT / "runs" / "storage" / "api" / "pdf_previews" / "sample-third-party-template.pdf"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    pdf_bytes = _build_simple_pdf(
+        title="Car Rental Legal Memo",
+        lines=[
+            "Subject: Legal Memo on Liability and Insurance Issues in Car Rentals",
+            "",
+            "To: [Recipient's Name], CEO, [Your Company Name]",
+            "From: [Your Name], [Your Job Title]",
+            "Date: [Date]",
+            "",
+            "Re: Legal Analysis and Recommendations on Liability and Insurance Issues",
+            "",
+            "Dear [Recipient's Name],",
+            "",
+            "As requested, I have conducted a comprehensive legal analysis of liability and insurance risks.",
+        ],
+        country="US",
+        language="en-US",
+        header_line="AI Jurisdicta Solution | Generated: 2026-04-21 10:00:00 UTC",
+        footer_line="AIJ | API 1.0 | Core 1.0",
+        draw_logo_mark=True,
+        include_title_block=False,
+    )
+    output_path.write_bytes(pdf_bytes)
+    print(f"Generated: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -71,7 +71,9 @@ if __name__ == "__main__":
     print("=== PDF export UX note ===")
     print(
         "For Slovakia-focused document exports, the API PDF builder now uses "
-        "a Slovak legal header profile and Central-European font preferences. "
+        "a Jurisdicta corporate document template (header + contact panel + centered title) "
+        "for court/third-party facing documents, "
+        "a Slovak legal header profile where needed, and Central-European font preferences. "
         "Rental packages with visible sections such as Nájomná zmluva, Inventárny zoznam, "
         "and Protokol o odovzdaní a prevzatí bytu export as a ZIP package. "
         "Document templates can also be previewed as PDFs from the chat simulator."


### PR DESCRIPTION
### Motivation

- Provide a branded corporate PDF template for court/third‑party facing documents so exported PDFs can include a Jurisdicta header, contact panel and centered title.
- Automatically decide when to apply the corporate template vs keep plain internal memorandum style exports using a simple classifier.
- Ship docs and a small example to preview the corporate PDF output.

### Description

- Added `use_corporate_template: bool` to `_DocumentExportAsset` and threaded the flag through export logic so each asset can opt into the corporate layout.
- Introduced `_is_third_party_document` classifier to decide when an export asset should receive the corporate template based on `document_kind`, `entry.type`, filename/path/title and content markers.
- Updated `_build_simple_pdf` to support a corporate layout when `draw_logo_mark` + `include_title_block` indicate corporate output, including larger title, increased top margin, and different line heights.
- Added `_draw_jurisdicta_corporate_header` which renders the branded header, contact block, separators and divider lines using `reportlab` colors and primitives.
- Updated archive export and single‑PDF export paths to pass the `use_corporate_template` flag through `header_line`, `draw_logo_mark` and `include_title_block` appropriately.
- Added `reportlab.lib.colors` import and bumped package version in `pyproject.toml`.
- Added tests in `tests/test_chat.py` covering the classifier and PDF corporate rendering, updated documentation `docs/DOCUMENT_TEMPLATES_API.md`, and included an example `examples/document_template_pdf_sample_demo.py` plus a small messaging update in `examples/minimal_demo.py`.

### Testing

- Ran unit tests with `pytest` including the new tests in `tests/test_chat.py`; all tests passed.
- Exercised PDF generation in tests by calling `_build_simple_pdf` and extracting text via `pypdf` to assert presence/absence of the corporate contact block; these assertions succeeded.
- Verified that archive vs single PDF export logic routes `use_corporate_template` to `_build_simple_pdf` for both single documents and zipped packages during automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76f86dd54833295e15777ce1df335)