### PR TITLE
Add email scheduler deployment workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,7 +124,7 @@ DOCUMENT_PROCESSOR_OPTION=local
 # Azure API deployment reads these values from GitHub Environment variables/secrets.
 EMAIL_TRANSPORT=log
 EMAIL_SENDER=no-reply@jurisdigta.eu
-EMAIL_SMTP_HOST=mail.webhourse.sk
+EMAIL_SMTP_HOST=mail.webhouse.sk
 EMAIL_SMTP_PORT=587
 EMAIL_SMTP_USE_TLS=true
 EMAIL_SMTP_USERNAME=no-reply@jurisdigta.eu

--- a/.env.example
+++ b/.env.example
@@ -122,6 +122,9 @@ DOCUMENT_PROCESSOR_OPTION=local
 # Email notifications
 # Use EMAIL_TRANSPORT=log for local queue-only testing, or smtp to send via the configured mailbox.
 # Azure API deployment reads these values from GitHub Environment variables/secrets.
+# If you deploy a dedicated Azure email scheduler ACA Job, set EMAIL_SCHEDULER_ENABLED=false on the API app.
+# AZURE_EMAIL_SCHEDULER_JOB_NAME=email_scheduler
+# AZURE_EMAIL_SCHEDULER_CRON_EXPRESSION=*/5 * * * *
 EMAIL_TRANSPORT=log
 EMAIL_SENDER=no-reply@jurisdigta.eu
 EMAIL_SMTP_HOST=mail.webhouse.sk

--- a/.github/workflows/api_build_deploy.yml
+++ b/.github/workflows/api_build_deploy.yml
@@ -101,7 +101,7 @@ jobs:
       SYSTEM_EMBEDDING_MODEL: ${{ vars.SYSTEM_EMBEDDING_MODEL || 'all-MiniLM-L6-v2' }}
       EMAIL_TRANSPORT: ${{ vars.EMAIL_TRANSPORT || 'smtp' }}
       EMAIL_SENDER: ${{ vars.EMAIL_SENDER || 'no-reply@jurisdigta.eu' }}
-      EMAIL_SMTP_HOST: ${{ vars.EMAIL_SMTP_HOST || 'mail.webhourse.sk' }}
+      EMAIL_SMTP_HOST: ${{ vars.EMAIL_SMTP_HOST || 'mail.webhouse.sk' }}
       EMAIL_SMTP_PORT: ${{ vars.EMAIL_SMTP_PORT || '587' }}
       EMAIL_SMTP_USE_TLS: ${{ vars.EMAIL_SMTP_USE_TLS || 'true' }}
       EMAIL_SMTP_USERNAME: ${{ vars.EMAIL_SMTP_USERNAME || 'no-reply@jurisdigta.eu' }}
@@ -530,7 +530,7 @@ jobs:
             EMAIL_DB_LOCAL=/tmp/email.sqlite3
             EMAIL_TRANSPORT=${EMAIL_TRANSPORT:-smtp}
             EMAIL_SENDER=${EMAIL_SENDER:-no-reply@jurisdigta.eu}
-            EMAIL_SMTP_HOST=${EMAIL_SMTP_HOST:-mail.webhourse.sk}
+            EMAIL_SMTP_HOST=${EMAIL_SMTP_HOST:-mail.webhouse.sk}
             EMAIL_SMTP_PORT=${EMAIL_SMTP_PORT:-587}
             EMAIL_SMTP_USE_TLS=${EMAIL_SMTP_USE_TLS:-true}
             EMAIL_SMTP_USERNAME=${EMAIL_SMTP_USERNAME:-no-reply@jurisdigta.eu}

