### PR TITLE
Add data-processing consent page and capture consent during user registration

### DIFF
--- a/api/aijuristiction-api/app/users/api.py
+++ b/api/aijuristiction-api/app/users/api.py
@@ -39,6 +39,8 @@ class UserProfileResponse(BaseModel):
     first_name: str | None = None
     last_name: str | None = None
     full_name: str
+    data_processing_consent_at: str | None = None
+    data_processing_consent_version: str | None = None
 
 
 class SignUpRequest(BaseModel):
@@ -47,6 +49,8 @@ class SignUpRequest(BaseModel):
     password: str = Field(min_length=1)
     first_name: str | None = None
     last_name: str | None = None
+    data_processing_consent_accepted: bool = False
+    data_processing_consent_version: str | None = None
 
 
 class SendRegistrationCodeRequest(BaseModel):
@@ -166,6 +170,8 @@ def sign_up(
             password=payload.password,
             first_name=payload.first_name,
             last_name=payload.last_name,
+            data_processing_consent_at=_now_if_accepted(payload.data_processing_consent_accepted),
+            data_processing_consent_version=payload.data_processing_consent_version,
         )
     except Exception as exc:
         if not _is_unique_constraint_error(exc):
@@ -208,6 +214,8 @@ def complete_registration(
         code=payload.verification_code,
     ):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid verification code")
+    if not payload.data_processing_consent_accepted:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Data processing consent is required")
     try:
         user = store.create_user(
             phone_number=payload.phone_number,
@@ -215,6 +223,8 @@ def complete_registration(
             password=payload.password,
             first_name=payload.first_name,
             last_name=payload.last_name,
+            data_processing_consent_at=_now_if_accepted(payload.data_processing_consent_accepted),
+            data_processing_consent_version=payload.data_processing_consent_version,
         )
     except Exception as exc:
         if not _is_unique_constraint_error(exc):
@@ -489,6 +499,8 @@ def _to_user_profile_response(user: User) -> UserProfileResponse:
         first_name=user.first_name,
         last_name=user.last_name,
         full_name=user.full_name,
+        data_processing_consent_at=user.data_processing_consent_at,
+        data_processing_consent_version=user.data_processing_consent_version,
     )
 
 
@@ -500,8 +512,18 @@ def _to_device_auth_user_profile_response(*, user: User, token: str) -> DeviceAu
         first_name=user.first_name,
         last_name=user.last_name,
         full_name=user.full_name,
+        data_processing_consent_at=user.data_processing_consent_at,
+        data_processing_consent_version=user.data_processing_consent_version,
         device_auth_token=token,
     )
+
+
+def _now_if_accepted(accepted: bool) -> str | None:
+    if not accepted:
+        return None
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat()
 
 
 def _sign_in_code_key(*, phone_number: str, device_id: str) -> str:

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260391"
+version = "1.0.260392"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_users.py
+++ b/api/aijuristiction-api/tests/test_users.py
@@ -143,6 +143,8 @@ def test_sign_up_complete_requires_valid_email_code(monkeypatch, tmp_path: Path)
             "email": "verify@example.com",
             "password": "secret-pass",
             "verification_code": valid_code,
+            "data_processing_consent_accepted": True,
+            "data_processing_consent_version": "2026-05-06",
         },
     )
     assert complete_response.status_code == 201
@@ -224,6 +226,8 @@ def test_device_bound_sign_in_flow(monkeypatch, tmp_path: Path) -> None:
             "phone_number": "+421900121314",
             "device_id": "test-device-1",
             "verification_code": valid_code,
+            "data_processing_consent_accepted": True,
+            "data_processing_consent_version": "2026-05-06",
         },
     )
     assert verify_response.status_code == 200

--- a/corporate-web/index.html
+++ b/corporate-web/index.html
@@ -405,6 +405,16 @@
           </ul>
         </article>
 
