### PR TITLE
Implement chat memory persistence for case-backed sessions

### DIFF
--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -479,8 +479,10 @@ The dedicated local database layout guide now lives under `docs/DATABASE_LAYOUT.
 
 - `GET /v1/cases/{case_id}/history?user_id=...&offset=0&limit=5` returns the selected case's persisted chat history page plus stored case-document metadata.
 - `GET /v1/cases/{case_id}/documents/{doc_id}?user_id=...` downloads a previously stored case document or chat attachment.
+- `GET /v1/cases/{case_id}/documents/context?user_id=...` now reports processed/unprocessed memory inputs across uploaded files, chat attachments, and generated `session_history` transcripts.
 - If a transcript or document payload is missing in local storage, history responses fall back to saved summaries and document download returns `404` instead of `500`.
 - Uploaded case documents are stored as `case -> many documents`. Each processed uploaded document keeps the extracted full text plus a real embedding in `case_document_contents`, and chunk-level text/embedding rows in `case_document_chunks`.
+- Case-backed chat streams now persist inline session documents as reusable case attachments, process them immediately in local/API mode, and refresh the per-session `session-{session_id}.txt` transcript document on every later turn in the same session.
 - Direct `POST /v1/chat/sessions/{session_id}/reply` now loads the most relevant processed document chunks for the user query by combining lexical overlap with semantic similarity from real embeddings, then injects those chunks into the extra system-context document message.
 - Slovak share-transfer intake now prefers labeled company fields such as `Nazov:` / `Názov:` / `Obchodné meno:` when extracting the ORSR lookup query, so owner names in later lines do not override the company verification step.
 - `POST /v1/chat/sessions/{session_id}/stream` in `ReadUser` mode now emits intermediate `processing` SSE events for the company-verification path, including ORSR tool start/result and which drafting inputs were detected vs. still missing.
@@ -902,6 +904,7 @@ New endpoints:
 
 If `POST /v1/chat/sessions` is created with `case_id`, the API now seeds that new in-memory session with the stored case history so the next reply/stream turn can continue the existing case context instead of starting with an empty prompt.
 If one of those seeded case-history transcript files is missing, the API falls back to the saved summary text so existing cases can still create a session and continue.
+Case-backed session `3` can now also reuse documents uploaded during session `1` and session `2`, because inline chat documents are persisted into case memory and refreshed session-history transcripts are reprocessed for later retrieval.
 
 
 ## Minimal runnable example (streaming API + core)
@@ -910,4 +913,10 @@ Start API first, then run:
 
 ```bash
 python examples/api_streaming_demo.py
