### PR TITLE
prepare-task: add cross-channel parity gate and multi-surface execution guidance

### DIFF
--- a/docs/PREPARE_TASK_SKILL.md
+++ b/docs/PREPARE_TASK_SKILL.md
@@ -11,3 +11,20 @@ Minimal runnable example:
 ```bash
 python examples/minimal_demo.py
 ```
+
+It now includes an explicit cross-channel parity gate so features that work in one surface (for example chat simulator document previews) are not considered ready until expected API/mobile/frontend behavior is specified as well.
+
+
+## Running the Skill Across Codex Surfaces
+
+Use one of these prompts in chat:
+
+- `$prepare-task`
+- `Here is my idea for a feature. Prepare the task.`
+- `Turn this into a GitHub task and ask me all missing technical/compliance questions first.`
+
+Supported usage pattern (same intent in each surface):
+
+- **VS Code:** start repository chat with `$prepare-task` (or a trigger phrase), answer follow-up questions, and confirm before any GitHub updates.
+- **Codex Web:** run the same prompt in workspace chat and continue the readiness interview flow.
+- **Codex Desktop:** use the same prompt in project chat; keep the same readiness gate before implementation.

--- a/skills/prepare-task/SKILL.md
+++ b/skills/prepare-task/SKILL.md
@@ -9,6 +9,28 @@ description: Prepare an idea or GitHub Project task for implementation in this r
 
 Turn a loose idea or existing GitHub Project task into an implementation-ready task description. In chat, run an interview flow: collect the idea, review repository context, ask only necessary questions, draft the task, and ask for explicit confirmation before creating or updating a GitHub issue/project item.
 
+
+## How to Execute This Skill (VS Code, Codex Web, Codex Desktop)
+
+Use any of these invocation styles in chat:
+
+- Direct skill call: `$prepare-task`
+- Natural language trigger examples:
+  - `Here is my idea for a feature. Prepare the task.`
+  - `Turn this into a GitHub task and ask me the missing questions first.`
+  - `Read this task description and make it implementation-ready.`
+
+Platform notes:
+
+- **VS Code (Codex extension):** open repository chat and start with `$prepare-task` or a trigger phrase. Keep answering follow-up questions until readiness is reached.
+- **Codex Web:** open the repository workspace chat and start with `$prepare-task` or a trigger phrase; confirm before issue/project updates.
+- **Codex Desktop:** in the project chat, use `$prepare-task` or the same trigger phrases; workflow and output format should match web/VS Code.
+
+Execution rule:
+
+- Run this skill first for idea intake.
+- Start implementation only after the task output says it is ready and blocking questions are resolved.
+
 ## Chat Intake
 
 When the user gives a feature idea directly in chat:
@@ -61,6 +83,22 @@ Review only the areas relevant to the idea, then summarize what was learned:
 - `.github/workflows/`, `infra/`, and `docs/GITHUB_ENVIRONMENTS.md` for deployment/input changes.
 - `databases/<projectname>/` and `runs/storage/<projectname>/` rules for database-related work.
 
+
+## Cross-Channel Parity Gate (Chat Simulator / API / Mobile / Frontend)
+
+For any feature that presents or renders user-visible outputs (especially document templates, previews, and PDFs), explicitly verify expected behavior per channel before marking readiness.
+
+Required parity questions (ask when not already answered):
+
+- Which channels are in scope: chat simulator, API direct, mobile app, web frontend, or all?
+- Must behavior be identical across channels, or are differences intentional?
+- For document/PDF flows, where is rendering performed (server/client/hybrid) and which endpoint/contract is authoritative?
+- What authentication/authorization is required per channel for fetching generated outputs?
+- What is the expected UX per channel for loading/error/empty/offline states?
+- Are share/download/open-in-external-app flows required on mobile/web?
+
+If any in-scope channel behavior remains unspecified, keep the task as **Not Ready Yet** and list blockers under Open Questions.
+
 ## Question Areas
 
 Ask questions only where the answer is missing or ambiguous:
@@ -70,7 +108,7 @@ Ask questions only where the answer is missing or ambiguous:
 - Data: personal data categories, input/output records, retention, deletion, consent, and audit needs.
 - Legal-risk output: whether the feature advises, drafts, judges, scores, classifies, or automates legal decisions.
 - Architecture: components, orchestration, agents/tools, persistence, external services, and failure modes.
-- UX/API contract: screens, endpoints, request/response shape, permissions, errors, and localization.
+- UX/API contract: screens, endpoints, request/response shape, permissions, errors, localization, and channel parity expectations.
 - Testing: unit, integration, e2e, visual, migration, privacy/compliance, and deterministic mock coverage.
 - Operations: logging, telemetry, secrets, environment variables, GitHub Environment setup, and deployment.
 - Documentation: docs to update and minimal runnable example expectations.
@@ -113,6 +151,7 @@ A task is ready for implementation only when:
 - Test and documentation requirements are specific.
 - The minimal runnable example requirement is named, defaulting to `python examples/minimal_demo.py`.
 - No blocking questions remain.
+- Cross-channel parity (chat simulator/API/mobile/frontend) is explicit for all in-scope channels.
 
 ## Minimal Example
 

--- a/skills/prepare-task/references/task-description-template.md
+++ b/skills/prepare-task/references/task-description-template.md
@@ -42,6 +42,15 @@ Use this template when preparing an existing GitHub issue/project task or creati
 - Migrations/seeds:
 - External services:
 
+### Channel Parity Matrix
+
+| Channel | In Scope | Expected Behavior | Contract/Endpoint | Auth | Error/Offline UX |
+|---|---|---|---|---|---|
+| Chat simulator |  |  |  |  |  |
+| API direct |  |  |  |  |  |
+| Mobile app |  |  |  |  |  |
+| Web frontend |  |  |  |  |  |
+
 ### Acceptance Criteria
 
 - [ ] 


### PR DESCRIPTION
### Motivation

- Ensure features that render user-visible outputs are validated for consistent behavior across chat simulator, API, mobile, and web before marking tasks ready.
- Provide clear, consistent invocation and execution guidance for the `prepare-task` skill across VS Code, Codex Web, and Codex Desktop surfaces.
- Make readiness gating and compliance checks explicit so repository-aware task preparation blocks implementation until parity and compliance questions are resolved.

### Description

- Updated `docs/PREPARE_TASK_SKILL.md` to document the new explicit cross-channel parity gate and to add multi-surface running instructions and invocation examples like `$prepare-task`.
- Extended `skills/prepare-task/SKILL.md` with platform notes for VS Code/Codex Web/Codex Desktop, added the Cross-Channel Parity Gate section with required parity questions, and tightened the Ready Criteria to require explicit channel parity.
- Added a `Channel Parity Matrix` table to `skills/prepare-task/references/task-description-template.md` so prepared tasks capture expected behavior, contract, auth, and UX per channel.

### Testing

- No automated tests were run for these documentation and guidance changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee11f33e88332917471953b355cbf)