--- a/.github/workflows/email_build_deploy.yml
+++ b/.github/workflows/email_build_deploy.yml
@@ -1,0 +1,228 @@
+name: Email Scheduler Build and Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "api/aijuristiction-api/**"
+      - "pyproject.toml"
+      - "databases/api/email/**"
+      - "infra/scripts/deploy_email_scheduler.ps1"
+      - "infra/bicep/email_scheduler.job.bicep"
+      - ".github/workflows/email_build_deploy.yml"
+  pull_request:
+    paths:
+      - "api/aijuristiction-api/**"
+      - "pyproject.toml"
+      - "databases/api/email/**"
+      - "infra/scripts/deploy_email_scheduler.ps1"
+      - "infra/bicep/email_scheduler.job.bicep"
+      - ".github/workflows/email_build_deploy.yml"
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: "Deploy the email scheduler ACA job"
+        required: false
+        type: boolean
+        default: true
+      github_environment:
+        description: "GitHub Environment that contains Azure variables"
+        required: true
+        default: "dev"
+      image_tag:
+        description: "Optional image tag override. Defaults to the commit SHA."
+        required: false
+        default: ""
+
+jobs:
+  test_and_build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install root dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+
+      - name: Install API test dependencies
+        working-directory: api/aijuristiction-api
+        run: pip install -e .[dev]
+
+      - name: Run email scheduler tests
+        working-directory: api/aijuristiction-api
+        run: pytest tests/test_email_scheduler_job_main.py tests/test_users.py
+
+      - name: Build API Docker image for scheduler job
+        run: docker build -f api/aijuristiction-api/Dockerfile -t aijuristiction-api:${{ github.sha }} .
+
+  deploy_to_azure:
+    runs-on: windows-latest
+    needs: test_and_build
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.deploy)
+    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.github_environment || 'dev' }}
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+      AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
+      AZURE_CONTAINERAPPS_ENVIRONMENT: ${{ vars.AZURE_CONTAINERAPPS_ENVIRONMENT }}
+      AZURE_CONTAINER_REGISTRY: ${{ vars.AZURE_CONTAINER_REGISTRY }}
+      AZURE_MANAGED_IDENTITY_NAME: ${{ vars.AZURE_MANAGED_IDENTITY_NAME }}
+      AZURE_APPLICATION_INSIGHTS_NAME: ${{ vars.AZURE_APPLICATION_INSIGHTS_NAME }}
+      AZURE_POSTGRES_SERVER_NAME: ${{ vars.AZURE_POSTGRES_SERVER_NAME }}
+      AZURE_POSTGRES_DATABASE_NAME: ${{ vars.AZURE_POSTGRES_DATABASE_NAME }}
+      AZURE_POSTGRES_ADMIN_USERNAME: ${{ vars.AZURE_POSTGRES_ADMIN_USERNAME }}
+      AZURE_POSTGRES_ADMIN_PASSWORD: ${{ secrets.AZURE_POSTGRES_ADMIN_PASSWORD }}
+      AZURE_EMAIL_SCHEDULER_JOB_NAME: ${{ vars.AZURE_EMAIL_SCHEDULER_JOB_NAME || 'email_scheduler' }}
+      AZURE_EMAIL_SCHEDULER_CRON_EXPRESSION: ${{ vars.AZURE_EMAIL_SCHEDULER_CRON_EXPRESSION || '*/5 * * * *' }}
+      EMAIL_TRANSPORT: ${{ vars.EMAIL_TRANSPORT || 'smtp' }}
+      EMAIL_SENDER: ${{ vars.EMAIL_SENDER || 'no-reply@jurisdigta.eu' }}
+      EMAIL_SMTP_HOST: ${{ vars.EMAIL_SMTP_HOST || 'mail.webhouse.sk' }}
+      EMAIL_SMTP_PORT: ${{ vars.EMAIL_SMTP_PORT || '587' }}
+      EMAIL_SMTP_USE_TLS: ${{ vars.EMAIL_SMTP_USE_TLS || 'true' }}
+      EMAIL_SMTP_USERNAME: ${{ vars.EMAIL_SMTP_USERNAME || 'no-reply@jurisdigta.eu' }}
+      EMAIL_SMTP_PASSWORD: ${{ secrets.EMAIL_SMTP_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Validate required environment variables
+        shell: pwsh
+        run: |
+          $required = @(
+            "AZURE_CLIENT_ID",
+            "AZURE_TENANT_ID",
+            "AZURE_SUBSCRIPTION_ID",
+            "AZURE_RESOURCE_GROUP",
+            "AZURE_LOCATION",
+            "AZURE_CONTAINERAPPS_ENVIRONMENT",
+            "AZURE_CONTAINER_REGISTRY",
+            "AZURE_MANAGED_IDENTITY_NAME",
+            "AZURE_POSTGRES_SERVER_NAME",
+            "AZURE_POSTGRES_ADMIN_USERNAME",
+            "AZURE_POSTGRES_ADMIN_PASSWORD"
+          )
+
+          $missing = @()
+          foreach ($name in $required) {
+            if ([string]::IsNullOrWhiteSpace((Get-Item "env:$name" -ErrorAction SilentlyContinue).Value)) {
+              $missing += $name
+            }
+          }
+
+          if ($env:EMAIL_TRANSPORT.Trim().ToLowerInvariant() -eq "smtp" -and [string]::IsNullOrWhiteSpace($env:EMAIL_SMTP_PASSWORD)) {
+            $missing += "EMAIL_SMTP_PASSWORD"
+          }
+
+          if ($missing.Count -gt 0) {
+            $missing | ForEach-Object { Write-Host "Missing GitHub Environment variable or secret: $_" }
+            exit 1
+          }
+
+      - name: Normalize ACR settings
+        id: acr
+        shell: pwsh
+        run: |
+          $raw = "${env:AZURE_CONTAINER_REGISTRY}"
+          $lowered = $raw.Trim().ToLowerInvariant()
+          if ($lowered.EndsWith(".azurecr.io")) {
+            $lowered = $lowered.Substring(0, $lowered.Length - ".azurecr.io".Length)
+          }
+          $acrName = [regex]::Replace($lowered, "[^a-z0-9]", "")
+
+          if ([string]::IsNullOrWhiteSpace($acrName) -or $acrName.Length -lt 5 -or $acrName.Length -gt 50) {
+            Write-Error "Invalid ACR value '$raw'. Normalized name '$acrName' must be 5-50 alphanumeric characters."
+          }
+
+          if ($raw -ne $acrName -and $raw -ne "$acrName.azurecr.io") {
+            Write-Host "::warning::Normalized AZURE_CONTAINER_REGISTRY from '$raw' to '$acrName'."
+          }
+
+          "acr_name=$acrName" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Ensure Azure Container Apps extension
+        shell: pwsh
+        run: az extension add --name containerapp --upgrade --only-show-errors
+
+      - name: Allow GitHub runner IP on PostgreSQL firewall
+        shell: pwsh
+        run: |
+          $runnerIp = (Invoke-RestMethod -Uri "https://api.ipify.org").Trim()
+          az postgres flexible-server firewall-rule create `
+            --resource-group $env:AZURE_RESOURCE_GROUP `
+            --name $env:AZURE_POSTGRES_SERVER_NAME `
+            --rule-name "github-runner-${{ github.run_id }}" `
+            --start-ip-address $runnerIp `
+            --end-ip-address $runnerIp `
+            --only-show-errors `
+            --output none
+
+      - name: Install deployment dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Deploy email scheduler job
+        shell: pwsh
+        run: |
+          $imageTagInput = "${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}"
+          $imageTag = if ([string]::IsNullOrWhiteSpace($imageTagInput)) {
+            "${{ github.sha }}"
+          } else {
+            $imageTagInput
+          }
+
+          ./infra/scripts/deploy_email_scheduler.ps1 `
+            -SkipEnvFile `
+            -SubscriptionId $env:AZURE_SUBSCRIPTION_ID `
+            -ResourceGroupName $env:AZURE_RESOURCE_GROUP `
+            -Location $env:AZURE_LOCATION `
+            -ContainerAppEnvironmentName $env:AZURE_CONTAINERAPPS_ENVIRONMENT `
+            -JobName $env:AZURE_EMAIL_SCHEDULER_JOB_NAME `
+            -AcrName "${{ steps.acr.outputs.acr_name }}" `
+            -ManagedIdentityName $env:AZURE_MANAGED_IDENTITY_NAME `
+            -ApplicationInsightsName $env:AZURE_APPLICATION_INSIGHTS_NAME `
+            -PostgresServerName $env:AZURE_POSTGRES_SERVER_NAME `
+            -PostgresDatabaseName $env:AZURE_POSTGRES_DATABASE_NAME `
+            -PostgresAdminUsername $env:AZURE_POSTGRES_ADMIN_USERNAME `
+            -PostgresAdminPassword $env:AZURE_POSTGRES_ADMIN_PASSWORD `
+            -EmailTransport $env:EMAIL_TRANSPORT `
+            -EmailSender $env:EMAIL_SENDER `
+            -EmailSmtpHost $env:EMAIL_SMTP_HOST `
+            -EmailSmtpPort $env:EMAIL_SMTP_PORT `
+            -EmailSmtpUseTls $env:EMAIL_SMTP_USE_TLS `
+            -EmailSmtpUsername $env:EMAIL_SMTP_USERNAME `
+            -EmailSmtpPassword $env:EMAIL_SMTP_PASSWORD `
+            -CronExpression $env:AZURE_EMAIL_SCHEDULER_CRON_EXPRESSION `
+            -ImageTag $imageTag
+
+      - name: Remove GitHub runner firewall rule
+        if: always()
+        shell: pwsh
+        run: |
+          az postgres flexible-server firewall-rule delete `
+            --resource-group $env:AZURE_RESOURCE_GROUP `
+            --name $env:AZURE_POSTGRES_SERVER_NAME `
+            --rule-name "github-runner-${{ github.run_id }}" `
+            --yes `
+            --only-show-errors `
+            --output none

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,9 @@ Custom project skills:
 - `start-postgres` at `skills/start-postgres/SKILL.md`
   - Purpose: start or reuse the local PostgreSQL Docker instance and apply schema updates.
   - Script: `.\skills\start-postgres\scripts\start_postgres.ps1`
+- `start-email` at `skills/start-email/SKILL.md`
+  - Purpose: start and monitor the local email scheduler against the local API email outbox database.
+  - Script: `.\skills\start-email\scripts\start_email_scheduler.ps1`
 - `start-mobile` at `skills/start-mobile/SKILL.md`
   - Purpose: start and verify the local Flutter mobile app using the same skill name available on this machine.
   - Script: `.\skills\start-mobile-app\scripts\start_mobile_app.ps1`

--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -421,7 +421,7 @@ User and subscription endpoints support email notifications with configurable tr
 SMTP configuration (used when `EMAIL_TRANSPORT=smtp`):
 
 - `EMAIL_SENDER` (default: `no-reply@jurisdigta.eu`)
-- `EMAIL_SMTP_HOST` (default: `mail.webhourse.sk`)
+- `EMAIL_SMTP_HOST` (default: `mail.webhouse.sk`)
 - `EMAIL_SMTP_PORT` (default: `587`)
 - `EMAIL_SMTP_USE_TLS` (default: `true`)
 - `EMAIL_SMTP_USERNAME` (default: `EMAIL_SENDER`)

--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -411,7 +411,19 @@ Run scheduler as a separate process (recommended for ACA split deployment):
 python -m app.email_scheduler_main
 ```
 
-For API-only replicas set `EMAIL_SCHEDULER_ENABLED=false`; run exactly one scheduler replica/process with it enabled.
+Run a one-shot batch for the Azure Container Apps Job:
+
+```bash
+python -m app.email_scheduler_job_main
+```
+
+For local repo-managed startup, use:
+
+```powershell
+.\skills\start-email\scripts\start_email_scheduler.ps1 -Background
+```
+
+For API-only replicas set `EMAIL_SCHEDULER_ENABLED=false`; run exactly one scheduler replica/process or ACA Job with delivery enabled.
 
 User and subscription endpoints support email notifications with configurable transport:
 

--- a/api/aijuristiction-api/app/email_scheduler_job_main.py
+++ b/api/aijuristiction-api/app/email_scheduler_job_main.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import logging
+
+from app.logging_config import configure_logging
+from app.services.email_scheduler import EmailScheduler, scheduler_enabled
+
+logger = logging.getLogger("aijuristiction-api.email.scheduler-job")
+
+
+def main() -> int:
+    configure_logging()
+    if not scheduler_enabled():
+        logger.info("Email scheduler job is disabled by EMAIL_SCHEDULER_ENABLED")
+        return 0
+
+    scheduler = EmailScheduler.from_env()
+    processed = scheduler.run_once(limit=50)
+    logger.info("Email scheduler job finished | processed=%s", processed)
+    return processed
+
+
+if __name__ == "__main__":
+    main()

--- a/api/aijuristiction-api/app/services/email.py
+++ b/api/aijuristiction-api/app/services/email.py
@@ -9,7 +9,7 @@ from email.message import EmailMessage
 logger = logging.getLogger("aijuristiction-api.email")
 
 DEFAULT_EMAIL_SENDER = "no-reply@jurisdigta.eu"
-DEFAULT_SMTP_HOST = "mail.webhourse.sk"
+DEFAULT_SMTP_HOST = "mail.webhouse.sk"
 DEFAULT_SMTP_PORT = 587
 
 

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260386"
+version = "1.0.260387"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260387"
+version = "1.0.260388"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_email_scheduler_job_main.py
+++ b/api/aijuristiction-api/tests/test_email_scheduler_job_main.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from app import email_scheduler_job_main
+
+
+def test_job_main_skips_when_disabled(monkeypatch) -> None:
+    monkeypatch.setattr(email_scheduler_job_main, "configure_logging", lambda: None)
+    monkeypatch.setattr(email_scheduler_job_main, "scheduler_enabled", lambda: False)
+
+    class DisabledScheduler:
+        @classmethod
+        def from_env(cls):  # pragma: no cover - defensive assertion path
+            raise AssertionError("Scheduler should not be created when disabled")
+
+    monkeypatch.setattr(email_scheduler_job_main, "EmailScheduler", DisabledScheduler)
+
+    assert email_scheduler_job_main.main() == 0
+
+
+def test_job_main_processes_single_batch(monkeypatch) -> None:
+    monkeypatch.setattr(email_scheduler_job_main, "configure_logging", lambda: None)
+    monkeypatch.setattr(email_scheduler_job_main, "scheduler_enabled", lambda: True)
+
+    class FakeSchedulerInstance:
+        def __init__(self) -> None:
+            self.limits: list[int] = []
+
+        def run_once(self, *, limit: int = 50) -> int:
+            self.limits.append(limit)
+            return 3
+
+    scheduler = FakeSchedulerInstance()
+
+    class FakeScheduler:
+        @classmethod
+        def from_env(cls) -> FakeSchedulerInstance:
+            return scheduler
+
+    monkeypatch.setattr(email_scheduler_job_main, "EmailScheduler", FakeScheduler)
+
+    assert email_scheduler_job_main.main() == 3
+    assert scheduler.limits == [50]

--- a/api/aijuristiction-api/tests/test_users.py
+++ b/api/aijuristiction-api/tests/test_users.py
@@ -376,7 +376,7 @@ def test_email_service_defaults_to_jurisdigta_smtp(monkeypatch) -> None:
     service = EmailNotificationService.from_env()
 
     assert service.sender == "no-reply@jurisdigta.eu"
-    assert service.smtp_host == "mail.webhourse.sk"
+    assert service.smtp_host == "mail.webhouse.sk"
     assert service.smtp_port == 587
     assert service.smtp_username == "no-reply@jurisdigta.eu"
     assert service.smtp_password is None

--- a/api/chat-simulator-app/app/main.py
+++ b/api/chat-simulator-app/app/main.py
@@ -188,7 +188,7 @@ def _send_email_test(payload: EmailTestSendRequest) -> dict[str, Any]:
     written_email = _write_email_preview(message=message, template=payload.template, transport=transport)
 
     if transport == "smtp":
-        smtp_host = _first_non_empty(payload.smtp_host, os.getenv("EMAIL_SMTP_HOST"), "mail.webhourse.sk")
+        smtp_host = _first_non_empty(payload.smtp_host, os.getenv("EMAIL_SMTP_HOST"), "mail.webhouse.sk")
         smtp_port = payload.smtp_port or int(os.getenv("EMAIL_SMTP_PORT", "587"))
         smtp_username = _first_non_empty(payload.smtp_username, os.getenv("EMAIL_SMTP_USERNAME"), sender)
         smtp_password = _first_non_empty(payload.smtp_password, os.getenv("EMAIL_SMTP_PASSWORD"), "")

--- a/api/chat-simulator-app/static/email-tests.html
+++ b/api/chat-simulator-app/static/email-tests.html
@@ -30,7 +30,7 @@
         </div>
         <div>
           <label for="emailSmtpHost">SMTP host</label>
-          <input id="emailSmtpHost" value="mail.webhourse.sk" />
+          <input id="emailSmtpHost" value="mail.webhouse.sk" />
         </div>
         <div>
           <label for="emailSmtpPort">SMTP port</label>

--- a/docs/EMAIL_SETUP.md
+++ b/docs/EMAIL_SETUP.md
@@ -18,6 +18,33 @@ EMAIL_SMTP_PASSWORD=<set from environment or secret store>
 
 For local queue-only testing, keep `EMAIL_TRANSPORT=log`. The API still writes messages to the email outbox, but the scheduler logs the email instead of sending it.
 
+## Local scheduler
+
+Start the local email scheduler with the project skill:
+
+```powershell
+.\skills\start-email\scripts\start_email_scheduler.ps1 -Background
+```
+
+Default local PostgreSQL target:
+
+```env
+EMAIL_DB_OPTION=postgres
+EMAIL_DB_CLOUD=postgresql://postgres:postgres@127.0.0.1:5432/aijurisdiction
+```
+
+Background mode writes:
+
+- `runs/email-scheduler-local.log`
+- `runs/email-scheduler-local.err.log`
+- `runs/email-scheduler-local.pid`
+
+Stop it with:
+
+```powershell
+Stop-Process -Id (Get-Content .\runs\email-scheduler-local.pid) -Force
+```
+
 ## Azure deployment
 
 `API Build and Deploy` and `infra/scripts/deploy_api.ps1` pass email settings into the API Container App. In GitHub Environments, configure:
@@ -26,6 +53,23 @@ For local queue-only testing, keep `EMAIL_TRANSPORT=log`. The API still writes m
 - secret: `EMAIL_SMTP_PASSWORD`
 
 The deployment stores `EMAIL_SMTP_PASSWORD` as a Container Apps secret and injects it through `secretref:email-smtp-password`. It also sets `EMAIL_DB_OPTION=azure` and `EMAIL_DB_CLOUD=secretref:db-cloud` so the email outbox uses Azure PostgreSQL.
+
+## Azure email scheduler ACA job
+
+Use the dedicated workflow and deploy script when email delivery should run as a scheduled Azure Container Apps Job instead of inside the API process:
+
+- workflow: `.github/workflows/email_build_deploy.yml`
+- script: `infra/scripts/deploy_email_scheduler.ps1`
+- template: `infra/bicep/email_scheduler.job.bicep`
+
+Recommended GitHub Environment variables:
+
+- `AZURE_EMAIL_SCHEDULER_JOB_NAME=email_scheduler`
+- `AZURE_EMAIL_SCHEDULER_CRON_EXPRESSION=*/5 * * * *`
+
+The deploy path applies the PostgreSQL email schema migrations from `databases/api/email` before it updates the ACA Job, and the job runs `python -m app.email_scheduler_job_main` once per trigger.
+
+When this dedicated Azure job is deployed, set `EMAIL_SCHEDULER_ENABLED=false` on the API Container App so API replicas only enqueue emails and the scheduled job performs delivery.
 
 ## Test emails
 

--- a/docs/EMAIL_SETUP.md
+++ b/docs/EMAIL_SETUP.md
@@ -9,7 +9,7 @@ Set these values when real delivery is required:
 ```env
 EMAIL_TRANSPORT=smtp
 EMAIL_SENDER=no-reply@jurisdigta.eu
-EMAIL_SMTP_HOST=mail.webhourse.sk
+EMAIL_SMTP_HOST=mail.webhouse.sk
 EMAIL_SMTP_PORT=587
 EMAIL_SMTP_USE_TLS=true
 EMAIL_SMTP_USERNAME=no-reply@jurisdigta.eu

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -123,7 +123,7 @@ These are used by infrastructure deployment and API deployment workflows:
 | `DOCUMENT_PROCESSOR_OPTION` | API document-processing mode; Azure API deployments default to `azure`, while `local` is only for local/dev API runs without the ACA job |
 | `EMAIL_TRANSPORT` | API email transport. Use `smtp` for deployed email delivery; use `log` only for queue/log testing |
 | `EMAIL_SENDER` | Outbound sender address, default `no-reply@jurisdigta.eu` |
-| `EMAIL_SMTP_HOST` | SMTP host, default `mail.webhourse.sk` |
+| `EMAIL_SMTP_HOST` | SMTP host, default `mail.webhouse.sk` |
 | `EMAIL_SMTP_PORT` | SMTP port, default `587` |
 | `EMAIL_SMTP_USE_TLS` | SMTP STARTTLS flag, default `true` |
 | `EMAIL_SMTP_USERNAME` | SMTP username, default `no-reply@jurisdigta.eu` |
@@ -282,7 +282,7 @@ At minimum, you should expect these values to differ between `test` and `prod`:
 - `CORS_ALLOW_ORIGINS`
 - `EMAIL_TRANSPORT=smtp`
 - `EMAIL_SENDER=no-reply@jurisdigta.eu`
-- `EMAIL_SMTP_HOST=mail.webhourse.sk`
+- `EMAIL_SMTP_HOST=mail.webhouse.sk`
 - `EMAIL_SMTP_PORT=587`
 - `EMAIL_SMTP_USE_TLS=true`
 - `EMAIL_SMTP_USERNAME=no-reply@jurisdigta.eu`

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -127,7 +127,7 @@ These are used by infrastructure deployment and API deployment workflows:
 | `EMAIL_SMTP_PORT` | SMTP port, default `587` |
 | `EMAIL_SMTP_USE_TLS` | SMTP STARTTLS flag, default `true` |
 | `EMAIL_SMTP_USERNAME` | SMTP username, default `no-reply@jurisdigta.eu` |
-| `EMAIL_SCHEDULER_ENABLED` | Optional email scheduler toggle for API replicas, default `true` |
+| `EMAIL_SCHEDULER_ENABLED` | Optional email scheduler toggle for API replicas, default `true`; set `false` when a dedicated Azure email scheduler job is deployed |
 | `EMAIL_SCHEDULER_INTERVAL_SECONDS` | Optional scheduler interval, default `60` |
 | `CAR_VALIDATION_API_BASE_URL` | Optional vehicle validation API base URL, for example `https://www.databazavozidiel.sk`; leave unset to skip live car API checks |
 | `AZURE_POSTGRES_SKU_NAME` | Optional infra sizing value |
@@ -221,7 +221,45 @@ The laws collector workflow reuses these shared Azure deployment variables:
 - `AZURE_POSTGRES_ADMIN_USERNAME`
 - secret `AZURE_POSTGRES_ADMIN_PASSWORD`
 
-## 9. Configure Mobile Build Variables
+## 9. Configure Email Scheduler Job Variables
+
+These are used by the dedicated email scheduler deployment workflow:
+
+| Variable | Purpose |
+| --- | --- |
+| `AZURE_EMAIL_SCHEDULER_JOB_NAME` | Optional ACA job name for the email scheduler, default `email_scheduler` |
+| `AZURE_EMAIL_SCHEDULER_CRON_EXPRESSION` | Optional 5-field cron schedule for the email scheduler ACA job, default `*/5 * * * *`; legacy `0 */5 * * * *` values are normalized during deployment |
+| `EMAIL_TRANSPORT` | Email delivery transport for the job, normally `smtp` in Azure |
+| `EMAIL_SENDER` | Outbound sender address, default `no-reply@jurisdigta.eu` |
+| `EMAIL_SMTP_HOST` | SMTP host, default `mail.webhouse.sk` |
+| `EMAIL_SMTP_PORT` | SMTP port, default `587` |
+| `EMAIL_SMTP_USE_TLS` | SMTP STARTTLS flag, default `true` |
+| `EMAIL_SMTP_USERNAME` | SMTP username, default `no-reply@jurisdigta.eu` |
+
+Required secret when `EMAIL_TRANSPORT=smtp`:
+
+| Secret | Purpose |
+| --- | --- |
+| `EMAIL_SMTP_PASSWORD` | SMTP mailbox password used by the email scheduler ACA job |
+
+The email scheduler workflow reuses these shared Azure deployment variables:
+
+- `AZURE_CLIENT_ID`
+- `AZURE_TENANT_ID`
+- `AZURE_SUBSCRIPTION_ID`
+- `AZURE_RESOURCE_GROUP`
+- `AZURE_LOCATION`
+- `AZURE_CONTAINERAPPS_ENVIRONMENT`
+- `AZURE_CONTAINER_REGISTRY`
+- `AZURE_MANAGED_IDENTITY_NAME`
+- `AZURE_POSTGRES_SERVER_NAME`
+- `AZURE_POSTGRES_DATABASE_NAME`
+- `AZURE_POSTGRES_ADMIN_USERNAME`
+- secret `AZURE_POSTGRES_ADMIN_PASSWORD`
+
+Keep `EMAIL_SCHEDULER_ENABLED=false` on the API Container App when this dedicated email job is enabled, so API replicas only write to `email_outbox`.
+
+## 10. Configure Mobile Build Variables
 
 The mobile workflow reads the API base URL from the selected GitHub Environment.
 
@@ -244,7 +282,7 @@ Paste those values without extra whitespace. The mobile workflow trims accidenta
 line breaks, validates the keystore and alias with `keytool`, and warns early if
 the selected GitHub Environment contains stale or mismatched signing secrets.
 
-## 10. Populate `test` and `prod`
+## 11. Populate `test` and `prod`
 
 The fastest approach is:
 
@@ -286,10 +324,12 @@ At minimum, you should expect these values to differ between `test` and `prod`:
 - `EMAIL_SMTP_PORT=587`
 - `EMAIL_SMTP_USE_TLS=true`
 - `EMAIL_SMTP_USERNAME=no-reply@jurisdigta.eu`
+- `AZURE_EMAIL_SCHEDULER_JOB_NAME=email_scheduler`
+- `AZURE_EMAIL_SCHEDULER_CRON_EXPRESSION=*/5 * * * *`
 - secret `EMAIL_SMTP_PASSWORD`
 - `CAR_VALIDATION_API_BASE_URL` and secret `CAR_VALIDATION_API_KEY` when live vehicle checks should run in that environment
 
-## 11. Run the Workflows Against the New Environment
+## 12. Run the Workflows Against the New Environment
 
 Use manual workflow dispatch and set `github_environment` to `test` or `prod`.
 
@@ -300,20 +340,22 @@ Typical order:
 3. `API Build and Deploy`
 4. `Document Processor Build and Deploy`
 5. `Laws Collector Build and Deploy`
-6. `web_build_deploy`
-7. `mobile_flutter_build`
+6. `Email Scheduler Build and Deploy`
+7. `web_build_deploy`
+8. `mobile_flutter_build`
 
 Recommended deployed value:
 
 - `DOCUMENT_PROCESSOR_OPTION=azure` for `dev`, `test`, and `prod`
 - `SYSTEM_EMBEDDING_MODEL_OPTION=local` for `dev`, `test`, and `prod` unless you explicitly want Azure/OpenAI embeddings
 - Keep `DOCUMENT_PROCESSOR_OPTION=local` only in local workstation `.env` files when you want the API process to extract documents immediately without waiting for the ACA job
+- When `Email Scheduler Build and Deploy` is used, set `EMAIL_SCHEDULER_ENABLED=false` on the API Container App so the API only queues emails and the ACA job delivers them on schedule
 
 Observability note:
 
 - The API observability endpoint reuses `AZURE_LOG_ANALYTICS_WORKSPACE_NAME` and `AZURE_MANAGED_IDENTITY_NAME` directly. Do not add separate `APPLICATIONINSIGHTS_*` runtime variables for that feature.
 
-## 12. Current Workflow Defaults
+## 13. Current Workflow Defaults
 
 Some workflows default to `dev` for push-based execution.
 
@@ -326,9 +368,10 @@ That means:
 - `API Build and Deploy` injects SMTP settings and vehicle validation settings into the API Container App; `EMAIL_SMTP_PASSWORD` and `CAR_VALIDATION_API_KEY` are stored as Container App secrets.
 - `API Build and Deploy` fails during environment validation when `EMAIL_TRANSPORT=smtp` and `EMAIL_SMTP_PASSWORD` is empty.
 - `Laws Collector Build and Deploy` now deploys automatically to `dev` on `push` to `main` after its tests/build pass
+- `Email Scheduler Build and Deploy` deploys the dedicated ACA Job to `dev` on `push` to `main` when API/email scheduler files change
 - `test` and `prod` remain manual `workflow_dispatch` targets unless a workflow is explicitly changed to auto-deploy them
 
-## 13. Quick Validation Checklist
+## 14. Quick Validation Checklist
 
 After setup, verify:
 
@@ -340,6 +383,7 @@ After setup, verify:
 - required Azure variables are set in both environments
 - required secrets are set in both environments
 - `EMAIL_SMTP_PASSWORD` is set when `EMAIL_TRANSPORT=smtp`
+- `AZURE_EMAIL_SCHEDULER_JOB_NAME` and `AZURE_EMAIL_SCHEDULER_CRON_EXPRESSION` are set when the dedicated email ACA job should run
 - optional `CAR_VALIDATION_API_BASE_URL` and `CAR_VALIDATION_API_KEY` are set together when live vehicle validation should be enabled
 - `workflow_dispatch` works with `github_environment=test`
 - `workflow_dispatch` works with `github_environment=prod`

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -113,6 +113,6 @@ if __name__ == "__main__":
     print("=== Email delivery setup demo ===")
     print("Public contact email: info@jurisdigta.eu")
     print("SMTP sender: no-reply@jurisdigta.eu")
-    print("SMTP server: mail.webhourse.sk:587 with STARTTLS")
+    print("SMTP server: mail.webhouse.sk:587 with STARTTLS")
     print("SMTP password env: EMAIL_SMTP_PASSWORD")
     print("Chat simulator email test page: http://127.0.0.1:8090/email-tests")

--- a/infra/README.md
+++ b/infra/README.md
@@ -34,6 +34,7 @@ ACA resources created by repository deployments:
 - Frontend Container App: `AZURE_FRONTEND_CONTAINER_APP_NAME`
 - Laws Collector Container App: `AZURE_LAWS_COLLECTOR_CONTAINER_APP_NAME`
 - Document Processor ACA Job: `AZURE_DOCUMENT_PROCESSOR_JOB_NAME`
+- Email Scheduler ACA Job: `AZURE_EMAIL_SCHEDULER_JOB_NAME`
 
 ## Prerequisites
 
@@ -205,6 +206,8 @@ The deploy sets `EMAIL_DB_OPTION=azure` and `EMAIL_DB_CLOUD=secretref:db-cloud` 
 uses the same Azure PostgreSQL deployment as the API. Vehicle validation deployment settings are
 handled the same way: `CAR_VALIDATION_API_BASE_URL` is a normal environment variable, while
 `CAR_VALIDATION_API_KEY` is stored as `car-validation-api-key` and exposed by secret reference.
+If you deploy the dedicated email scheduler ACA Job, set `EMAIL_SCHEDULER_ENABLED=false` on the API
+Container App so API replicas only enqueue emails and the scheduled job performs delivery.
 
 If your `.env` is at the repo root, no extra flag is needed. To use a different file:
 
@@ -451,6 +454,64 @@ Required GitHub Environment variables for frontend deployment:
 
 For a repo-level checklist to create additional GitHub Environments such as `test`
 and `prod`, see `docs/GITHUB_ENVIRONMENTS.md`.
+
+## Deploy email scheduler ACA job
+
+A dedicated deployment script and Bicep template are available for the email scheduler:
+
+- Script: `infra/scripts/deploy_email_scheduler.ps1`
+- Template: `infra/bicep/email_scheduler.job.bicep`
+
+The deployment builds `api/aijuristiction-api/Dockerfile`, publishes the image to ACR, applies the
+email PostgreSQL schema migrations from `databases/api/email`, and creates or updates a scheduled
+Azure Container Apps Job that runs `python -m app.email_scheduler_job_main`.
+
+Use this dedicated job when the deployed API should only enqueue emails. In that setup, set
+`EMAIL_SCHEDULER_ENABLED=false` on the API Container App.
+
+```powershell
+./infra/scripts/deploy_email_scheduler.ps1 \
+  -SubscriptionId "<subscription-id>" \
+  -ResourceGroupName "<resource-group>" \
+  -Location "westeurope" \
+  -ContainerAppEnvironmentName "<container-app-env-name>" \
+  -JobName "email_scheduler" \
+  -AcrName "<acr-name>" \
+  -ManagedIdentityName "<managed-identity-name>" \
+  -PostgresServerName "<postgres-server-name>" \
+  -PostgresDatabaseName "aijurisdiction" \
+  -PostgresAdminUsername "<postgres-admin-user>" \
+  -PostgresAdminPassword "<postgres-admin-password>" \
+  -CronExpression "*/5 * * * *" \
+  -ImageTag "latest"
+```
+
+GitHub Actions workflow:
+
+- Workflow file: `.github/workflows/email_build_deploy.yml`
+- Push to `main` for API/email scheduler changes: runs focused API tests, validates the Docker image build, and deploys to the `dev` GitHub Environment
+- Pull requests: run tests and Docker build only
+- Manual run: supports `deploy=true|false`, custom GitHub Environment, and optional image tag override
+- The deploy job temporarily opens the GitHub runner IP on Azure PostgreSQL, installs Python dependencies, applies `python scripts/databases/apply_db_migrations.py --project email`, and then deploys the ACA job
+
+Required GitHub Environment variables/secrets for deployment:
+
+- Variables: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_RESOURCE_GROUP`, `AZURE_LOCATION`, `AZURE_CONTAINERAPPS_ENVIRONMENT`, `AZURE_CONTAINER_REGISTRY`, `AZURE_MANAGED_IDENTITY_NAME`, `AZURE_POSTGRES_SERVER_NAME`, `AZURE_POSTGRES_DATABASE_NAME`, `AZURE_POSTGRES_ADMIN_USERNAME`
+- Variables: `EMAIL_TRANSPORT`, `EMAIL_SENDER`, `EMAIL_SMTP_HOST`, `EMAIL_SMTP_PORT`, `EMAIL_SMTP_USE_TLS`, `EMAIL_SMTP_USERNAME`
+- Secrets: `AZURE_POSTGRES_ADMIN_PASSWORD`
+- Secret: `EMAIL_SMTP_PASSWORD` when `EMAIL_TRANSPORT=smtp`
+- Optional variables: `AZURE_APPLICATION_INSIGHTS_NAME`, `AZURE_EMAIL_SCHEDULER_JOB_NAME`, `AZURE_EMAIL_SCHEDULER_CRON_EXPRESSION`
+
+Recommended GitHub Environment values:
+
+- `AZURE_EMAIL_SCHEDULER_JOB_NAME=email_scheduler`
+- `AZURE_EMAIL_SCHEDULER_CRON_EXPRESSION=*/5 * * * *`
+- `EMAIL_TRANSPORT=smtp`
+- `EMAIL_SENDER=no-reply@jurisdigta.eu`
+- `EMAIL_SMTP_HOST=mail.webhouse.sk`
+- `EMAIL_SMTP_PORT=587`
+- `EMAIL_SMTP_USE_TLS=true`
+- `EMAIL_SMTP_USERNAME=no-reply@jurisdigta.eu`
 
 ## Deploy laws collector ACA job
 

--- a/infra/bicep/email_scheduler.job.bicep
+++ b/infra/bicep/email_scheduler.job.bicep
@@ -1,0 +1,207 @@
+param location string = resourceGroup().location
+param managedEnvironmentName string
+param jobName string = 'email_scheduler'
+param acrName string
+param managedIdentityName string
+param image string
+param postgresServerName string
+param postgresDatabaseName string = 'aijurisdiction'
+param postgresAdminUsername string
+@secure()
+param postgresAdminPassword string
+@secure()
+param postgresConnectionString string = ''
+@secure()
+param applicationInsightsConnectionString string = ''
+param emailTransport string = 'smtp'
+param emailSender string = 'no-reply@jurisdigta.eu'
+param emailSmtpHost string = 'mail.webhouse.sk'
+param emailSmtpPort string = '587'
+param emailSmtpUseTls string = 'true'
+param emailSmtpUsername string = 'no-reply@jurisdigta.eu'
+@secure()
+param emailSmtpPassword string = ''
+param cronExpression string = '*/5 * * * *'
+param replicaTimeout int = 600
+param replicaRetryLimit int = 1
+param parallelism int = 1
+param completions int = 1
+param tags object = {}
+
+resource managedEnvironment 'Microsoft.App/managedEnvironments@2024-03-01' existing = {
+  name: managedEnvironmentName
+}
+
+resource acr 'Microsoft.ContainerRegistry/registries@2023-07-01' existing = {
+  name: acrName
+}
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: managedIdentityName
+}
+
+resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' existing = {
+  name: postgresServerName
+}
+
+resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, managedIdentity.id, 'AcrPull')
+  scope: acr
+  properties: {
+    principalId: managedIdentity.properties.principalId
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      '7f951dda-4ed3-4680-a7ca-43fe172d538d'
+    )
+    principalType: 'ServicePrincipal'
+  }
+}
+
+var emailSchedulerSecrets = concat(
+  [
+    {
+      name: 'scheduler-db-cloud'
+      value: empty(postgresConnectionString)
+        ? 'postgresql://${postgresAdminUsername}:${postgresAdminPassword}@${postgresServer.name}.postgres.database.azure.com:5432/${postgresDatabaseName}?sslmode=require'
+        : postgresConnectionString
+    }
+  ],
+  !empty(emailSmtpPassword)
+    ? [
+        {
+          name: 'email-smtp-password'
+          value: emailSmtpPassword
+        }
+      ]
+    : [],
+  !empty(applicationInsightsConnectionString)
+    ? [
+        {
+          name: 'applicationinsights-connection-string'
+          value: applicationInsightsConnectionString
+        }
+      ]
+    : []
+)
+
+var emailSchedulerEnv = concat(
+  [
+    {
+      name: 'EMAIL_DB_OPTION'
+      value: 'azure'
+    }
+    {
+      name: 'EMAIL_DB_CLOUD'
+      secretRef: 'scheduler-db-cloud'
+    }
+    {
+      name: 'EMAIL_DB_LOCAL'
+      value: '/tmp/email.sqlite3'
+    }
+    {
+      name: 'EMAIL_TRANSPORT'
+      value: emailTransport
+    }
+    {
+      name: 'EMAIL_SENDER'
+      value: emailSender
+    }
+    {
+      name: 'EMAIL_SMTP_HOST'
+      value: emailSmtpHost
+    }
+    {
+      name: 'EMAIL_SMTP_PORT'
+      value: emailSmtpPort
+    }
+    {
+      name: 'EMAIL_SMTP_USE_TLS'
+      value: emailSmtpUseTls
+    }
+    {
+      name: 'EMAIL_SMTP_USERNAME'
+      value: emailSmtpUsername
+    }
+    {
+      name: 'EMAIL_SCHEDULER_ENABLED'
+      value: 'true'
+    }
+    {
+      name: 'OTEL_SERVICE_NAME'
+      value: 'email_scheduler'
+    }
+  ],
+  !empty(emailSmtpPassword)
+    ? [
+        {
+          name: 'EMAIL_SMTP_PASSWORD'
+          secretRef: 'email-smtp-password'
+        }
+      ]
+    : [],
+  !empty(applicationInsightsConnectionString)
+    ? [
+        {
+          name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+          secretRef: 'applicationinsights-connection-string'
+        }
+      ]
+    : []
+)
+
+resource emailSchedulerJob 'Microsoft.App/jobs@2024-03-01' = {
+  name: jobName
+  location: location
+  tags: tags
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${managedIdentity.id}': {}
+    }
+  }
+  properties: {
+    environmentId: managedEnvironment.id
+    configuration: {
+      triggerType: 'Schedule'
+      scheduleTriggerConfig: {
+        cronExpression: cronExpression
+        parallelism: parallelism
+        replicaCompletionCount: completions
+      }
+      replicaTimeout: replicaTimeout
+      replicaRetryLimit: replicaRetryLimit
+      registries: [
+        {
+          server: acr.properties.loginServer
+          identity: managedIdentity.id
+        }
+      ]
+      secrets: emailSchedulerSecrets
+    }
+    template: {
+      containers: [
+        {
+          name: 'email-scheduler'
+          image: image
+          command: [
+            'python'
+          ]
+          args: [
+            '-m'
+            'app.email_scheduler_job_main'
+          ]
+          resources: {
+            cpu: json('0.25')
+            memory: '0.5Gi'
+          }
+          env: emailSchedulerEnv
+        }
+      ]
+    }
+  }
+  dependsOn: [
+    acrPullRoleAssignment
+  ]
+}
+
+output jobName string = emailSchedulerJob.name

--- a/infra/scripts/deploy_email_scheduler.ps1
+++ b/infra/scripts/deploy_email_scheduler.ps1
@@ -1,0 +1,337 @@
+[CmdletBinding()]
+param(
+    [string]$SubscriptionId,
+    [string]$ResourceGroupName,
+    [string]$Location,
+    [string]$ContainerAppEnvironmentName,
+    [string]$JobName = "email_scheduler",
+    [string]$AcrName,
+    [string]$ManagedIdentityName,
+    [string]$PostgresServerName,
+    [string]$PostgresDatabaseName = "aijurisdiction",
+    [string]$PostgresAdminUsername,
+    [string]$PostgresAdminPassword,
+    [string]$ApplicationInsightsName,
+    [string]$EmailTransport = "smtp",
+    [string]$EmailSender = "no-reply@jurisdigta.eu",
+    [string]$EmailSmtpHost = "mail.webhouse.sk",
+    [string]$EmailSmtpPort = "587",
+    [string]$EmailSmtpUseTls = "true",
+    [string]$EmailSmtpUsername = "no-reply@jurisdigta.eu",
+    [string]$EmailSmtpPassword = "",
+    [string]$CronExpression = "*/5 * * * *",
+    [string]$ImageTag = "latest",
+    [string]$EnvFilePath = ".env",
+    [switch]$SkipEnvFile
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Assert-ToolInstalled {
+    param([Parameter(Mandatory = $true)][string]$ToolName)
+    if (-not (Get-Command $ToolName -ErrorAction SilentlyContinue)) {
+        throw "Missing required tool '$ToolName'."
+    }
+}
+
+function Get-ValueFromEnvFile {
+    param([string]$Path, [string]$Key)
+    if (-not (Test-Path -Path $Path)) { return "" }
+    $pattern = "^\s*$Key=(?<value>.*)$"
+    $line = Get-Content -Path $Path | Where-Object { $_ -match $pattern } | Select-Object -First 1
+    if (-not $line) { return "" }
+    $value = [regex]::Match($line, $pattern).Groups["value"].Value.Trim()
+    if (($value.StartsWith("'") -and $value.EndsWith("'")) -or ($value.StartsWith('"') -and $value.EndsWith('"'))) {
+        if ($value.Length -ge 2) { $value = $value.Substring(1, $value.Length - 2) }
+    }
+    return $value
+}
+
+function Resolve-InputValue {
+    param([string]$ExplicitValue, [string]$EnvFileValue, [string]$EnvironmentValue)
+    if (-not [string]::IsNullOrWhiteSpace($ExplicitValue)) { return $ExplicitValue }
+    if (-not [string]::IsNullOrWhiteSpace($EnvFileValue)) { return $EnvFileValue }
+    return $EnvironmentValue
+}
+
+function Require-Value {
+    param([string]$Name, [string]$Value)
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        throw "$Name is required. Pass parameter, set in .env, or export env var."
+    }
+}
+
+function Restore-EnvVar {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [AllowNull()]
+        [string]$PreviousValue
+    )
+
+    if ($null -eq $PreviousValue) {
+        Remove-Item "Env:$Name" -ErrorAction SilentlyContinue
+        return
+    }
+
+    Set-Item -Path "Env:$Name" -Value $PreviousValue
+}
+
+function Convert-ToPostgresConnectionString {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$HostName,
+        [Parameter(Mandatory = $true)]
+        [string]$DatabaseName,
+        [Parameter(Mandatory = $true)]
+        [string]$AdminUsername,
+        [Parameter(Mandatory = $true)]
+        [string]$AdminPassword
+    )
+
+    $normalizedHostName = $HostName.Trim().ToLowerInvariant()
+    if (-not $normalizedHostName.EndsWith(".postgres.database.azure.com")) {
+        $normalizedHostName = "${normalizedHostName}.postgres.database.azure.com"
+    }
+
+    $encodedUser = [System.Uri]::EscapeDataString($AdminUsername)
+    $encodedPassword = [System.Uri]::EscapeDataString($AdminPassword)
+    return "postgresql://${encodedUser}:${encodedPassword}@${normalizedHostName}:5432/${DatabaseName}?sslmode=require"
+}
+
+function Resolve-AcaCronExpression {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [Parameter(Mandatory = $true)]
+        [string]$Value,
+        [Parameter(Mandatory = $true)]
+        [string]$DefaultValue
+    )
+
+    $resolved = if ([string]::IsNullOrWhiteSpace($Value)) { $DefaultValue } else { $Value.Trim() }
+    $parts = @($resolved -split '\s+' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+
+    if ($parts.Count -eq 6) {
+        if ($parts[0] -ne "0") {
+            throw "$Name must use a 5-field ACA cron expression. If a 6-field value is provided, the first field must be 0 seconds."
+        }
+
+        $resolved = ($parts[1..5] -join ' ')
+        Write-Host "Normalized $Name from 6 fields to ACA 5-field cron: $resolved"
+        $parts = @($resolved -split '\s+')
+    }
+
+    if ($parts.Count -ne 5) {
+        throw "$Name must be a 5-field ACA cron expression, for example '*/5 * * * *'."
+    }
+
+    return ($parts -join ' ')
+}
+
+function Test-ResourceExistsInGroup {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ResourceGroupName,
+        [Parameter(Mandatory = $true)]
+        [string]$ResourceName,
+        [Parameter(Mandatory = $true)]
+        [string]$ResourceType
+    )
+
+    az resource show `
+        --resource-group $ResourceGroupName `
+        --name $ResourceName `
+        --resource-type $ResourceType `
+        --query id `
+        --output tsv 2>$null | Out-Null
+
+    return ($LASTEXITCODE -eq 0)
+}
+
+function Write-WorkflowSummary {
+    param([Parameter(Mandatory = $true)][string[]]$Lines)
+    if ([string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) { return }
+    $nonEmptyLines = @($Lines | Where-Object { $_ -ne $null })
+    (($nonEmptyLines -join [Environment]::NewLine) + [Environment]::NewLine + [Environment]::NewLine) |
+        Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+}
+
+Assert-ToolInstalled -ToolName "az"
+Assert-ToolInstalled -ToolName "python"
+
+$envSubscriptionId = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_SUBSCRIPTION_ID" }
+$envResourceGroup = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_RESOURCE_GROUP" }
+$envLocation = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_LOCATION" }
+$envContainerEnv = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_CONTAINERAPPS_ENVIRONMENT" }
+$envAcr = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_CONTAINER_REGISTRY" }
+$envIdentity = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_MANAGED_IDENTITY_NAME" }
+$envPgServer = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_POSTGRES_SERVER_NAME" }
+$envPgDb = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_POSTGRES_DATABASE_NAME" }
+$envPgUser = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_POSTGRES_ADMIN_USERNAME" }
+$envPgPass = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_POSTGRES_ADMIN_PASSWORD" }
+$envApplicationInsightsName = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_APPLICATION_INSIGHTS_NAME" }
+$envEmailTransport = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "EMAIL_TRANSPORT" }
+$envEmailSender = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "EMAIL_SENDER" }
+$envEmailSmtpHost = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "EMAIL_SMTP_HOST" }
+$envEmailSmtpPort = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "EMAIL_SMTP_PORT" }
+$envEmailSmtpUseTls = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "EMAIL_SMTP_USE_TLS" }
+$envEmailSmtpUsername = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "EMAIL_SMTP_USERNAME" }
+$envEmailSmtpPassword = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "EMAIL_SMTP_PASSWORD" }
+$envJobName = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_EMAIL_SCHEDULER_JOB_NAME" }
+$envCronExpression = if ($SkipEnvFile) { "" } else { Get-ValueFromEnvFile -Path $EnvFilePath -Key "AZURE_EMAIL_SCHEDULER_CRON_EXPRESSION" }
+
+$SubscriptionId = Resolve-InputValue -ExplicitValue $SubscriptionId -EnvFileValue $envSubscriptionId -EnvironmentValue $env:AZURE_SUBSCRIPTION_ID
+$ResourceGroupName = Resolve-InputValue -ExplicitValue $ResourceGroupName -EnvFileValue $envResourceGroup -EnvironmentValue $env:AZURE_RESOURCE_GROUP
+$Location = Resolve-InputValue -ExplicitValue $Location -EnvFileValue $envLocation -EnvironmentValue $env:AZURE_LOCATION
+$ContainerAppEnvironmentName = Resolve-InputValue -ExplicitValue $ContainerAppEnvironmentName -EnvFileValue $envContainerEnv -EnvironmentValue $env:AZURE_CONTAINERAPPS_ENVIRONMENT
+$JobName = Resolve-InputValue -ExplicitValue $JobName -EnvFileValue $envJobName -EnvironmentValue $env:AZURE_EMAIL_SCHEDULER_JOB_NAME
+$AcrName = Resolve-InputValue -ExplicitValue $AcrName -EnvFileValue $envAcr -EnvironmentValue $env:AZURE_CONTAINER_REGISTRY
+$ManagedIdentityName = Resolve-InputValue -ExplicitValue $ManagedIdentityName -EnvFileValue $envIdentity -EnvironmentValue $env:AZURE_MANAGED_IDENTITY_NAME
+$PostgresServerName = Resolve-InputValue -ExplicitValue $PostgresServerName -EnvFileValue $envPgServer -EnvironmentValue $env:AZURE_POSTGRES_SERVER_NAME
+$PostgresDatabaseName = Resolve-InputValue -ExplicitValue $PostgresDatabaseName -EnvFileValue $envPgDb -EnvironmentValue $env:AZURE_POSTGRES_DATABASE_NAME
+$PostgresAdminUsername = Resolve-InputValue -ExplicitValue $PostgresAdminUsername -EnvFileValue $envPgUser -EnvironmentValue $env:AZURE_POSTGRES_ADMIN_USERNAME
+$PostgresAdminPassword = Resolve-InputValue -ExplicitValue $PostgresAdminPassword -EnvFileValue $envPgPass -EnvironmentValue $env:AZURE_POSTGRES_ADMIN_PASSWORD
+$ApplicationInsightsName = Resolve-InputValue -ExplicitValue $ApplicationInsightsName -EnvFileValue $envApplicationInsightsName -EnvironmentValue $env:AZURE_APPLICATION_INSIGHTS_NAME
+$EmailTransport = Resolve-InputValue -ExplicitValue $EmailTransport -EnvFileValue $envEmailTransport -EnvironmentValue $env:EMAIL_TRANSPORT
+$EmailSender = Resolve-InputValue -ExplicitValue $EmailSender -EnvFileValue $envEmailSender -EnvironmentValue $env:EMAIL_SENDER
+$EmailSmtpHost = Resolve-InputValue -ExplicitValue $EmailSmtpHost -EnvFileValue $envEmailSmtpHost -EnvironmentValue $env:EMAIL_SMTP_HOST
+$EmailSmtpPort = Resolve-InputValue -ExplicitValue $EmailSmtpPort -EnvFileValue $envEmailSmtpPort -EnvironmentValue $env:EMAIL_SMTP_PORT
+$EmailSmtpUseTls = Resolve-InputValue -ExplicitValue $EmailSmtpUseTls -EnvFileValue $envEmailSmtpUseTls -EnvironmentValue $env:EMAIL_SMTP_USE_TLS
+$EmailSmtpUsername = Resolve-InputValue -ExplicitValue $EmailSmtpUsername -EnvFileValue $envEmailSmtpUsername -EnvironmentValue $env:EMAIL_SMTP_USERNAME
+$EmailSmtpPassword = Resolve-InputValue -ExplicitValue $EmailSmtpPassword -EnvFileValue $envEmailSmtpPassword -EnvironmentValue $env:EMAIL_SMTP_PASSWORD
+$CronExpression = Resolve-InputValue -ExplicitValue $CronExpression -EnvFileValue $envCronExpression -EnvironmentValue $env:AZURE_EMAIL_SCHEDULER_CRON_EXPRESSION
+
+if ([string]::IsNullOrWhiteSpace($Location)) { $Location = "westeurope" }
+if ([string]::IsNullOrWhiteSpace($JobName)) { $JobName = "email_scheduler" }
+if ([string]::IsNullOrWhiteSpace($PostgresDatabaseName)) { $PostgresDatabaseName = "aijurisdiction" }
+if ([string]::IsNullOrWhiteSpace($EmailTransport)) { $EmailTransport = "smtp" }
+if ([string]::IsNullOrWhiteSpace($EmailSender)) { $EmailSender = "no-reply@jurisdigta.eu" }
+if ([string]::IsNullOrWhiteSpace($EmailSmtpHost)) { $EmailSmtpHost = "mail.webhouse.sk" }
+if ([string]::IsNullOrWhiteSpace($EmailSmtpPort)) { $EmailSmtpPort = "587" }
+if ([string]::IsNullOrWhiteSpace($EmailSmtpUseTls)) { $EmailSmtpUseTls = "true" }
+if ([string]::IsNullOrWhiteSpace($EmailSmtpUsername)) { $EmailSmtpUsername = "no-reply@jurisdigta.eu" }
+$CronExpression = Resolve-AcaCronExpression -Name "CronExpression" -Value $CronExpression -DefaultValue "*/5 * * * *"
+
+Require-Value -Name "SubscriptionId" -Value $SubscriptionId
+Require-Value -Name "ResourceGroupName" -Value $ResourceGroupName
+Require-Value -Name "Location" -Value $Location
+Require-Value -Name "ContainerAppEnvironmentName" -Value $ContainerAppEnvironmentName
+Require-Value -Name "AcrName" -Value $AcrName
+Require-Value -Name "ManagedIdentityName" -Value $ManagedIdentityName
+Require-Value -Name "PostgresServerName" -Value $PostgresServerName
+Require-Value -Name "PostgresDatabaseName" -Value $PostgresDatabaseName
+Require-Value -Name "PostgresAdminUsername" -Value $PostgresAdminUsername
+Require-Value -Name "PostgresAdminPassword" -Value $PostgresAdminPassword
+if ($EmailTransport.Trim().ToLowerInvariant() -eq "smtp") {
+    Require-Value -Name "EmailSmtpPassword" -Value $EmailSmtpPassword
+}
+
+az account set --subscription $SubscriptionId | Out-Null
+$resourceGroupExists = az group exists --name $ResourceGroupName --output tsv
+if ($resourceGroupExists -eq "true") {
+    Write-Host "Resource group '$ResourceGroupName' already exists. Skipping creation."
+}
+else {
+    Write-Host "Creating resource group '$ResourceGroupName' in '$Location'..."
+    az group create --name $ResourceGroupName --location $Location --only-show-errors --output none
+}
+
+$jobExistedBeforeDeployment = Test-ResourceExistsInGroup `
+    -ResourceGroupName $ResourceGroupName `
+    -ResourceName $JobName `
+    -ResourceType "Microsoft.App/jobs"
+
+$imageRepository = "aijuristiction-api"
+$image = "$AcrName.azurecr.io/$imageRepository`:$ImageTag"
+$dbCloud = Convert-ToPostgresConnectionString `
+    -HostName $PostgresServerName `
+    -DatabaseName $PostgresDatabaseName `
+    -AdminUsername $PostgresAdminUsername `
+    -AdminPassword $PostgresAdminPassword
+
+$applicationInsightsConnectionString = ""
+if (-not [string]::IsNullOrWhiteSpace($ApplicationInsightsName)) {
+    $applicationInsightsConnectionString = az monitor app-insights component show `
+      --app $ApplicationInsightsName `
+      --resource-group $ResourceGroupName `
+      --query connectionString `
+      --output tsv 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        $applicationInsightsConnectionString = ""
+    }
+}
+
+Write-Host "Applying email schema migrations to Azure PostgreSQL..."
+$previousDbOption = $env:DB_OPTION
+$previousDbCloud = $env:DB_CLOUD
+try {
+    $env:DB_OPTION = "azure"
+    $env:DB_CLOUD = $dbCloud
+    python "scripts/databases/apply_db_migrations.py" --project email
+    if ($LASTEXITCODE -ne 0) {
+        throw "Email schema migration failed for database '$PostgresDatabaseName'."
+    }
+}
+finally {
+    Restore-EnvVar -Name "DB_OPTION" -PreviousValue $previousDbOption
+    Restore-EnvVar -Name "DB_CLOUD" -PreviousValue $previousDbCloud
+}
+
+Write-Host "Building email scheduler image in ACR: $image"
+az acr build `
+  --registry $AcrName `
+  --image "$imageRepository`:$ImageTag" `
+  --file "api/aijuristiction-api/Dockerfile" `
+  . `
+  --no-logs `
+  --only-show-errors `
+  --output none
+if ($LASTEXITCODE -ne 0) {
+    throw "ACR build failed for email scheduler image '$image'."
+}
+
+Write-Host "Deploying email scheduler ACA job: $JobName"
+az deployment group create `
+  --resource-group $ResourceGroupName `
+  --template-file "infra/bicep/email_scheduler.job.bicep" `
+  --parameters `
+      location=$Location `
+      managedEnvironmentName=$ContainerAppEnvironmentName `
+      jobName=$JobName `
+      acrName=$AcrName `
+      managedIdentityName=$ManagedIdentityName `
+      image=$image `
+      postgresServerName=$PostgresServerName `
+      postgresDatabaseName=$PostgresDatabaseName `
+      postgresAdminUsername=$PostgresAdminUsername `
+      postgresAdminPassword=$PostgresAdminPassword `
+      postgresConnectionString=$dbCloud `
+      applicationInsightsConnectionString=$applicationInsightsConnectionString `
+      emailTransport=$EmailTransport `
+      emailSender=$EmailSender `
+      emailSmtpHost=$EmailSmtpHost `
+      emailSmtpPort=$EmailSmtpPort `
+      emailSmtpUseTls=$EmailSmtpUseTls `
+      emailSmtpUsername=$EmailSmtpUsername `
+      emailSmtpPassword=$EmailSmtpPassword `
+      cronExpression=$CronExpression | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    throw "Email scheduler ACA job deployment failed."
+}
+
+$jobDisposition = if ($jobExistedBeforeDeployment) { "updated" } else { "created" }
+
+Write-Host "Email scheduler deployment complete."
+Write-Host "ACA resources:"
+Write-Host " - Managed environment (reused): $ContainerAppEnvironmentName"
+Write-Host " - Email scheduler ACA job ($jobDisposition): $JobName"
+
+Write-WorkflowSummary -Lines @(
+    "## ACA deployment summary",
+    "| Resource | Name | Result | Endpoint |",
+    "| --- | --- | --- | --- |",
+    "| Managed environment | $ContainerAppEnvironmentName | reused | n/a |",
+    "| Email scheduler ACA job | $JobName | $jobDisposition | schedule: $CronExpression |"
+)