+```
+
+Cross-session memory formatting demo:
+
+```bash
+python examples/conversation_memory_minimal_demo.py
 ```

--- a/api/aijuristiction-api/app/cases_api.py
+++ b/api/aijuristiction-api/app/cases_api.py
@@ -476,7 +476,7 @@ def _document_context(*, case_id: str, store: ApiDatabaseStore) -> CaseDocumentC
     processed: list[str] = []
     unprocessed: list[str] = []
     for document in store.list_case_documents(case_id=case_id):
-        if document.kind != 'uploaded':
+        if document.kind not in {'uploaded', 'chat_attachment', 'session_history'}:
             continue
         if document.processing_status == 'processed':
             processed.append(document.original_filename)

--- a/api/aijuristiction-api/app/chat/api.py
+++ b/api/aijuristiction-api/app/chat/api.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from io import BytesIO
 import json
 import logging
+import os
 import re
 import time
 import textwrap
@@ -41,7 +42,7 @@ from app.chat.result_metadata import build_session_result_metadata
 from app.security import require_api_key
 from app.versioning import get_api_version, get_core_version
 
-from aijurisdictionagents.api_db import ApiDatabaseStore
+from aijurisdictionagents.api_db import ApiDatabaseStore, CaseDocument
 from aijurisdictionagents.llm import get_embedding_client
 from aijurisdictionagents.schemas import Document as CoreDocument
 from aijurisdictionagents.schemas import Message as CoreMessage
@@ -50,6 +51,7 @@ from services.document_processor.runtime import (
     lexical_overlap_score,
     parse_embedding_vector,
 )
+from services.document_processor.service import DocumentProcessor
 
 router = APIRouter(prefix="/v1/chat", tags=["chat"], dependencies=[Depends(require_api_key)])
 _repository = InMemoryChatRepository()
@@ -152,12 +154,60 @@ def _persist_session_history_document_if_needed(*, session: Session, session_id:
     store = _get_store()
     add_session_history_document = getattr(store, "add_case_session_history_document", None)
     if callable(add_session_history_document):
-        add_session_history_document(
+        doc_id = add_session_history_document(
             case_id=case_id,
             session_id=str(session_id),
             content=transcript,
             uploaded_by_user_id=str(session.user_id) if session.user_id else None,
         )
+        get_case_document = getattr(store, "get_case_document", None)
+        if callable(get_case_document):
+            _process_case_documents_if_needed(
+                store=store,
+                documents=[get_case_document(case_id=case_id, doc_id=doc_id)],
+            )
+
+
+def _document_processor_mode() -> str:
+    value = os.getenv(
+        "DOCUMENT_PROCESSOR_OPTION",
+        os.getenv("DOCUMENT_PROCESSOR", "api"),
+    ).strip().lower()
+    if value == "azure":
+        return "azure"
+    return "api"
+
+
+def _process_case_documents_if_needed(
+    *,
+    store: ApiDatabaseStore,
+    documents: list[CaseDocument],
+) -> None:
+    if not documents or _document_processor_mode() == "azure":
+        return
+    DocumentProcessor(store).process_documents(documents)
+
+
+def _persist_inline_case_documents_if_needed(
+    *,
+    session: Session,
+    documents: list[InputDocument],
+) -> None:
+    case_id = (session.case_id or "").strip()
+    if not case_id or not documents:
+        return
+    store = _get_store()
+    persisted_documents: list[CaseDocument] = []
+    for index, document in enumerate(documents, start=1):
+        filename = Path(document.path).name.strip() or f"attachment-{index}.txt"
+        doc_id = store.add_case_text_document(
+            case_id=case_id,
+            original_filename=filename,
+            content=document.content,
+            uploaded_by_user_id=str(session.user_id) if session.user_id else None,
+        )
+        persisted_documents.append(store.get_case_document(case_id=case_id, doc_id=doc_id))
+    _process_case_documents_if_needed(store=store, documents=persisted_documents)
 
 
 def _read_case_communication_content(*, store: ApiDatabaseStore, communication: Any) -> str:
@@ -236,7 +286,7 @@ def _load_case_documents_for_llm(
     processed_entries: list[tuple[str, str, str, str]] = []
     processed_names_by_doc_id: dict[str, str] = {}
     for document in list_case_documents(case_id=case_id):
-        if document.kind not in {'uploaded', 'session_history'}:
+        if document.kind not in {'uploaded', 'chat_attachment', 'session_history'}:
             continue
         if document.processing_status == 'processed' and document.doc_id in contents_by_doc_id:
             name, text, vector = contents_by_doc_id[document.doc_id]
@@ -730,6 +780,7 @@ def stream_session(session_id: UUID, payload: StartSessionStreamRequest) -> Stre
         raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
     if session.state == SessionState.COMPLETED and payload.user_simulation_mode != "ReadUser":
         raise HTTPException(status_code=409, detail="Session already completed")
+    _persist_inline_case_documents_if_needed(session=session, documents=payload.documents)
     if payload.user_simulation_mode == "ReadUser":
         return _stream_read_user_session(session_id=session_id, session=session, payload=payload)
 

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260385"
+version = "1.0.260386"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_cases.py
+++ b/api/aijuristiction-api/tests/test_cases.py
@@ -209,3 +209,41 @@ def test_download_case_document_returns_404_when_payload_missing() -> None:
 
     assert response.status_code == 404
     assert response.json()["detail"] == "Stored payload is unavailable for document doc-1"
+
+
+def test_session_history_document_reuses_same_doc_id_and_refreshes_payload(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("DB_OPTION", "local")
+    monkeypatch.setenv("STORAGE_OPTION", "local")
+    monkeypatch.setenv("DB_LOCAL", str(tmp_path / "api.sqlite3"))
+    monkeypatch.setenv("STORE_LOCAL", str(tmp_path / "storage"))
+
+    store = ApiDatabaseStore.from_env()
+    store.initialize()
+    user = store.create_user(
+        email="history-refresh@example.com",
+        password="secret",
+        phone_number="+421900000099",
+    )
+    case = store.create_case(user_id=user.user_id, company_id=None, title="History refresh case")
+
+    first_doc_id = store.add_case_session_history_document(
+        case_id=case.case_id,
+        session_id="session-1",
+        content="USER: first turn",
+        uploaded_by_user_id=user.user_id,
+    )
+    second_doc_id = store.add_case_session_history_document(
+        case_id=case.case_id,
+        session_id="session-1",
+        content="USER: first turn\nASSISTANT: refreshed turn",
+        uploaded_by_user_id=user.user_id,
+    )
+
+    assert second_doc_id == first_doc_id
+    stored_document = store.get_case_document(case_id=case.case_id, doc_id=first_doc_id)
+    assert stored_document.processing_status == "uploaded"
+    assert store.read_storage_text(storage_uri=stored_document.storage_uri) == (
+        "USER: first turn\nASSISTANT: refreshed turn"
+    )

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -2518,6 +2518,181 @@ def test_reply_persists_session_history_document_to_case(monkeypatch) -> None:
     assert "ASSISTANT: Stored response for conversation memory. (agent=LawyerSlovakia)" in persisted_transcript
 
 
+def test_case_memory_reuses_previous_session_messages_and_documents(monkeypatch, tmp_path) -> None:
+    from app.chat.repository import InMemoryChatRepository
+    import app.chat.api as chat_api
+
+    monkeypatch.setenv("DB_OPTION", "local")
+    monkeypatch.setenv("STORAGE_OPTION", "local")
+    monkeypatch.setenv("DB_LOCAL", str(tmp_path / "api.sqlite3"))
+    monkeypatch.setenv("STORE_LOCAL", str(tmp_path / "storage"))
+
+    class _FakeEmbeddingClient:
+        def embed_texts(self, texts: list[str]) -> SimpleNamespace:
+            return SimpleNamespace(
+                model_name="fake-embedding-model",
+                vectors=[[float(index + 1), float(len(text))] for index, text in enumerate(texts)],
+            )
+
+    captured_documents: list[list[str]] = []
+
+    class _FakeLawyer:
+        system_prompt = "fake-system"
+
+        def respond(self, *, conversation, documents, sources, system_prompt_override):
+            captured_documents.append([doc.path for doc in documents])
+            return SimpleNamespace(
+                content="Stored response for cross-session memory.",
+                agent_name="LawyerSlovakia",
+            )
+
+    monkeypatch.setattr(chat_api, "_repository", InMemoryChatRepository())
+    monkeypatch.setattr(
+        "services.document_processor.service.get_embedding_client",
+        lambda: _FakeEmbeddingClient(),
+    )
+    monkeypatch.setattr(
+        "aijurisdictionagents.agents.create_lawyer_agent",
+        lambda llm, country: _FakeLawyer(),
+    )
+    monkeypatch.setattr("aijurisdictionagents.llm.get_llm_client", lambda: object())
+
+    response = client.post(
+        "/v1/users/sign-up",
+        headers=AUTH_HEADERS,
+        json={
+            "phone_number": "+421900000333",
+            "email": "memory-user@example.com",
+            "password": "secret",
+        },
+    )
+    assert response.status_code == 201
+    user_id = response.json()["user_id"]
+
+    case_response = client.post(
+        "/v1/cases",
+        headers=AUTH_HEADERS,
+        json={"user_id": user_id, "title": "Cross-session memory"},
+    )
+    assert case_response.status_code == 201
+    case_id = case_response.json()["case_id"]
+
+    session_one = client.post(
+        "/v1/chat/sessions",
+        json={
+            "user_id": user_id,
+            "case_id": case_id,
+            "country": "SK",
+            "discussion_type": "advice",
+            "language": "SK",
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert session_one.status_code == 200
+    session_one_id = session_one.json()["id"]
+
+    with client.stream(
+        "POST",
+        f"/v1/chat/sessions/{session_one_id}/stream",
+        headers=AUTH_HEADERS,
+        json={
+            "instruction": "Please review the uploaded lease document.",
+            "documents": [
+                {
+                    "doc_id": "doc-1",
+                    "path": "lease-session-1.txt",
+                    "content": "Lease clause from session one.",
+                }
+            ],
+            "user_simulation_mode": "ReadUser",
+        },
+    ) as stream_one:
+        assert stream_one.status_code == 200
+        assert "event: done" in "".join(stream_one.iter_text())
+
+    session_two = client.post(
+        "/v1/chat/sessions",
+        json={
+            "user_id": user_id,
+            "case_id": case_id,
+            "country": "SK",
+            "discussion_type": "advice",
+            "language": "SK",
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert session_two.status_code == 200
+    session_two_id = session_two.json()["id"]
+
+    with client.stream(
+        "POST",
+        f"/v1/chat/sessions/{session_two_id}/stream",
+        headers=AUTH_HEADERS,
+        json={
+            "instruction": "Please review the uploaded payment evidence.",
+            "documents": [
+                {
+                    "doc_id": "doc-2",
+                    "path": "payment-session-2.txt",
+                    "content": "Payment evidence from session two.",
+                }
+            ],
+            "user_simulation_mode": "ReadUser",
+        },
+    ) as stream_two:
+        assert stream_two.status_code == 200
+        assert "event: done" in "".join(stream_two.iter_text())
+
+    session_three = client.post(
+        "/v1/chat/sessions",
+        json={
+            "user_id": user_id,
+            "case_id": case_id,
+            "country": "SK",
+            "discussion_type": "advice",
+            "language": "SK",
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert session_three.status_code == 200
+    session_three_id = session_three.json()["id"]
+
+    seeded_messages_response = client.get(
+        f"/v1/chat/sessions/{session_three_id}/messages",
+        headers=AUTH_HEADERS,
+    )
+    assert seeded_messages_response.status_code == 200
+    seeded_messages = seeded_messages_response.json()
+    assert len(seeded_messages) == 4
+    assert seeded_messages[0]["content"] == "Please review the uploaded lease document."
+    assert seeded_messages[2]["content"] == "Please review the uploaded payment evidence."
+
+    memory_response = client.get(
+        f"/v1/cases/{case_id}/documents/context?user_id={user_id}",
+        headers=AUTH_HEADERS,
+    )
+    assert memory_response.status_code == 200
+    memory_payload = memory_response.json()
+    processed_documents = memory_payload["processed_documents"]
+    assert "lease-session-1.txt" in processed_documents
+    assert "payment-session-2.txt" in processed_documents
+    assert f"session-{session_one_id}.txt" in processed_documents
+    assert f"session-{session_two_id}.txt" in processed_documents
+
+    reply_response = client.post(
+        f"/v1/chat/sessions/{session_three_id}/reply",
+        json={"content": "Summarize all uploaded documents and prior discussions."},
+        headers=AUTH_HEADERS,
+    )
+    assert reply_response.status_code == 200
+    assert captured_documents
+    final_document_paths = captured_documents[-1]
+    assert any(path.startswith("lease-session-1.txt") for path in final_document_paths)
+    assert any(path.startswith("payment-session-2.txt") for path in final_document_paths)
+    assert any(path.startswith(f"session-{session_one_id}.txt") for path in final_document_paths)
+    assert any(path.startswith(f"session-{session_two_id}.txt") for path in final_document_paths)
+
+
 def test_reply_endpoint_respects_session_language_sk() -> None:
     session_response = client.post(
         "/v1/chat/sessions",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,6 +37,7 @@ Each agent message includes:
 ## API document-task planning
 
 The API chat reply flow can add policy-driven task-planning guidance for uploaded-document requests before sending the prompt to the lawyer agent.
+Case-backed chat memory relies on persisted `uploaded`, `chat_attachment`, and `session_history` documents being available to the active document-processing path so later sessions can retrieve earlier inline uploads and refreshed transcript snapshots.
 
 - Mixed requests such as "review/update uploaded document and summarize it" are converted into an ordered internal task plan.
 - The task order follows the user message order.

--- a/examples/conversation_memory_minimal_demo.py
+++ b/examples/conversation_memory_minimal_demo.py
@@ -1,4 +1,4 @@
-"""Minimal runnable demo of session transcript persistence formatting.
+"""Minimal runnable demo of cross-session case memory formatting.
 
 Run:
     python examples/conversation_memory_minimal_demo.py
@@ -20,14 +20,56 @@ def build_session_history_document(messages: list[dict[str, str]]) -> str:
     return "\n".join(lines)
 
 
-if __name__ == "__main__":
-    sample_messages = [
-        {"role": "user", "content": "Please review my rental contract.", "agent_name": "User"},
-        {
-            "role": "assistant",
-            "content": "Sure. Upload the document and I will extract key clauses.",
-            "agent_name": "LawyerSlovakia",
-        },
-        {"role": "user", "content": "I uploaded it.", "agent_name": "User"},
+def build_case_memory_snapshot(
+    *,
+    session_documents: dict[str, list[str]],
+    session_messages: dict[str, list[dict[str, str]]],
+) -> dict[str, list[str]]:
+    processed_documents: list[str] = []
+    for session_id, filenames in session_documents.items():
+        processed_documents.extend(filenames)
+        processed_documents.append(f"session-{session_id}.txt")
+    seeded_messages = [
+        build_session_history_document(messages)
+        for _session_id, messages in session_messages.items()
     ]
-    print(build_session_history_document(sample_messages))
+    return {
+        "processed_documents": processed_documents,
+        "seeded_transcripts": seeded_messages,
+    }
+
+
+if __name__ == "__main__":
+    session_messages = {
+        "session-1": [
+            {"role": "user", "content": "Please review my rental contract.", "agent_name": "User"},
+            {
+                "role": "assistant",
+                "content": "Sure. Upload the document and I will extract key clauses.",
+                "agent_name": "LawyerSlovakia",
+            },
+        ],
+        "session-2": [
+            {"role": "user", "content": "Here is payment evidence from the second session.", "agent_name": "User"},
+            {
+                "role": "assistant",
+                "content": "I will compare it with the lease obligations.",
+                "agent_name": "LawyerSlovakia",
+            },
+        ],
+    }
+    session_documents = {
+        "session-1": ["lease-session-1.txt"],
+        "session-2": ["payment-session-2.txt"],
+    }
+    snapshot = build_case_memory_snapshot(
+        session_documents=session_documents,
+        session_messages=session_messages,
+    )
+    print("Processed documents visible to session 3:")
+    for filename in snapshot["processed_documents"]:
+        print(f"- {filename}")
+    print("\nSeeded transcripts visible to session 3:")
+    for transcript in snapshot["seeded_transcripts"]:
+        print("---")
+        print(transcript)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aijurisdictionagents"
-version = "1.0.260371"
+version = "1.0.260372"
 description = "Multi-agent legal discussion scaffold."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aijurisdictionagents"
-version = "1.0.260370"
+version = "1.0.260371"
 description = "Multi-agent legal discussion scaffold."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260370"
+__version__ = "1.0.260371"

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260371"
+__version__ = "1.0.260372"

--- a/src/aijurisdictionagents/api_db/store.py
+++ b/src/aijurisdictionagents/api_db/store.py
@@ -1253,7 +1253,8 @@ class ApiDatabaseStore:
                 SELECT doc_id, case_id, kind, version, storage_uri, original_filename, uploaded_by_user_id,
                        processing_status, processing_error, processed_at, created_at
                 FROM case_documents
-                WHERE kind IN ('uploaded', 'session_history') AND processing_status IN ('uploaded', 'failed')
+                WHERE kind IN ('uploaded', 'chat_attachment', 'session_history')
+                  AND processing_status IN ('uploaded', 'failed')
                 ORDER BY created_at ASC
                 LIMIT ?
                 """,

--- a/src/aijurisdictionagents/api_db/store.py
+++ b/src/aijurisdictionagents/api_db/store.py
@@ -1076,18 +1076,38 @@ class ApiDatabaseStore:
         uploaded_by_user_id: str | None = None,
     ) -> str:
         filename = f"session-{session_id}.txt"
+        payload = content.encode("utf-8")
         with self._connect() as conn:
             existing = self._fetchone(
                 conn,
                 """
-                SELECT doc_id FROM case_documents
+                SELECT doc_id, storage_uri FROM case_documents
                 WHERE case_id = ? AND kind = 'session_history' AND original_filename = ?
                 LIMIT 1
                 """,
                 (case_id, filename),
             )
             if existing is not None:
-                return str(existing[0])
+                doc_id = str(existing[0])
+                storage_uri = str(existing[1])
+                self._replace_stored_payload(storage_uri=storage_uri, payload=payload)
+                self._execute(
+                    conn,
+                    """
+                    UPDATE case_documents
+                    SET uploaded_by_user_id = ?, processing_status = 'uploaded',
+                        processing_error = NULL, processed_at = NULL
+                    WHERE doc_id = ?
+                    """,
+                    (uploaded_by_user_id, doc_id),
+                )
+                self._execute(
+                    conn,
+                    "UPDATE cases SET updated_at = ? WHERE case_id = ?",
+                    (_now_iso(), case_id),
+                )
+                conn.commit()
+                return doc_id
             row = self._fetchone(
                 conn,
                 """
@@ -1103,7 +1123,7 @@ class ApiDatabaseStore:
             kind="session_history",
             version=next_version,
             original_filename=filename,
-            payload=content.encode("utf-8"),
+            payload=payload,
             uploaded_by_user_id=uploaded_by_user_id,
         )
 
@@ -1388,6 +1408,11 @@ class ApiDatabaseStore:
             prefix = self.store_cloud.rstrip("/")
             return f"{prefix}/{relative_uri.as_posix()}"
         return relative_uri.as_posix()
+
+    def _replace_stored_payload(self, *, storage_uri: str, payload: bytes) -> None:
+        destination = self._resolve_storage_path(storage_uri)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(payload)
 
     def _resolve_storage_path(self, storage_uri: str) -> Path:
         normalized = storage_uri.strip()

--- a/tests/test_api_database_layer.py
+++ b/tests/test_api_database_layer.py
@@ -236,3 +236,44 @@ def test_postgres_store_init_does_not_create_local_dirs(tmp_path: Path) -> None:
 
     assert not db_path.parent.exists()
     assert not blob_root.exists()
+
+
+def test_list_unprocessed_case_documents_includes_chat_attachments(tmp_path: Path) -> None:
+    store = ApiDatabaseStore(
+        db_path=tmp_path / "api.sqlite3",
+        blob_root=tmp_path / "blob",
+    )
+    store.initialize()
+
+    user = store.create_user(
+        phone_number="+421900444333",
+        email="attachments@example.com",
+        password="secret",
+        first_name="Attachment",
+        last_name="User",
+    )
+    case = store.create_case(
+        user_id=user.user_id,
+        company_id=None,
+        title="Attachment processing",
+    )
+
+    chat_attachment_id = store.add_case_text_document(
+        case_id=case.case_id,
+        original_filename="lease.txt",
+        content="Lease clause from chat upload.",
+        uploaded_by_user_id=user.user_id,
+    )
+    session_history_id = store.add_case_session_history_document(
+        case_id=case.case_id,
+        session_id="session-1",
+        content="USER: first turn",
+        uploaded_by_user_id=user.user_id,
+    )
+
+    unprocessed_ids = {
+        document.doc_id for document in store.list_unprocessed_case_documents(limit=10)
+    }
+
+    assert chat_attachment_id in unprocessed_ids
+    assert session_history_id in unprocessed_ids


### PR DESCRIPTION
## Summary
- persist inline chat documents into case memory for reuse across later sessions
- refresh and reprocess per-session transcript documents so session history stays current
- extend retrieval, docs, and tests so session 3 can reuse messages and documents from sessions 1 and 2

## Testing
- C:\Users\maton\Projects\aijurisdictionagents\conda\python.exe -m pytest api/aijuristiction-api/tests/test_cases.py -k "session_history_document_reuses_same_doc_id_and_refreshes_payload"
- C:\Users\maton\Projects\aijurisdictionagents\conda\python.exe -m pytest api/aijuristiction-api/tests/test_chat.py -k "case_memory_reuses_previous_session_messages_and_documents or reply_persists_session_history_document_to_case"
- C:\Users\maton\Projects\aijurisdictionagents\conda\python.exe -m pytest api/aijuristiction-api/tests/test_cases.py api/aijuristiction-api/tests/test_chat.py -k "case_memory or session_history_document or case_history_paging_and_document_download or existing_case_history_is_seeded_into_new_reply_session"