+        <article id="data-processing-consent" class="legal-card">
+          <h3 data-i18n="legal_data_processing_title">Data processing notice and consent</h3>
+          <ul class="legal-list">
+            <li data-i18n="legal_data_processing_item_1">Users may provide personal and financial data during document preparation, including third-party data, only when they have legal basis and authority.</li>
+            <li data-i18n="legal_data_processing_item_2">JurisDigta processes provided data as a processor/controller under GDPR principles and applies security, minimization, access controls, and retention policies.</li>
+            <li data-i18n="legal_data_processing_item_3">Users remain responsible for legality, accuracy, and lawful sharing of party data and must avoid prohibited or unlawful processing.</li>
+            <li data-i18n="legal_data_processing_item_4">AI outputs support legal drafting workflows; users must review and confirm compliance with applicable law, GDPR, and EU AI Act obligations before use.</li>
+          </ul>
+        </article>
+
         <article id="terms" class="legal-card">
           <h3 data-i18n="legal_terms_title">Terms of Service</h3>
           <p data-i18n="legal_terms_body">
@@ -424,6 +434,7 @@
       <a href="#privacy" data-i18n="footer_link_privacy">Privacy Policy</a>
       <a href="#disclaimer" data-i18n="footer_link_disclaimer">Disclaimer</a>
       <a href="#terms" data-i18n="footer_link_terms">Terms of Service</a>
+      <a href="#data-processing-consent" data-i18n="footer_link_data_processing">Data processing notice</a>
     </div>
     <div class="footer-meta">
       <span>(c) 2026 AI Jurisdiction</span>
@@ -857,6 +868,7 @@
         footer_link_privacy: "Privacy Policy",
         footer_link_disclaimer: "Disclaimer",
         footer_link_terms: "Terms of Service",
+        footer_link_data_processing: "Data processing notice",
         footer_version_api_label: "API version",
         footer_version_core_label: "System core version",
         legal_title: "Legal information",
@@ -874,6 +886,11 @@
         legal_ai_act_item_1: "JurisDigta provides AI-assisted legal workflow support and does not replace licensed legal counsel.",
         legal_ai_act_item_2: "Human review and decision-making remain required for legal conclusions and external filings.",
         legal_ai_act_item_3: "Users are informed when outputs are AI-generated and should validate critical facts before use.",
+        legal_data_processing_title: "Data processing notice and consent",
+        legal_data_processing_item_1: "Users may provide personal and financial data during document preparation, including third-party data, only when they have legal basis and authority.",
+        legal_data_processing_item_2: "JurisDigta processes provided data as a processor/controller under GDPR principles and applies security, minimization, access controls, and retention policies.",
+        legal_data_processing_item_3: "Users remain responsible for legality, accuracy, and lawful sharing of party data and must avoid prohibited or unlawful processing.",
+        legal_data_processing_item_4: "AI outputs support legal drafting workflows; users must review and confirm compliance with applicable law, GDPR, and EU AI Act obligations before use.",
         legal_last_updated_label: "Last Updated",
         legal_last_updated_date: "May 6, 2026",
         legal_terms_title: "Terms of Service",
