### PR TITLE
Update corporate website with GDPR and EU AI Act information

### DIFF
--- a/corporate-web/index.html
+++ b/corporate-web/index.html
@@ -372,13 +372,13 @@
     <section id="legal" class="section legal">
       <div class="section-head">
         <h2 data-i18n="legal_title">Legal information</h2>
-        <p data-i18n="legal_lede">Policy, disclaimer, and service terms for all users.</p>
+        <p data-i18n="legal_lede">Policy, GDPR, EU AI Act transparency, disclaimer, and service terms for all users.</p>
       </div>
       <div class="legal-grid">
         <article id="privacy" class="legal-card">
           <h3 data-i18n="legal_privacy_title">Privacy Policy</h3>
           <p data-i18n="legal_privacy_body">
-            We process account and case data to operate the service securely and in line with legal obligations.
+            We process account and case data under GDPR principles (lawfulness, minimization, retention controls) to operate the service securely and in line with legal obligations.
           </p>
         </article>
         <article id="disclaimer" class="legal-card">
@@ -393,9 +393,18 @@
           </ul>
           <p class="legal-updated">
             <strong data-i18n="legal_last_updated_label">Last Updated</strong>:
-            <span data-i18n="legal_last_updated_date">February 18, 2026</span>
+            <span data-i18n="legal_last_updated_date">May 6, 2026</span>
           </p>
         </article>
+        <article id="ai-act" class="legal-card">
+          <h3 data-i18n="legal_ai_act_title">EU AI Act Transparency</h3>
+          <ul class="legal-list">
+            <li data-i18n="legal_ai_act_item_1">JurisDigta provides AI-assisted legal workflow support and does not replace licensed legal counsel.</li>
+            <li data-i18n="legal_ai_act_item_2">Human review and decision-making remain required for legal conclusions and external filings.</li>
+            <li data-i18n="legal_ai_act_item_3">Users are informed when outputs are AI-generated and should validate critical facts before use.</li>
+          </ul>
+        </article>
+
         <article id="terms" class="legal-card">
           <h3 data-i18n="legal_terms_title">Terms of Service</h3>
           <p data-i18n="legal_terms_body">
@@ -559,7 +568,7 @@
         footer_version_api_label: "API verzia",
         footer_version_core_label: "Verzia system core",
         legal_title: "Pravne informacie",
-        legal_lede: "Pravidla sukromia, upozornenie a podmienky sluzby pre pouzivatelov.",
+        legal_lede: "Pravidla sukromia (GDPR), transparentnost EU AI Act, upozornenie a podmienky sluzby pre pouzivatelov.",
         legal_privacy_title: "Zasady sukromia",
         legal_privacy_body: "Spracuvame udaje o ucte a pripade na bezpecnu prevadzku sluzby a splnenie pravnych povinnosti.",
         legal_disclaimer_title: "Upozornenie",
@@ -569,8 +578,12 @@
         legal_disclaimer_item_4: "Jurisdikcnu vhodnost je potrebne overit s kvalifikovanym pravnikom.",
         legal_disclaimer_item_5: "Pouzivatel nesie zodpovednost za rozhodnutia a pravne kroky.",
         legal_disclaimer_item_6: "Externe odkazy sa mozu menit a obsah mozeme upravit bez upozornenia.",
+        legal_ai_act_title: "Transparentnost podla EU AI Act",
+        legal_ai_act_item_1: "JurisDigta poskytuje AI asistovanu podporu pravnych workflow a nenahradza licencovane pravne poradenstvo.",
+        legal_ai_act_item_2: "Ludsky dohľad a rozhodovanie su nadalej potrebne pre pravne zavery a externe podania.",
+        legal_ai_act_item_3: "Pouzivatelia su informovani, ked je vystup AI generovany, a maju overit klucove fakty pred pouzitim.",
         legal_last_updated_label: "Posledna aktualizacia",
-        legal_last_updated_date: "18. februar 2026",
+        legal_last_updated_date: "6. maj 2026",
         legal_terms_title: "Podmienky sluzby",
         legal_terms_body: "Pouzivanim webu a platformy suhlasite so zakonnyma podmienkami a aktualnymi pravidlami sluzby."
       },
@@ -701,7 +714,7 @@
         footer_version_api_label: "API-Version",
         footer_version_core_label: "System-Core-Version",
         legal_title: "Rechtliche Informationen",
-        legal_lede: "Datenschutz, Haftungsausschluss und Nutzungsbedingungen fur alle Nutzer.",
+        legal_lede: "Datenschutz (DSGVO), EU AI Act Transparenz, Haftungsausschluss und Nutzungsbedingungen fur alle Nutzer.",
         legal_privacy_title: "Datenschutz",
         legal_privacy_body: "Wir verarbeiten Konto- und Falldaten fur den sicheren Betrieb und zur Erfullung rechtlicher Pflichten.",
         legal_disclaimer_title: "Haftungsausschluss",
@@ -711,8 +724,12 @@
         legal_disclaimer_item_4: "Die juristische Anwendbarkeit muss durch qualifizierte Juristen gepruft werden.",
         legal_disclaimer_item_5: "Nutzer tragen die Verantwortung fur Entscheidungen und rechtliche Schritte.",
         legal_disclaimer_item_6: "Externe Links konnen sich andern und Inhalte konnen ohne Mitteilung aktualisiert werden.",
