### PR TITLE
Auto-preload prepared testcase documents after creating session

### DIFF
--- a/api/chat-simulator-app/README.md
+++ b/api/chat-simulator-app/README.md
@@ -25,6 +25,8 @@ The simulator now supports:
 - loading prepared case instructions directly from `api/chat-simulator-app/testcases/` into the rendered internal simulator page and copying the selected case into the instruction box
 - supporting both `CaseDescription` and the legacy typo `CaseDescripton` in prepared-case JSON-like files
 - preloading prepared-case `Documents` attachments from `api/chat-simulator-app/testcases/` into the browser file picker so they are immediately ready for `Upload To Case`
+- auto-uploading prepared-case `Documents` to a newly created case right after `Create Session`, so testcase attachments are persisted without an extra manual `Upload To Case` click
+  - this auto-upload is intentionally skipped when you select an existing case from the dropdown
 - showing a clear prepared-case dropdown state when no local prepared cases are available
 - rendering the simulator page with no-cache headers and versioned static asset URLs so browser refresh picks up the latest internal UI changes immediately
 - showing an initial localized Jurisdicta welcome message in the End User Chat View (`SK` default, `EN`, `GE`, with `DE` accepted as alias for German)

--- a/api/chat-simulator-app/static/simulator.js
+++ b/api/chat-simulator-app/static/simulator.js
@@ -72,6 +72,7 @@ let activeDocumentViewUrl = null;
 let processingStatusTimerId = null;
 let processingStatusBaseMessage = "";
 let processingStatusStartedAt = 0;
+let activeCaseSelectionMode = null;
 
 function decodeBase64ToBytes(base64Value) {
   const normalized = String(base64Value || "").trim();
@@ -101,6 +102,21 @@ function applyPreparedCaseDocuments(documents) {
     transfer.items.add(file);
   }
   documentsInput.files = transfer.files;
+}
+
+function selectedPreparedCase() {
+  const selectedId = String(preparedCaseInput?.value || "").trim();
+  if (!selectedId) return null;
+  return preparedCases.find((item) => item.id === selectedId) || null;
+}
+
+function buildPreparedCaseFile(document) {
+  const fileName = String(document?.fileName || document?.sourcePath || "document").trim();
+  const mimeType = String(document?.mimeType || "application/octet-stream").trim();
+  const contentBase64 = String(document?.contentBase64 || "").trim();
+  if (!fileName || !contentBase64 || typeof File === "undefined") return null;
+  const bytes = decodeBase64ToBytes(contentBase64);
+  return new File([bytes], fileName, { type: mimeType });
 }
 
 function normalizeLanguageCode(languageCode) {
@@ -891,6 +907,7 @@ async function selectExistingCase(caseId) {
   const normalizedCaseId = String(caseId || "").trim();
   if (!normalizedCaseId) {
     currentCaseId = null;
+    activeCaseSelectionMode = null;
     hasUploadedCaseDocuments = false;
     resetLoadedCaseData();
     updateExistingCaseStatus();
@@ -908,6 +925,7 @@ async function selectExistingCase(caseId) {
   }
 
   currentCaseId = normalizedCaseId;
+  activeCaseSelectionMode = "existing";
   if (caseTitleInput) {
     caseTitleInput.value = String(selectedCase?.title || caseTitleInput.value || "").trim() || "Simulator persisted case";
   }
@@ -1318,6 +1336,7 @@ async function createPersistedCase() {
   }
   const body = await parseResponse(response);
   currentCaseId = body.case_id;
+  activeCaseSelectionMode = "new";
   hasUploadedCaseDocuments = false;
   resetLoadedCaseData();
   invalidateSession("Case created. You can Create Session immediately, or use Upload To Case first for persisted document retrieval.");
@@ -1474,7 +1493,41 @@ async function createSession() {
   clearWorkflowWarning();
   refreshReplyControls();
   refreshPersistedCaseControls();
+  await preloadPreparedCaseDocumentsToActiveCase();
   await refreshMessages();
+}
+
+async function preloadPreparedCaseDocumentsToActiveCase() {
+  if (!currentCaseId || !currentUserId) return;
+  if (activeCaseSelectionMode === "existing") return;
+  if (hasUploadedCaseDocuments) return;
+  const preparedCase = selectedPreparedCase();
+  const preparedDocuments = Array.isArray(preparedCase?.documents) ? preparedCase.documents : [];
+  if (!preparedDocuments.length) return;
+
+  const files = preparedDocuments
+    .map((document) => buildPreparedCaseFile(document))
+    .filter((file) => file !== null);
+  if (!files.length) return;
+
+  const formData = new FormData();
+  for (const file of files) {
+    formData.append("files", file);
+  }
+
+  const response = await fetch(
+    `${getBaseUrl()}/v1/cases/${encodeURIComponent(currentCaseId)}/documents?user_id=${encodeURIComponent(currentUserId)}`,
+    {
+      method: "POST",
+      headers: requestHeaders(false),
+      body: formData,
+    },
+  );
+  await parseResponse(response);
+  hasUploadedCaseDocuments = true;
+  appendStream(`prepared_case_documents_preloaded: case=${currentCaseId} count=${files.length}`);
+  setWorkflowWarning("Prepared testcase documents were preloaded to this case.");
+  await inspectCaseDocuments();
 }
 
 async function readSelectedDocuments() {


### PR DESCRIPTION
### Motivation
- Enable prepared testcase `Documents` embedded in `testcases/*.txt` to be persisted automatically when a new persisted case/session is created so testers don't need a separate `Upload To Case` step. 
- Skip the auto-upload when a user explicitly selects an existing persisted case so we don't overwrite or unexpectedly change existing case documents.

### Description
- Added `activeCaseSelectionMode` state to track whether the active case was created just now (`"new"`) or selected from existing persisted cases (`"existing"`).
- Added helper functions `selectedPreparedCase()` and `buildPreparedCaseFile()` to resolve the chosen prepared testcase and convert embedded `Documents` entries (base64/mime/fileName) into browser `File` objects for upload. 
- On `Create Session` the simulator now calls `preloadPreparedCaseDocumentsToActiveCase()` which automatically uploads prepared-case files to the newly created case via `POST /v1/cases/{case_id}/documents` and then calls `inspectCaseDocuments()`; this flow is skipped when `activeCaseSelectionMode === "existing"` or when documents are already uploaded. 
- Updated `api/chat-simulator-app/README.md` to document the new auto-upload behavior and the explicit skip when an existing case is selected.

### Testing
- Ran `cd api/chat-simulator-app && pytest -q` which failed in the non-PYTHONPATH environment due to module import resolution (expected in this environment). (failed)
- Ran `cd api/chat-simulator-app && PYTHONPATH=. pytest -q` which executed the simulator tests successfully. (passed)
- Verified the simulator JS changes build and the new helper functions are invoked from `createSession()` and that README reflects the new behavior. (manual verification in test environment)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8db5e21108332a692ed63d4cd046f)