### PR TITLE
Fix chat API type-check failure in technical payload persistence

### DIFF
--- a/api/aijuristiction-api/app/chat/api.py
+++ b/api/aijuristiction-api/app/chat/api.py
@@ -1814,7 +1814,7 @@ def _persist_case_technical_payload(
     filename = f"assistant-technical-{timestamp}-{uuid4().hex[:8]}.{extension}"
     try:
         store = _get_store()
-        return store.add_case_document(
+        doc_id = store.add_case_document(
             case_id=case_id,
             kind="technical_payload",
             version=1,
@@ -1822,6 +1822,7 @@ def _persist_case_technical_payload(
             payload=payload.encode("utf-8"),
             uploaded_by_user_id=str(session.user_id) if session.user_id else None,
         )
+        return doc_id if isinstance(doc_id, str) else None
     except Exception:
         _LOGGER.warning(
             "Failed to persist hidden assistant technical payload as a case document",

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260384"
+version = "1.0.260385"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
### Motivation
- CI type checking failed because `_persist_case_technical_payload` in `app/chat/api.py` could return an untyped `Any` from the store, violating the declared `str | None` return type.

### Description
- Assign the result of `store.add_case_document(...)` to `doc_id` and return `doc_id if isinstance(doc_id, str) else None` so the function always returns `str | None` as declared.
- Bumped the API package revision in `api/aijuristiction-api/pyproject.toml` from `1.0.260384` to `1.0.260385` to comply with repository versioning rules for changes under `api/aijuristiction-api/`.

### Testing
- Ran `cd api/aijuristiction-api && mypy app/chat/api.py --follow-imports=skip --disable-error-code misc --disable-error-code untyped-decorator --show-error-codes` and it completed with `Success: no issues found in 1 source file` confirming the original `no-any-return` error was resolved.
- A full strict `mypy` run still reports unrelated pre-existing type errors in `src/services/laws_collector/*`, which are outside the scope of this fix and were not changed by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8de9702ac833287c15e559a6c0c9a)