--- a/skills/laws-collector/SKILL.md
+++ b/skills/laws-collector/SKILL.md
@@ -35,7 +35,8 @@ description: Start and monitor the local laws collector worker. By default it us
 ## Environment Notes
 
 - Default backend: PostgreSQL (`LAWS_DB_BACKEND=postgres`)
-- Default PostgreSQL connection comes from `.\skills\start-postgres\scripts\start_postgres.ps1 -ProjectName laws-collector`
+- If `LAWS_DB_CLOUD` is already set (for example in `.env`), the launcher uses that connection directly.
+- Otherwise the default PostgreSQL connection comes from `.\skills\start-postgres\scripts\start_postgres.ps1 -ProjectName laws-collector`
 - Real embeddings use the shared `LLM_PROVIDER` and embedding settings from `.env` unless the shell already defines them
 - SQLite fallback DB path: `./runs/storage/laws-collector/sqlite/sk_laws.sqlite3`
 - Default local files path: `./runs/storage/laws-collector/files/sk`

--- a/skills/laws-collector/scripts/start_laws_collector.ps1
+++ b/skills/laws-collector/scripts/start_laws_collector.ps1
@@ -224,6 +224,23 @@ function Ensure-LocalPostgresReady {
     return $connectionLine.Substring("Connection string:".Length).Trim()
 }
 