+        legal_ai_act_title: "Transparenz nach EU AI Act",
+        legal_ai_act_item_1: "JurisDigta bietet KI-gestutzte Unterstutzung fur juristische Workflows und ersetzt keine zugelassene Rechtsberatung.",
+        legal_ai_act_item_2: "Menschliche Prufung und Entscheidung bleiben fur rechtliche Schlussfolgerungen und externe Einreichungen erforderlich.",
+        legal_ai_act_item_3: "Nutzer werden informiert, wenn Inhalte KI-generiert sind, und sollen kritische Fakten vor Nutzung validieren.",
         legal_last_updated_label: "Letzte Aktualisierung",
-        legal_last_updated_date: "18. Februar 2026",
+        legal_last_updated_date: "6. Mai 2026",
         legal_terms_title: "Nutzungsbedingungen",
         legal_terms_body: "Durch die Nutzung von Website und Plattform stimmen Sie den geltenden Servicebedingungen zu."
       },
@@ -843,9 +860,9 @@
         footer_version_api_label: "API version",
         footer_version_core_label: "System core version",
         legal_title: "Legal information",
-        legal_lede: "Policy, disclaimer, and service terms for all users.",
+        legal_lede: "Policy, GDPR, EU AI Act transparency, disclaimer, and service terms for all users.",
         legal_privacy_title: "Privacy Policy",
-        legal_privacy_body: "We process account and case data to operate the service securely and in line with legal obligations.",
+        legal_privacy_body: "We process account and case data under GDPR principles (lawfulness, minimization, retention controls) to operate the service securely and in line with legal obligations.",
         legal_disclaimer_title: "Disclaimer",
         legal_disclaimer_item_1: "AI-generated information only, not legal advice.",
         legal_disclaimer_item_2: "No attorney-client relationship is created.",
@@ -853,8 +870,12 @@
         legal_disclaimer_item_4: "Jurisdictional fit must be verified by qualified legal professionals.",
         legal_disclaimer_item_5: "Users remain responsible for decisions and legal actions.",
         legal_disclaimer_item_6: "External links may change and content can be updated without notice.",
+        legal_ai_act_title: "EU AI Act Transparency",
+        legal_ai_act_item_1: "JurisDigta provides AI-assisted legal workflow support and does not replace licensed legal counsel.",
+        legal_ai_act_item_2: "Human review and decision-making remain required for legal conclusions and external filings.",
+        legal_ai_act_item_3: "Users are informed when outputs are AI-generated and should validate critical facts before use.",
         legal_last_updated_label: "Last Updated",
-        legal_last_updated_date: "February 18, 2026",
+        legal_last_updated_date: "May 6, 2026",
         legal_terms_title: "Terms of Service",
         legal_terms_body: "By using this website and platform, you agree to lawful use requirements and current service terms."
       }

--- a/docs/CORPORATE_WEB.md
+++ b/docs/CORPORATE_WEB.md
@@ -57,3 +57,12 @@ Remote FTP folder: `www_root_aiagenticsolutions_eu`.
 - Basic plan: up to 5 uploaded documents per case.
 - Premium plan: up to 50 uploaded documents per case.
 - Test phone `+421944400166` keeps premium-equivalent document capacity for validation flows.
+
+
+## GDPR and EU AI Act content
+
+The legal section on the corporate web page now explicitly covers:
+
+- GDPR-oriented personal data handling principles (lawfulness, minimization, retention controls).
+- EU AI Act transparency expectations for AI-assisted legal workflows.
+- Human oversight requirements and user notification for AI-generated output.

--- a/examples/corporate_web_gdpr_ai_act_minimal_demo.py
+++ b/examples/corporate_web_gdpr_ai_act_minimal_demo.py
@@ -1,0 +1,16 @@
+"""Minimal runnable check for corporate-web GDPR/AI Act copy."""
+from pathlib import Path
+
+html = Path("corporate-web/index.html").read_text(encoding="utf-8")
+required = [
+    "GDPR",
+    "EU AI Act",
+    "legal_ai_act_title",
+    "legal_ai_act_item_1",
+]
+
+missing = [token for token in required if token not in html]
+if missing:
+    raise SystemExit(f"Missing required tokens: {missing}")
+
+print("Corporate web contains GDPR and EU AI Act legal disclosures.")


### PR DESCRIPTION
### Motivation
- Make the corporate legal copy explicitly reference GDPR principles and EU AI Act transparency to clarify data handling and AI disclosure/human oversight expectations.
- Keep localized strings and the visible "Last Updated" stamp consistent across translations and documentation.

### Description
- Add a dedicated EU AI Act legal card to `corporate-web/index.html` with three disclosure points about AI-assisted support, required human review, and AI-generated output notification.
- Update the legal lead and `Privacy Policy` wording in `corporate-web/index.html` to reference GDPR principles (lawfulness, minimization, retention controls) and update the visible date to `May 6, 2026`.
- Extend the in-page localization keys for Slovak/German/English with `legal_ai_act_title` and `legal_ai_act_item_1|2|3` and update corresponding translated strings.
- Add documentation and a minimal runnable verification script: update `docs/CORPORATE_WEB.md` with a GDPR/AI Act section and add `examples/corporate_web_gdpr_ai_act_minimal_demo.py` which asserts required tokens exist in `corporate-web/index.html`.

### Testing
- Ran the minimal check with `python examples/corporate_web_gdpr_ai_act_minimal_demo.py`, which completed successfully and confirmed the required GDPR / EU AI Act tokens are present in `corporate-web/index.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fafa23bbb483329eb7777da7c40371)