### PR TITLE
Limit OTP-free mobile sign-in to 8 hours and clear device token on logout

### DIFF
--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -48,7 +48,8 @@ Flutter mobile client prepared for local testing of the AIJurisDictA (AI Juris D
   - `Sign up`: phone number + email/password (required), first/last name (optional), persisted through the API
   - `Sign up` now also requires an email verification code: users must tap `Send code`, receive the one-time code by email, and complete registration with that code.
   - `Sign in`: app first tries silent login with a device-bound token; if not available/expired, app sends a one-time sign-in code and verifies it.
-  - first successful OTP sign-in stores a device-bound token so subsequent logins on the same device can be silent.
+  - first successful OTP sign-in stores a device-bound token; subsequent sign-ins on the same device are silent for 8 hours, then OTP is required again.
+  - explicit `Sign out` clears the device-bound token and forces OTP on the next sign-in.
   - after sign-in, `Account` page shows the stored phone number and email as read-only fields, and allows updating only password, first name, and last name
   - browser/local web remembers the last signed-in phone number and pre-fills the sign-in form
   - local runs also prefill `+421944400166` when no phone was remembered yet

--- a/mobile_app/lib/auth/local_auth_store.dart
+++ b/mobile_app/lib/auth/local_auth_store.dart
@@ -168,7 +168,10 @@ class LocalAuthStore {
   static const String _currentUserKeyPrefix = 'mobile_auth_current_user_v3';
   static const String _lastPhoneKeyPrefix = 'mobile_auth_last_phone_v3';
   static const String _deviceTokenKeyPrefix = 'mobile_auth_device_token_v1';
+  static const String _deviceTokenIssuedAtKeyPrefix =
+      'mobile_auth_device_token_issued_at_v1';
   static const String _deviceIdKeyPrefix = 'mobile_auth_device_id_v1';
+  static const Duration _deviceTokenRememberDuration = Duration(hours: 8);
 
   const LocalAuthStore({
     required this.baseUri,
@@ -181,6 +184,8 @@ class LocalAuthStore {
   String get _currentUserKey => '${_currentUserKeyPrefix}_${_storageScope()}';
   String get _lastPhoneKey => '${_lastPhoneKeyPrefix}_${_storageScope()}';
   String get _deviceTokenKey => '${_deviceTokenKeyPrefix}_${_storageScope()}';
+  String get _deviceTokenIssuedAtKey =>
+      '${_deviceTokenIssuedAtKeyPrefix}_${_storageScope()}';
   String get _deviceIdKey => '${_deviceIdKeyPrefix}_${_storageScope()}';
 
   String _storageScope() {
@@ -261,6 +266,7 @@ class LocalAuthStore {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_currentUserKey);
     await prefs.remove(_deviceTokenKey);
+    await prefs.remove(_deviceTokenIssuedAtKey);
   }
 
   Future<String> getOrCreateDeviceBindingId() async {
@@ -391,6 +397,18 @@ class LocalAuthStore {
         resolvedDeviceId.isEmpty ||
         cachedToken == null ||
         cachedToken.trim().isEmpty) {
+      return null;
+    }
+    final tokenIssuedAtEpochMs = prefs.getInt(_deviceTokenIssuedAtKey);
+    if (tokenIssuedAtEpochMs == null) {
+      await _cacheDeviceToken(null);
+      return null;
+    }
+    final tokenIssuedAt =
+        DateTime.fromMillisecondsSinceEpoch(tokenIssuedAtEpochMs, isUtc: true);
+    if (DateTime.now().toUtc().difference(tokenIssuedAt) >=
+        _deviceTokenRememberDuration) {
+      await _cacheDeviceToken(null);
       return null;
     }
     final response = await _postJson(
@@ -561,9 +579,14 @@ class LocalAuthStore {
     final prefs = await SharedPreferences.getInstance();
     if (token == null || token.trim().isEmpty) {
       await prefs.remove(_deviceTokenKey);
+      await prefs.remove(_deviceTokenIssuedAtKey);
       return;
     }
     await prefs.setString(_deviceTokenKey, token.trim());
+    await prefs.setInt(
+      _deviceTokenIssuedAtKey,
+      DateTime.now().toUtc().millisecondsSinceEpoch,
+    );
   }
 
   Future<http.Response> _postJson({

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ai_jurisdiction_mobile
-version: 0.1.5+52
+version: 0.1.5+53
 publish_to: none
 
 environment:

--- a/mobile_app/test/local_auth_store_test.dart
+++ b/mobile_app/test/local_auth_store_test.dart
@@ -75,4 +75,52 @@ void main() {
     expect(await localStore.getCurrentUser(), isNull);
     expect((await devStore.getCurrentUser())?.userId, 'dev-user');
   });
+
+  test('sign out clears scoped device token metadata', () async {
+    SharedPreferences.setMockInitialValues({
+      'mobile_auth_device_token_v1_http_127_0_0_1_8080': 'token-local',
+      'mobile_auth_device_token_issued_at_v1_http_127_0_0_1_8080':
+          DateTime.utc(2026, 1, 1).millisecondsSinceEpoch,
+      'mobile_auth_device_token_v1_https_api_juris_dev_example_com':
+          'token-dev',
+      'mobile_auth_device_token_issued_at_v1_https_api_juris_dev_example_com':
+          DateTime.utc(2026, 1, 1).millisecondsSinceEpoch,
+    });
+
+    final localStore = LocalAuthStore(
+      baseUri: Uri.parse('http://127.0.0.1:8080'),
+      apiKey: 'aijuris',
+    );
+    final devStore = LocalAuthStore(
+      baseUri: Uri.parse('https://api-juris-dev.example.com'),
+      apiKey: 'aijuris',
+    );
+
+    await localStore.signOut();
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(
+      prefs.getString('mobile_auth_device_token_v1_http_127_0_0_1_8080'),
+      isNull,
+    );
+    expect(
+      prefs.getInt('mobile_auth_device_token_issued_at_v1_http_127_0_0_1_8080'),
+      isNull,
+    );
+    expect(
+      prefs.getString(
+        'mobile_auth_device_token_v1_https_api_juris_dev_example_com',
+      ),
+      'token-dev',
+    );
+    expect(
+      prefs.getInt(
+        'mobile_auth_device_token_issued_at_v1_https_api_juris_dev_example_com',
+      ),
+      DateTime.utc(2026, 1, 1).millisecondsSinceEpoch,
+    );
+
+    expect((await devStore.getCurrentUser()), isNull);
+  });
+
 }


### PR DESCRIPTION
### Motivation
- Users should be able to skip OTP on the same device for a limited time (8 hours) but explicit logout must force OTP again. 
- The app currently re-prompts for OTP after reopening; a short, explicit TTL for device-bound tokens provides the desired balance between convenience and security.

### Description
- Add a device-token issued-at metadata key and an `_deviceTokenRememberDuration = Duration(hours: 8)` constant, scoped to the API base URL, stored in `SharedPreferences` (new keys in `mobile_app/lib/auth/local_auth_store.dart`).
- Enforce the 8-hour TTL in `signInByDeviceToken` by rejecting cached tokens older than the TTL and clearing expired token metadata so the flow falls back to OTP.
- Clear both the cached device token and its issued-at metadata in `signOut` so an explicit logout forces OTP on the next sign-in.
- Update `mobile_app/README.md` to document the 8-hour silent sign-in behavior and bump the mobile build revision in `mobile_app/pubspec.yaml` from `0.1.5+52` to `0.1.5+53` per mobile versioning rules.
- Add a unit test `mobile_app/test/local_auth_store_test.dart` that verifies sign-out clears the scoped device-token metadata without affecting other API scopes.

### Testing
- Added unit tests in `mobile_app/test/local_auth_store_test.dart` that exercise the scoped token metadata removal (tests were added but not executed in this environment).
- Attempted to run formatting with `dart format lib/auth/local_auth_store.dart test/local_auth_store_test.dart` which failed because the `dart` tool is not available in the current environment (tooling missing).
- Attempted to run unit tests with `cd mobile_app && flutter test test/local_auth_store_test.dart` which failed because the `flutter` tool is not available in the current environment (tooling missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec96011dbc8332b9b97b5b48b98533)