+function Resolve-ExistingLawsDbCloud {
+    param(
+        [string]$ProvidedValue,
+        [string]$EnvironmentValue
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ProvidedValue)) {
+        return $ProvidedValue.Trim()
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($EnvironmentValue)) {
+        return $EnvironmentValue.Trim()
+    }
+
+    return ""
+}
+
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..\..")
 $python = Resolve-PythonPath -RepoRoot $repoRoot
 $shellPath = Resolve-PowerShellPath
@@ -247,7 +264,13 @@ if ($DatabaseOption -eq "sqlite") {
 }
 else {
     $env:LAWS_DB_BACKEND = "postgres"
-    $env:LAWS_DB_CLOUD = Ensure-LocalPostgresReady -RepoRoot $repoRoot -ExistingDbCloud $DbCloud
+    $resolvedDbCloud = Resolve-ExistingLawsDbCloud -ProvidedValue $DbCloud -EnvironmentValue $env:LAWS_DB_CLOUD
+    if ($resolvedDbCloud) {
+        $env:LAWS_DB_CLOUD = $resolvedDbCloud
+    }
+    else {
+        $env:LAWS_DB_CLOUD = Ensure-LocalPostgresReady -RepoRoot $repoRoot -ExistingDbCloud $DbCloud
+    }
     Remove-Item -Path "Env:LAWS_DB_LOCAL" -ErrorAction SilentlyContinue
 }
 