@@ -972,20 +989,23 @@
       document.documentElement.lang = lang;
       document.querySelectorAll("[data-i18n]").forEach((element) => {
         const key = element.dataset.i18n;
-        if (dictionary[key]) {
-          element.textContent = dictionary[key];
+        const translated = dictionary[key] || translations.en[key];
+        if (translated) {
+          element.textContent = translated;
         }
       });
       document.querySelectorAll("[data-i18n-alt]").forEach((element) => {
         const key = element.dataset.i18nAlt;
-        if (dictionary[key]) {
-          element.setAttribute("alt", dictionary[key]);
+        const translated = dictionary[key] || translations.en[key];
+        if (translated) {
+          element.setAttribute("alt", translated);
         }
       });
       document.querySelectorAll("[data-i18n-aria]").forEach((element) => {
         const key = element.dataset.i18nAria;
-        if (dictionary[key]) {
-          element.setAttribute("aria-label", dictionary[key]);
+        const translated = dictionary[key] || translations.en[key];
+        if (translated) {
+          element.setAttribute("aria-label", translated);
         }
       });
       if (metaDescription && dictionary.meta_description) {

--- a/docs/CORPORATE_WEB.md
+++ b/docs/CORPORATE_WEB.md
@@ -66,3 +66,5 @@ The legal section on the corporate web page now explicitly covers:
 - GDPR-oriented personal data handling principles (lawfulness, minimization, retention controls).
 - EU AI Act transparency expectations for AI-assisted legal workflows.
 - Human oversight requirements and user notification for AI-generated output.
+
+- Added legal section #data-processing-consent for GDPR/AI Act data-processing disclosures and registration consent linking from mobile app.

--- a/mobile_app/lib/auth/local_auth_store.dart
+++ b/mobile_app/lib/auth/local_auth_store.dart
@@ -72,6 +72,8 @@ class LocalAuthUser {
     required this.password,
     this.firstName,
     this.lastName,
+    this.dataProcessingConsentAt,
+    this.dataProcessingConsentVersion,
   });
 
   final String userId;
@@ -80,6 +82,8 @@ class LocalAuthUser {
   final String password;
   final String? firstName;
   final String? lastName;
+  final String? dataProcessingConsentAt;
+  final String? dataProcessingConsentVersion;
 
   String get displayName {
     final first = (firstName ?? '').trim();
@@ -98,6 +102,8 @@ class LocalAuthUser {
     String? password,
     String? firstName,
     String? lastName,
+    String? dataProcessingConsentAt,
+    String? dataProcessingConsentVersion,
   }) {
     return LocalAuthUser(
       userId: userId ?? this.userId,
@@ -106,6 +112,10 @@ class LocalAuthUser {
       password: password ?? this.password,
       firstName: firstName ?? this.firstName,
       lastName: lastName ?? this.lastName,
+      dataProcessingConsentAt:
+          dataProcessingConsentAt ?? this.dataProcessingConsentAt,
+      dataProcessingConsentVersion:
+          dataProcessingConsentVersion ?? this.dataProcessingConsentVersion,
     );
   }
 
@@ -117,6 +127,8 @@ class LocalAuthUser {
       'password': password,
       'first_name': firstName,
       'last_name': lastName,
+      'data_processing_consent_at': dataProcessingConsentAt,
+      'data_processing_consent_version': dataProcessingConsentVersion,
     };
   }
 
@@ -128,6 +140,9 @@ class LocalAuthUser {
       password: json['password'] as String? ?? '',
       firstName: json['first_name'] as String?,
       lastName: json['last_name'] as String?,
+      dataProcessingConsentAt: json['data_processing_consent_at'] as String?,
+      dataProcessingConsentVersion:
+          json['data_processing_consent_version'] as String?,
     );
   }
 }
@@ -140,6 +155,8 @@ class SignUpInput {
     required this.verificationCode,
     this.firstName,
     this.lastName,
+    required this.dataProcessingConsentAccepted,
+    required this.dataProcessingConsentVersion,
   });
 
   final String phoneNumber;
@@ -148,6 +165,8 @@ class SignUpInput {
   final String verificationCode;
   final String? firstName;
   final String? lastName;
+  final bool dataProcessingConsentAccepted;
+  final String dataProcessingConsentVersion;
 }
 
 class UpdateProfileInput {
@@ -308,6 +327,8 @@ class LocalAuthStore {
         'verification_code': verificationCode,
         'first_name': _normalizeOptionalText(input.firstName),
         'last_name': _normalizeOptionalText(input.lastName),
+        'data_processing_consent_accepted': input.dataProcessingConsentAccepted,
+        'data_processing_consent_version': input.dataProcessingConsentVersion,
       },
     );
     if (response.statusCode != 201) {
@@ -642,6 +663,9 @@ class LocalAuthStore {
       password: password,
       firstName: decoded['first_name'] as String?,
       lastName: decoded['last_name'] as String?,
+      dataProcessingConsentAt: decoded['data_processing_consent_at'] as String?,
+      dataProcessingConsentVersion:
+          decoded['data_processing_consent_version'] as String?,
     );
   }
 

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -53,6 +53,9 @@ const String _defaultLanguage = String.fromEnvironment(
   defaultValue: 'SK',
 );
 const String _localAutofillPhoneNumber = '+421944400166';
+const String _dataProcessingNoticeUrl =
+    'https://www.jurisdigta.eu/#data-processing-consent';
+const String _dataProcessingConsentVersion = '2026-05-06';
 final FileOpener _savedFileOpener = createFileOpener();
 
 const Map<String, String> _sessionExpiredMessagesByLanguage = <String, String>{
@@ -170,6 +173,11 @@ class AppStrings {
       'send_code': 'Poslať kód',
       'code_sent': 'Kód bol odoslaný na e-mail.',
       'send_code_failed': 'Odoslanie kódu zlyhalo: {{error}}',
+      'data_processing_consent_label':
+          'Súhlasím so spracovaním osobných a finančných údajov podľa právneho oznámenia.',
+      'data_processing_consent_link': 'Pozrieť právne oznámenie',
+      'data_processing_consent_required':
+          'Pred registráciou musíte potvrdiť právne oznámenie.',
       'account': 'Účet',
       'sign_out': 'Odhlásiť sa',
       'save_changes': 'Uložiť zmeny',
@@ -410,6 +418,11 @@ class AppStrings {
       'send_code': 'Send code',
       'code_sent': 'Code was sent to email.',
       'send_code_failed': 'Sending code failed: {{error}}',
+      'data_processing_consent_label':
+          'I agree with processing of personal and financial data according to the legal notice.',
+      'data_processing_consent_link': 'Review legal notice',
+      'data_processing_consent_required':
+          'You must confirm the legal notice before registration.',
       'account': 'Account',
       'sign_out': 'Sign out',
       'save_changes': 'Save changes',
@@ -645,6 +658,11 @@ class AppStrings {
       'send_code': 'Code senden',
       'code_sent': 'Code wurde per E-Mail gesendet.',
       'send_code_failed': 'Code senden fehlgeschlagen: {{error}}',
+      'data_processing_consent_label':
+          'Ich stimme der Verarbeitung personenbezogener und finanzieller Daten gemäß Rechtshinweis zu.',
+      'data_processing_consent_link': 'Rechtshinweis ansehen',
+      'data_processing_consent_required':
+          'Bitte bestätigen Sie den Rechtshinweis vor der Registrierung.',
       'account': 'Konto',
       'sign_out': 'Abmelden',
       'save_changes': 'Aenderungen speichern',
@@ -3011,6 +3029,7 @@ class _AuthEntryPageState extends State<AuthEntryPage>
   final TextEditingController _signUpLastNameController =
       TextEditingController();
   bool _showPhoneOtpSignIn = false;
+  bool _dataProcessingConsentAccepted = false;
   bool _isBusy = false;
   String _appVersionLabel = 'v0.1.5+43';
   String? _devicePhoneNumber;
@@ -3201,6 +3220,8 @@ class _AuthEntryPageState extends State<AuthEntryPage>
           verificationCode: _signUpVerificationCodeController.text,
           firstName: _signUpFirstNameController.text,
           lastName: _signUpLastNameController.text,
+          dataProcessingConsentAccepted: _dataProcessingConsentAccepted,
+          dataProcessingConsentVersion: _dataProcessingConsentVersion,
         ),
       );
       await widget.logger.info(
@@ -3566,6 +3587,41 @@ class _AuthEntryPageState extends State<AuthEntryPage>
                                                 ),
                                               ),
                                               const SizedBox(height: 16),
+                                              CheckboxListTile(
+                                                contentPadding: EdgeInsets.zero,
+                                                value:
+                                                    _dataProcessingConsentAccepted,
+                                                onChanged: (value) {
+                                                  setState(() {
+                                                    _dataProcessingConsentAccepted =
+                                                        value ?? false;
+                                                  });
+                                                },
+                                                title: Text(strings.t(
+                                                  'data_processing_consent_label',
+                                                )),
+                                              ),
+                                              Align(
+                                                alignment:
+                                                    Alignment.centerLeft,
+                                                child: TextButton(
+                                                  onPressed: () {
+                                                    launchUrl(
+                                                      Uri.parse(
+                                                        _dataProcessingNoticeUrl,
+                                                      ),
+                                                      mode: LaunchMode
+                                                          .externalApplication,
+                                                    );
+                                                  },
+                                                  child: Text(
+                                                    strings.t(
+                                                      'data_processing_consent_link',
+                                                    ),
+                                                  ),
+                                                ),
+                                              ),
+                                              const SizedBox(height: 8),
                                               SizedBox(
                                                 width: double.infinity,
                                                 child: FilledButton(
@@ -8297,3 +8353,7 @@ class _CameraCapturePageState extends State<CameraCapturePage> {
     );
   }
 }
+    if (!_dataProcessingConsentAccepted) {
+      _showSnackbar(_strings.t('data_processing_consent_required'));
+      return;
+    }

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ai_jurisdiction_mobile
-version: 0.1.5+54
+version: 0.1.5+55
 publish_to: none
 
 environment:

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260372"
+__version__ = "1.0.260373"

--- a/src/aijurisdictionagents/api_db/store.py
+++ b/src/aijurisdictionagents/api_db/store.py
@@ -31,6 +31,8 @@ class User:
     first_name: str | None
     last_name: str | None
     full_name: str
+    data_processing_consent_at: str | None
+    data_processing_consent_version: str | None
 
 
 @dataclass(frozen=True)
@@ -183,6 +185,8 @@ class ApiDatabaseStore:
                     first_name TEXT,
                     last_name TEXT,
                     full_name TEXT NOT NULL,
+                    data_processing_consent_at TEXT,
+                    data_processing_consent_version TEXT,
                     password_hash TEXT NOT NULL,
                     created_at TEXT NOT NULL
                 );
@@ -393,6 +397,8 @@ class ApiDatabaseStore:
         full_name: str | None = None,
         first_name: str | None = None,
         last_name: str | None = None,
+        data_processing_consent_at: str | None = None,
+        data_processing_consent_version: str | None = None,
     ) -> User:
         user_id = str(uuid.uuid4())
         now = _now_iso()
