### PR TITLE
Update mobile app title, chat composer, speech timeout, mic behavior, and document export

### DIFF
--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -347,3 +347,10 @@ the app.
 Reference UI snapshot prepared for review of the mobile chat layout.
 
 Open `docs/chat_ui_snapshot.html` in a browser for the updated rebrand layout preview.
+
+## Recent UI updates
+- App title updated to **Jurisdigta AI Agent**.
+- Chat composer expands to a fixed 5-line input area when focused for better keyboard visibility on mobile.
+- Speech input now waits at least 30 seconds of pause before stopping and shows a user notice when auto-stopped.
+- Documents export button is enabled when the case has processed/generated documents.
+- Tapping the microphone now auto-enables speech input instead of only showing a disabled message.

--- a/mobile_app/android/app/src/main/AndroidManifest.xml
+++ b/mobile_app/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
     <application
-        android:label="JurisDigtA"
+        android:label="Jurisdigta AI Agent"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -237,6 +237,8 @@ class AppStrings {
       'speech_input_disabled': 'Vstup hlasom vypnutý',
       'speech_input_disabled_message':
           'Vstup hlasom je vypnutý. Zapnite ho tlačidlom Vstup hlasom.',
+      'speech_input_auto_stopped':
+          'Hlasový vstup bol po 30 sekundách ticha zastavený. Klepnite na mikrofón pre pokračovanie.',
       'speaker_output': 'Hlasový výstup asistenta',
       'speaker_voice_label': 'Hlas asistenta',
       'speaker_voice_unavailable': 'Pre zvolený jazyk nie je dostupný hlas.',
@@ -479,6 +481,8 @@ class AppStrings {
       'speech_input_disabled': 'Speech input off',
       'speech_input_disabled_message':
           'Speech input is turned off. Use the Speech input button to enable it.',
+      'speech_input_auto_stopped':
+          'Speech input paused for 30 seconds and was stopped. Tap the microphone to continue.',
       'speaker_output': 'Assistant voice output',
       'speaker_voice_label': 'Assistant voice',
       'speaker_voice_unavailable':
@@ -987,7 +991,7 @@ class AIJurisdictionMobileApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      title: 'AIJurisDigta',
+      title: 'Jurisdigta AI Agent',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
         useMaterial3: true,
@@ -4229,7 +4233,7 @@ class _ChatHomePageState extends State<ChatHomePage>
   static const double _questionTimeoutSeconds = 3600;
   static const double _maxDiscussionMinutes = 60;
   static const double _communicationMinutes = 60;
-  static const Duration _speechSilenceTimeout = Duration(seconds: 10);
+  static const Duration _speechSilenceTimeout = Duration(seconds: 30);
   static const Duration _speechMaxListenDuration = Duration(minutes: 30);
 
   final TextEditingController _inputController = TextEditingController();
@@ -5565,6 +5569,9 @@ class _ChatHomePageState extends State<ChatHomePage>
       ),
     );
     if (!isListening) {
+      if (!_stoppingSpeechManually && _speechInputEnabled && _lastFinalSpeechResult == null) {
+        _showSnackbar(_strings.t('speech_input_auto_stopped'));
+      }
       final shouldProcess = _processSpeechOnStop;
       final shouldSubmit = _submitSpeechOnStop;
       _processSpeechOnStop = true;
@@ -5649,6 +5656,7 @@ class _ChatHomePageState extends State<ChatHomePage>
     }
     final completer = Completer<void>();
     _speechStopCompleter = completer;
+    _stoppingSpeechManually = true;
     await _speechRecognizer.stop();
     if (!completer.isCompleted) {
       await completer.future.timeout(
@@ -5656,6 +5664,7 @@ class _ChatHomePageState extends State<ChatHomePage>
         onTimeout: () {},
       );
     }