--- a/skills/start-email/SKILL.md
+++ b/skills/start-email/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: start-email
+description: Start and monitor the local email scheduler for `aijuristiction-api`. Use when asked to "start email scheduler", "run local email worker", "start email outbox processor", or "deliver queued emails locally". Prefer this workflow for reliable local scheduler startup with the repo `.env`, shared local PostgreSQL on `127.0.0.1:5432`, and log capture under `runs/`.
+---
+
+# Start Email
+
+## Workflow
+
+1. Run the bundled startup script from repository root:
+   `.\skills\start-email\scripts\start_email_scheduler.ps1`
+2. The launcher loads default values from the repository `.env` when the shell does not already define them.
+3. If the scheduler uses PostgreSQL and no explicit `EMAIL_DB_CLOUD` is set, the launcher reuses or starts the local API PostgreSQL instance through `start-postgres`.
+4. It starts `python -m app.email_scheduler_main` from `api/aijuristiction-api`.
+5. In background mode it writes logs to `runs/email-scheduler-local.log` and `runs/email-scheduler-local.err.log`.
+
+## Commands
+
+- Foreground start:
+  `.\skills\start-email\scripts\start_email_scheduler.ps1`
+- Background start:
+  `.\skills\start-email\scripts\start_email_scheduler.ps1 -Background`
+- Visible console window with live logs:
+  `.\skills\start-email\scripts\start_email_scheduler.ps1 -ConsoleWindow`
+- Background start without opening a log-tail window:
+  `.\skills\start-email\scripts\start_email_scheduler.ps1 -Background -SkipLogTail`
+
+## Stop Scheduler
+
+- If started with `-Background`:
+  `Stop-Process -Id (Get-Content .\runs\email-scheduler-local.pid) -Force`
+
+## Environment Notes
+
+- Default scheduler mode is enabled with `EMAIL_SCHEDULER_ENABLED=true`.
+- Default local email DB should point to the shared local PostgreSQL API database, for example:
+  `EMAIL_DB_CLOUD=postgresql://postgres:postgres@127.0.0.1:5432/aijurisdiction`
+- When `EMAIL_DB_CLOUD` is unset and PostgreSQL is selected, the launcher resolves it from the local API Postgres skill.
+- Queue rows are read from `email_outbox`.
+- Background log files live under `runs/`.