@@ -413,9 +419,10 @@ class ApiDatabaseStore:
                 conn,
                 """
                 INSERT INTO users(
-                    user_id, phone_number, email, first_name, last_name, full_name, password_hash, created_at
+                    user_id, phone_number, email, first_name, last_name, full_name,
+                    data_processing_consent_at, data_processing_consent_version, password_hash, created_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     user_id,
@@ -424,6 +431,8 @@ class ApiDatabaseStore:
                     normalized_first,
                     normalized_last,
                     resolved_full_name,
+                    data_processing_consent_at,
+                    data_processing_consent_version,
                     password_hash,
                     now,
                 ),
@@ -445,6 +454,8 @@ class ApiDatabaseStore:
             first_name=normalized_first,
             last_name=normalized_last,
             full_name=resolved_full_name,
+            data_processing_consent_at=data_processing_consent_at,
+            data_processing_consent_version=data_processing_consent_version,
         )
 
     def save_registration_code(
@@ -719,7 +730,7 @@ class ApiDatabaseStore:
             row = self._fetchone(
                 conn,
                 """
-                SELECT user_id, phone_number, email, first_name, last_name, full_name
+                SELECT user_id, phone_number, email, first_name, last_name, full_name, data_processing_consent_at, data_processing_consent_version
                 FROM users
                 WHERE phone_number = ?
                 """,
@@ -734,7 +745,7 @@ class ApiDatabaseStore:
             row = self._fetchone(
                 conn,
                 """
