### PR TITLE
Fix mobile document download filename parsing

### DIFF
--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -210,6 +210,7 @@ PDF exports are downloaded through:
 Use the single `Documents` button above the message composer to download all user-requested export documents (summary + document PDF).
 If multiple export files are downloaded, the app now shows a picker list of the saved files and opens the selected file after the user taps it.
 On Android, saved PDF/case-document files are now opened through the platform file-opening flow instead of a raw `file://` launcher call, which avoids the previous `Could not open the saved file` failure for locally saved documents.
+Case-document downloads now correctly handle `Content-Disposition` variants (`filename*=UTF-8''...` and unquoted `filename=...`), which fixes failed downloads when backend filenames include UTF-8 characters.
 Buttons are enabled after AI stream emits `result`/`done` (PDF must be generated first).
 In `Real Agent` mode, when the lawyer decides a formal document is needed, the agent first asks for confirmation and the PDF buttons stay disabled until the follow-up reply actually prepares the document.
 The mobile app now also resets document-export readiness to `false` when a fresh session result is unavailable, so a previous case cannot leave the `Documents` button enabled for a new conversation.

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -2530,16 +2530,36 @@ class ApiClient {
     if (headerValue == null || headerValue.trim().isEmpty) {
       return null;
     }
-    final match = RegExp(r'filename="([^"]+)"', caseSensitive: false)
+
+    final utf8Match = RegExp(
+      r"filename\*=UTF-8''([^;]+)",
+      caseSensitive: false,
+    ).firstMatch(headerValue);
+    if (utf8Match != null) {
+      final encoded = utf8Match.group(1)?.trim();
+      if (encoded != null && encoded.isNotEmpty) {
+        return Uri.decodeComponent(encoded).trim();
+      }
+    }
+
+    final quotedMatch = RegExp(
+      r'filename="([^"]+)"',
+      caseSensitive: false,
+    ).firstMatch(headerValue);
+    if (quotedMatch != null) {
+      final quoted = quotedMatch.group(1)?.trim();
+      if (quoted != null && quoted.isNotEmpty) {
+        return quoted;
+      }
+    }
+
+    final plainMatch = RegExp(r'filename=([^;]+)', caseSensitive: false)
         .firstMatch(headerValue);
-    if (match == null) {
+    final plain = plainMatch?.group(1)?.trim();
+    if (plain == null || plain.isEmpty) {
       return null;
     }
-    final value = match.group(1)?.trim();
-    if (value == null || value.isEmpty) {
-      return null;
-    }
-    return value;
+    return plain.replaceAll('"', '').trim();
   }
 
   Future<ExportFilePayload> downloadExportPdf({

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ai_jurisdiction_mobile
-version: 0.1.5+58
+version: 0.1.5+59
 publish_to: none
 
 environment:


### PR DESCRIPTION
### Motivation
- Users reported that case documents could not be downloaded/opened from the mobile app because the app only accepted a very narrow `Content-Disposition` `filename="..."` header format.
- The change aims to make filename extraction robust to common server variants (RFC 5987 `filename*=UTF-8''...`, quoted `filename="..."`, and unquoted `filename=...`) so saved files have correct names and can be opened by the platform.
- The mobile version revision is bumped to follow the repository mobile app versioning rule.

### Description
- Rewrote `ApiClient._filenameFromContentDisposition` to parse `filename*=UTF-8''...`, then quoted `filename="..."`, then fallback to unquoted `filename=...` and URI-decode RFC5987 encoded names (`mobile_app/lib/main.dart`).
- Bumped the mobile build revision from `0.1.5+58` to `0.1.5+59` in `mobile_app/pubspec.yaml` per project rules.
- Updated `mobile_app/README.md` to document the compatibility fix for `Content-Disposition` variants when downloading case documents.

### Testing
- Ran repository checks and source change validation: `git status --short` and committed the changes (commit created successfully).
- Attempted `dart format mobile_app/lib/main.dart` but the `dart` CLI is not available in this environment so formatting could not be executed here.
- Attempted `flutter --version` but the `flutter` CLI is not available in this environment so full Flutter build/tests could not be run.
- Created PR metadata summarizing the change; no unit/integration tests were run due to the missing local Dart/Flutter toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1c8f5a0483328338d8f90c66b40f)