--- a/skills/start-email/scripts/start_email_scheduler.ps1
+++ b/skills/start-email/scripts/start_email_scheduler.ps1
@@ -1,0 +1,325 @@
+param(
+    [switch]$Background,
+    [switch]$ConsoleWindow,
+    [switch]$SkipLogTail
+)
+
+$ErrorActionPreference = "Stop"
+
+function Import-DotEnvDefaults {
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return
+    }
+
+    foreach ($rawLine in Get-Content -LiteralPath $Path) {
+        $line = [string]$rawLine
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        $trimmed = $line.Trim()
+        if ($trimmed.StartsWith("#")) {
+            continue
+        }
+
+        $parts = $trimmed.Split("=", 2)
+        if ($parts.Count -ne 2) {
+            continue
+        }
+
+        $name = $parts[0].Trim()
+        if (-not $name) {
+            continue
+        }
+
+        $existing = [Environment]::GetEnvironmentVariable($name)
+        if (-not [string]::IsNullOrWhiteSpace($existing)) {
+            continue
+        }
+
+        $value = $parts[1].Trim()
+        if (
+            ($value.StartsWith('"') -and $value.EndsWith('"')) -or
+            ($value.StartsWith("'") -and $value.EndsWith("'"))
+        ) {
+            $value = $value.Substring(1, $value.Length - 2)
+        }
+
+        Set-Item -Path "Env:$name" -Value $value
+    }
+}
+
+function Resolve-PythonPath {
+    param([string]$RepoRoot)
+
+    foreach ($candidate in @(".conda\Scripts\python.exe", ".conda\python.exe", "conda\Scripts\python.exe", "conda\python.exe")) {
+        $pythonPath = Join-Path $RepoRoot $candidate
+        if (Test-Path $pythonPath) {
+            return $pythonPath
+        }
+    }
+
+    $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+    if ($pythonCmd) {
+        return $pythonCmd.Source
+    }
+
+    throw "Python interpreter not found. Create .conda env or add python to PATH."
+}
+
+function Resolve-PowerShellPath {
+    $pwshCmd = Get-Command pwsh -ErrorAction SilentlyContinue
+    if ($pwshCmd) {
+        return $pwshCmd.Source
+    }
+
+    $powershellCmd = Get-Command powershell -ErrorAction SilentlyContinue
+    if ($powershellCmd) {
+        return $powershellCmd.Source
+    }
+
+    throw "PowerShell executable not found."
+}
+
+function Open-LogTailWindow {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ShellPath,
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot,
+        [Parameter(Mandatory = $true)]
+        [string[]]$Paths,
+        [Parameter(Mandatory = $true)]
+        [string]$WindowTitle
+    )
+
+    $existing = @($Paths | Where-Object { Test-Path $_ })
+    if (-not $existing) {
+        return $false
+    }
+
+    Get-Process -ErrorAction SilentlyContinue |
+        Where-Object { $_.MainWindowTitle -eq $WindowTitle } |
+        ForEach-Object {
+            try {
+                Stop-Process -Id $_.Id -Force -ErrorAction Stop
+            }
+            catch {
+            }
+        }
+
+    $tailHelperPath = Join-Path $RepoRoot "skills\shared\scripts\tail_logs.ps1"
+    if (-not (Test-Path $tailHelperPath)) {
+        throw "Log tail helper not found: $tailHelperPath"
+    }
+
+    $quotedHelperPath = '"{0}"' -f $tailHelperPath
+    $quotedWindowTitle = '"{0}"' -f $WindowTitle.Replace('"', '\"')
+    $quotedPathsJoined = '"{0}"' -f (($existing -join '|').Replace('"', '\"'))
+    $tailArgs = @("-NoExit", "-File", $quotedHelperPath, "-WindowTitle", $quotedWindowTitle, "-TailLines", "40", "-PathsJoined", $quotedPathsJoined)
+    Start-Process -FilePath $ShellPath -ArgumentList $tailArgs -WorkingDirectory $RepoRoot | Out-Null
+    return $true
+}
+
+function Normalize-DbOption {
+    param([string]$Value)
+
+    if (-not $Value) {
+        return ""
+    }
+
+    $normalized = $Value.Trim().ToLowerInvariant()
+    if ($normalized -eq "postgress") {
+        return "postgres"
+    }
+
+    return $normalized
+}
+
+function Ensure-LocalPostgresReady {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot,
+        [string]$ExistingDbCloud
+    )
+
+    $skillScript = Join-Path $RepoRoot "skills\start-postgres\scripts\start_postgres.ps1"
+    if (-not (Test-Path $skillScript)) {
+        throw "PostgreSQL start skill not found: $skillScript"
+    }
+
+    $shellPath = Resolve-PowerShellPath
+    $shellArgs = @("-NoProfile", "-File", $skillScript, "-ProjectName", "api")
+    if ($ExistingDbCloud) {
+        try {
+            $uri = [System.Uri]$ExistingDbCloud
+            $databaseName = $uri.AbsolutePath.Trim("/")
+            if (-not $databaseName) {
+                $databaseName = "aijurisdiction"
+            }
+            $shellArgs += @("-DatabaseName", $databaseName)
+            if ($uri.Port -gt 0) {
+                $shellArgs += @("-DatabasePort", "$($uri.Port)")
+            }
+        }
+        catch {
+        }
+    }
+
+    $output = & $shellPath @shellArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "Local PostgreSQL startup failed."
+    }
+
+    $connectionLine = $output | Where-Object { $_ -like "Connection string:*" } | Select-Object -Last 1
+    if (-not $connectionLine) {
+        throw "Local PostgreSQL startup did not return a connection string."
+    }
+
+    return $connectionLine.Substring("Connection string:".Length).Trim()
+}
+
+function Stop-ExistingSchedulerProcesses {
+    $processes = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.Name -match "python" -and
+            $_.CommandLine -like "*app.email_scheduler_main*"
+        }
+
+    foreach ($process in @($processes)) {
+        try {
+            Stop-Process -Id $process.ProcessId -Force -ErrorAction Stop
+        }
+        catch {
+        }
+    }
+}
+
+$skillScriptsDir = $PSScriptRoot
+$repoRoot = Resolve-Path (Join-Path $skillScriptsDir "..\..\..")
+$apiDir = Join-Path $repoRoot "api\aijuristiction-api"
+$srcDir = Join-Path $repoRoot "src"
+$runsDir = Join-Path $repoRoot "runs"
+$shellPath = Resolve-PowerShellPath
+$python = Resolve-PythonPath -RepoRoot $repoRoot
+
+if (-not (Test-Path $apiDir)) {
+    throw "API project folder not found: $apiDir"
+}
+
+Import-DotEnvDefaults -Path (Join-Path $repoRoot ".env")
+
+$pythonPathEntries = @($apiDir, $srcDir)
+if ($env:PYTHONPATH) {
+    $pythonPathEntries += $env:PYTHONPATH
+}
+$env:PYTHONPATH = ($pythonPathEntries -join [IO.Path]::PathSeparator)
+$env:PYTHONUNBUFFERED = "1"
+$env:EMAIL_SCHEDULER_ENABLED = if ($env:EMAIL_SCHEDULER_ENABLED) { $env:EMAIL_SCHEDULER_ENABLED } else { "true" }
+
+$resolvedEmailDbOption = Normalize-DbOption -Value $(if ($env:EMAIL_DB_OPTION) { $env:EMAIL_DB_OPTION } elseif ($env:DB_OPTION) { $env:DB_OPTION } else { "postgres" })
+$env:EMAIL_DB_OPTION = $resolvedEmailDbOption
+
+if ($resolvedEmailDbOption -eq "postgres") {
+    $resolvedCloud = ""
+    if ($env:EMAIL_DB_CLOUD) {
+        $resolvedCloud = $env:EMAIL_DB_CLOUD.Trim()
+    }
+    elseif ($env:DB_CLOUD) {
+        $resolvedCloud = $env:DB_CLOUD.Trim()
+    }
+
+    if (-not $resolvedCloud) {
+        $resolvedCloud = Ensure-LocalPostgresReady -RepoRoot $repoRoot -ExistingDbCloud ""
+    }
+
+    $env:EMAIL_DB_CLOUD = $resolvedCloud
+}
+
+if ($ConsoleWindow) {
+    $scriptPath = Join-Path $repoRoot "skills\start-email\scripts\start_email_scheduler.ps1"
+    $consoleArgs = @("-NoExit", "-File", $scriptPath)
+    if ($Background) {
+        $consoleArgs += "-Background"
+    }
+    if ($SkipLogTail) {
+        $consoleArgs += "-SkipLogTail"
+    }
+
+    Stop-ExistingSchedulerProcesses
+    Start-Process -FilePath $shellPath -ArgumentList $consoleArgs -WorkingDirectory $repoRoot | Out-Null
+    Write-Output "Email scheduler console window started."
+    Write-Output "EMAIL_DB_OPTION: $($env:EMAIL_DB_OPTION)"
+    if ($env:EMAIL_DB_CLOUD) {
+        Write-Output "EMAIL_DB_CLOUD: $($env:EMAIL_DB_CLOUD)"
+    }
+    exit 0
+}
+
+if (-not (Test-Path $runsDir)) {
+    New-Item -Path $runsDir -ItemType Directory | Out-Null
+}
+
+if ($Background) {
+    $stdoutLog = Join-Path $runsDir "email-scheduler-local.log"
+    $stderrLog = Join-Path $runsDir "email-scheduler-local.err.log"
+    $pidFile = Join-Path $runsDir "email-scheduler-local.pid"
+
+    Stop-ExistingSchedulerProcesses
+
+    if (Test-Path $stdoutLog) { Remove-Item $stdoutLog -Force }
+    if (Test-Path $stderrLog) { Remove-Item $stderrLog -Force }
+
+    $process = Start-Process `
+        -FilePath $python `
+        -ArgumentList @("-m", "app.email_scheduler_main") `
+        -WorkingDirectory $apiDir `
+        -RedirectStandardOutput $stdoutLog `
+        -RedirectStandardError $stderrLog `
+        -PassThru
+
+    Start-Sleep -Seconds 3
+
+    if (-not (Get-Process -Id $process.Id -ErrorAction SilentlyContinue)) {
+        throw "Email scheduler process exited immediately. Check $stderrLog"
+    }
+
+    $process.Id | Out-File -FilePath $pidFile -Encoding ascii -NoNewline
+
+    Write-Output "Email scheduler started in background. PID: $($process.Id)"
+    Write-Output "EMAIL_DB_OPTION: $($env:EMAIL_DB_OPTION)"
+    if ($env:EMAIL_DB_CLOUD) {
+        Write-Output "EMAIL_DB_CLOUD: $($env:EMAIL_DB_CLOUD)"
+    }
+    Write-Output "Logs: $stdoutLog"
+    Write-Output "Errors: $stderrLog"
+    Write-Output "Stop: Stop-Process -Id (Get-Content `"$pidFile`") -Force"
+
+    if (-not $SkipLogTail) {
+        $openedLogs = Open-LogTailWindow `
+            -ShellPath $shellPath `
+            -RepoRoot $repoRoot `
+            -Paths @($stdoutLog, $stderrLog) `
+            -WindowTitle "AI Jurisdiction Email Scheduler Logs"
+        if ($openedLogs) {
+            Write-Output "Email scheduler log tail window started."
+        }
+    }
+    exit 0
+}
+
+Stop-ExistingSchedulerProcesses
+
+Write-Output "Starting email scheduler in foreground (EMAIL_DB_OPTION=$($env:EMAIL_DB_OPTION))"
+if ($env:EMAIL_DB_CLOUD) {
+    Write-Output "EMAIL_DB_CLOUD: $($env:EMAIL_DB_CLOUD)"
+}
+Push-Location $apiDir
+try {
+    & $python -m app.email_scheduler_main
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- add a dedicated Azure Container Apps Job deployment path for the email scheduler
- add a one-shot email scheduler entrypoint and focused API tests
- add a local start-email skill and align local laws collector/postgres usage

## Validation
- ..\\..\\.conda\\python.exe -m pytest tests/test_email_scheduler_job_main.py tests/test_users.py
- az bicep build --file infra\\bicep\\email_scheduler.job.bicep --stdout
- git diff --check