+    _stoppingSpeechManually = false;
   }
 
   Future<void> _requestNewCaseFromCommand({
@@ -6004,8 +6013,10 @@ class _ChatHomePageState extends State<ChatHomePage>
       return;
     }
     if (!_speechInputEnabled) {
-      _showSnackbar(_strings.t('speech_input_disabled_message'));
-      return;
+      await _toggleSpeechInputEnabled();
+      if (!_speechInputEnabled || !mounted) {
+        return;
+      }
     }
     if (_isListening) {
       await _stopSpeechListening(submitAfterStop: true);
@@ -7495,9 +7506,9 @@ class _ChatHomePageState extends State<ChatHomePage>
     return TextField(
       controller: _inputController,
       focusNode: _inputFocusNode,
-      minLines: expanded ? null : 1,
-      maxLines: expanded ? null : 1,
-      expands: expanded,
+      minLines: expanded ? 5 : 1,
+      maxLines: expanded ? 5 : 1,
+      expands: false,
       keyboardType: TextInputType.multiline,
       textInputAction:
           expanded ? TextInputAction.newline : TextInputAction.send,
@@ -7994,7 +8005,8 @@ class _ChatHomePageState extends State<ChatHomePage>
                       ),
                       FilledButton.tonalIcon(
                         onPressed:
-                            (_isDownloading || _isSending || !_hasExportReady)
+                            (_isDownloading || _isSending ||
+                                    !(_hasExportReady || _hasGeneratedCaseDocuments))
                                 ? null
                                 : _downloadRequestedDocuments,
                         icon: _isDownloading

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ai_jurisdiction_mobile
-version: 0.1.5+56
+version: 0.1.5+57
 publish_to: none
 
 environment:

--- a/mobile_app/web/index.html
+++ b/mobile_app/web/index.html
@@ -23,13 +23,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="ai_jurisdiction_mobile">
+  <meta name="apple-mobile-web-app-title" content="Jurisdigta AI Agent">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>ai_jurisdiction_mobile</title>
+  <title>Jurisdigta AI Agent</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/mobile_app/web/manifest.json
+++ b/mobile_app/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "ai_jurisdiction_mobile",
-    "short_name": "ai_jurisdiction_mobile",
+    "name": "Jurisdigta AI Agent",
+    "short_name": "Jurisdigta",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",


### PR DESCRIPTION
### Motivation
- Rebrand the mobile app surface and improve mobile chat UX so users can see the end of the input when the keyboard shows. 
- Make speech input more resilient to short pauses and inform users when the recognizer auto-stops. 
- Make the microphone action more helpful by auto-enabling speech input when disabled. 
- Ensure the Documents/export action is enabled when the current case already contains processed/generated documents.

### Description
- Changed the visible app title to `Jurisdigta AI Agent` in the Flutter `MaterialApp`, Android manifest, and web metadata (`mobile_app/lib/main.dart`, `mobile_app/android/app/src/main/AndroidManifest.xml`, `mobile_app/web/manifest.json`, `mobile_app/web/index.html`).
- Updated the chat composer so the focused input uses a fixed 5-line area (`minLines`/`maxLines` set to 5 and `expands:false`) to keep the input end visible when the keyboard opens (`mobile_app/lib/main.dart`).
- Increased the speech silence timeout to 30 seconds (`_speechSilenceTimeout`) and added a localized auto-stop notification message (`speech_input_auto_stopped`) shown when the recognizer stops due to pause but not when manually stopped (`mobile_app/lib/main.dart`).
- Made the mic tap flow auto-enable speech input if it was disabled by calling the existing toggle before starting listening, so the UI no longer only shows a disabled message (`mobile_app/lib/main.dart`).
- Enabled the Documents/export button when either `_hasExportReady` or case documents include processed/generated items by adding `_hasGeneratedCaseDocuments` and adjusting the button enable condition (`mobile_app/lib/main.dart`).
- Bumped the mobile build revision in `mobile_app/pubspec.yaml` from `0.1.5+56` to `0.1.5+57` and documented the UI changes in `mobile_app/README.md`.

### Testing
- Ran `git -C /workspace/aijurisdictionagents status --short` to confirm changes were staged and committed, which succeeded. 
- Attempted to format the modified Dart file with `cd mobile_app && dart format lib/main.dart`, but the environment lacks the Dart SDK and the command failed (`dart: command not found`).
- No CI/unit test runs were executed in this environment; formatting and full `flutter test` should be run in a developer environment or CI that has Flutter/Dart installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9065ba5083329203558aecda550e)