-                SELECT user_id, phone_number, email, first_name, last_name, full_name
+                SELECT user_id, phone_number, email, first_name, last_name, full_name, data_processing_consent_at, data_processing_consent_version
                 FROM users
                 WHERE user_id = ?
                 """,
@@ -749,7 +760,7 @@ class ApiDatabaseStore:
             row = self._fetchone(
                 conn,
                 """
-                SELECT user_id, phone_number, email, first_name, last_name, full_name
+                SELECT user_id, phone_number, email, first_name, last_name, full_name, data_processing_consent_at, data_processing_consent_version
                 FROM users
                 WHERE user_id = ?
                 """,
@@ -776,7 +787,7 @@ class ApiDatabaseStore:
             current = self._fetchone(
                 conn,
                 """
-                SELECT user_id, phone_number, email, first_name, last_name, full_name
+                SELECT user_id, phone_number, email, first_name, last_name, full_name, data_processing_consent_at, data_processing_consent_version
                 FROM users
                 WHERE user_id = ?
                 """,
@@ -832,6 +843,8 @@ class ApiDatabaseStore:
             first_name=normalized_first,
             last_name=normalized_last,
             full_name=resolved_full_name,
+            data_processing_consent_at=current_user.data_processing_consent_at,
+            data_processing_consent_version=current_user.data_processing_consent_version,
         )
 
     def create_company(self, *, legal_name: str, profile_json: str = "{}") -> Company:
@@ -1490,6 +1503,10 @@ class ApiDatabaseStore:
             self._execute(conn, "ALTER TABLE users ADD COLUMN first_name TEXT")
         if "last_name" not in columns:
             self._execute(conn, "ALTER TABLE users ADD COLUMN last_name TEXT")
+        if "data_processing_consent_at" not in columns:
+            self._execute(conn, "ALTER TABLE users ADD COLUMN data_processing_consent_at TEXT")
+        if "data_processing_consent_version" not in columns:
+            self._execute(conn, "ALTER TABLE users ADD COLUMN data_processing_consent_version TEXT")
         self._execute(
             conn,
             """
@@ -1800,6 +1817,8 @@ def _row_to_user(row: tuple[object, ...]) -> User:
         first_name=str(values[3]) if values[3] is not None else None,
         last_name=str(values[4]) if values[4] is not None else None,
         full_name=str(values[5]),
+        data_processing_consent_at=str(values[6]) if len(values) > 6 and values[6] is not None else None,
+        data_processing_consent_version=str(values[7]) if len(values) > 7 and values[7] is not None else None,
     )
 
 


### PR DESCRIPTION
### Motivation
- Provide an explicit corporate legal notice about processing of personal and financial data so users understand responsibilities when adding third-party or sensitive data to documents. 
- Capture and persist user confirmation of that notice during account registration so the system records consent metadata for audit and compliance tracking. 
- Surface consent state in API user profiles and mobile client flows so downstream workflows can reference recorded consent. 

### Description
- Added a corporate web legal card `#data-processing-consent` with GDPR / EU AI Act transparency text and a footer link in `corporate-web/index.html`. 
- Added consent capture to the API by extending the user model and schema with `data_processing_consent_at` and `data_processing_consent_version`, accepting `data_processing_consent_accepted`/`data_processing_consent_version` in sign-up payloads, and requiring consent for `/v1/users/sign-up/complete` in `api/aijuristiction-api/app/users/api.py` and `src/aijurisdictionagents/api_db/store.py`. 
- Updated the mobile registration UX to include a consent checkbox and an external link to the corporate notice, and to send the consent fields to the API; persisted consent fields in local auth state in `mobile_app/lib/main.dart` and `mobile_app/lib/auth/local_auth_store.dart`. 
- Added schema evolution (`ALTER TABLE ... ADD COLUMN ...`) to backfill consent columns for existing DBs, updated API and core package revision numbers and mobile build (`mobile_app/pubspec.yaml`, `api/aijuristiction-api/pyproject.toml`, `src/aijurisdictionagents/__init__.py`), and documented the new legal section in `docs/CORPORATE_WEB.md`. 

### Testing
- Ran the users test suite with `pytest api/aijuristiction-api/tests/test_users.py -q`; an initial run surfaced a missing-field regression which was fixed and the suite was re-run. 
- Final automated test run `pytest api/aijuristiction-api/tests/test_users.py -q` succeeded (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbaa098e8c8332b6c59a91f365b4dd)