### PR TITLE
Add law-collector PostgreSQL backup/validation and Azure copy scripts

### DIFF
--- a/Deployment/Databases/law-collector/README.md
+++ b/Deployment/Databases/law-collector/README.md
@@ -1,0 +1,48 @@
+# Law collector DB backup and copy scripts
+
+This folder contains scripts to back up a local up-to-date PostgreSQL laws database and copy it to another PostgreSQL environment (including Azure Database for PostgreSQL).
+
+## Scripts
+
+- `backup_and_validate_laws_db.ps1`
+  - Creates a PostgreSQL custom-format backup (`pg_dump`).
+  - Validates data quality for the requested country and year range:
+    - at least one law exists for every year from 1995 to current year
+    - every law version has an embedding vector
+    - every law version has matching metadata
+  - Writes a JSON validation report beside the backup.
+
+- `copy_to_azure_postgres.ps1`
+  - Exports source DB with `pg_dump`.
+  - Imports to target PostgreSQL using `pg_restore --clean --if-exists`.
+  - Runs sanity checks (`law_documents`, `law_versions`, `law_metadata` counts).
+
+## Requirements
+
+- PowerShell 7+
+- PostgreSQL client tools available in PATH: `pg_dump`, `pg_restore`, `psql`
+- Network connectivity to source and target PostgreSQL instances
+- For Azure targets, use SSL-enabled connection strings (for example with `sslmode=require`)
+
+## Example usage
+
+```powershell
+# Backup + validation (defaults LAWS_DB_CLOUD, years 1995..current, country SK)
+./Deployment/Databases/law-collector/backup_and_validate_laws_db.ps1
+
+# Backup + validation with explicit connection
+./Deployment/Databases/law-collector/backup_and_validate_laws_db.ps1 `
+  -ConnectionString "postgresql://user:pass@127.0.0.1:5432/laws_sk"
+
+# Copy to Azure PostgreSQL
+./Deployment/Databases/law-collector/copy_to_azure_postgres.ps1 `
+  -SourceConnectionString "postgresql://user:pass@127.0.0.1:5432/laws_sk" `
+  -TargetConnectionString "postgresql://jurisadmin:pass@server.postgres.database.azure.com:5432/laws_sk?sslmode=require"
+```
+
+## GDPR + EU AI Act guardrails applied
+
+- Scripts process only database-level legal corpus records and produce aggregate validation output (no additional personal-data enrichment).
+- Validation report stores only counts and year-level coverage gaps (data-minimization).
+- Backups should be retained and deleted per your environment retention policy.
+- Keep execution logs for traceability and human oversight before promoting restored data to production.

--- a/Deployment/Databases/law-collector/backup_and_validate_laws_db.ps1
+++ b/Deployment/Databases/law-collector/backup_and_validate_laws_db.ps1
@@ -1,0 +1,90 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$ConnectionString = $env:LAWS_DB_CLOUD,
+
+    [Parameter(Mandatory = $false)]
+    [string]$BackupRoot = "runs/storage/laws-collector/postgres/backups",
+
+    [Parameter(Mandatory = $false)]
+    [int]$StartYear = 1995,
+
+    [Parameter(Mandatory = $false)]
+    [int]$EndYear = (Get-Date).Year,
+
+    [Parameter(Mandatory = $false)]
+    [string]$CountryCode = "SK"
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($ConnectionString)) {
+    throw "Connection string is empty. Pass -ConnectionString or set LAWS_DB_CLOUD."
+}
+
+$null = New-Item -ItemType Directory -Path $BackupRoot -Force
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$backupFile = Join-Path $BackupRoot ("laws-collector-{0}.dump" -f $timestamp)
+$reportFile = Join-Path $BackupRoot ("laws-validation-{0}.json" -f $timestamp)
+
+Write-Host "Creating PostgreSQL backup: $backupFile"
+pg_dump --format=custom --file "$backupFile" "$ConnectionString"
+
+Write-Host "Running validation checks (country=$CountryCode, years=$StartYear..$EndYear)"
+$validationSql = @"
+WITH years AS (
+  SELECT generate_series($StartYear, $EndYear) AS law_year
+),
+coverage AS (
+  SELECT y.law_year,
+         EXISTS (
+            SELECT 1
+            FROM law_documents d
+            WHERE d.country_code = '$CountryCode'
+              AND d.law_year = y.law_year
+         ) AS has_law
+  FROM years y
+),
+version_checks AS (
+  SELECT
+      COUNT(*) FILTER (WHERE vector_dims(v.embedding_vector) > 0) AS versions_with_embeddings,
+      COUNT(*) AS total_versions,
+      COUNT(m.version_id) AS versions_with_metadata
+  FROM law_versions v
+  LEFT JOIN law_metadata m ON m.version_id = v.version_id
+  JOIN law_documents d ON d.document_id = v.document_id
+  WHERE d.country_code = '$CountryCode'
+    AND d.law_year BETWEEN $StartYear AND $EndYear
+)
+SELECT json_build_object(
+  'country_code', '$CountryCode',
+  'start_year', $StartYear,
+  'end_year', $EndYear,
+  'missing_years', COALESCE((SELECT json_agg(law_year) FROM coverage WHERE has_law = false), '[]'::json),
+  'versions_with_embeddings', (SELECT versions_with_embeddings FROM version_checks),
+  'versions_with_metadata', (SELECT versions_with_metadata FROM version_checks),
+  'total_versions', (SELECT total_versions FROM version_checks)
+) AS report;
+"@
+
+$reportJson = psql "$ConnectionString" -X -A -t -v ON_ERROR_STOP=1 -c "$validationSql"
+$reportJson | Set-Content -Encoding UTF8 $reportFile
+
+$report = $reportJson | ConvertFrom-Json
+$missingYearsCount = @($report.missing_years).Count
+$embeddingComplete = [int]$report.versions_with_embeddings -eq [int]$report.total_versions
+$metadataComplete = [int]$report.versions_with_metadata -eq [int]$report.total_versions
+
+if ($missingYearsCount -gt 0) {
+    throw "Validation failed: missing laws for years: $($report.missing_years -join ', '). Report: $reportFile"
+}
+if (-not $embeddingComplete) {
+    throw "Validation failed: embeddings incomplete ($($report.versions_with_embeddings)/$($report.total_versions)). Report: $reportFile"
+}
+if (-not $metadataComplete) {
+    throw "Validation failed: metadata incomplete ($($report.versions_with_metadata)/$($report.total_versions)). Report: $reportFile"
+}
+
+Write-Host "Validation passed."
+Write-Host "Backup: $backupFile"
+Write-Host "Validation report: $reportFile"

--- a/Deployment/Databases/law-collector/copy_to_azure_postgres.ps1
+++ b/Deployment/Databases/law-collector/copy_to_azure_postgres.ps1
@@ -1,0 +1,35 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$SourceConnectionString,
+
+    [Parameter(Mandatory = $true)]
+    [string]$TargetConnectionString,
+
+    [Parameter(Mandatory = $false)]
+    [string]$TempRoot = "runs/storage/laws-collector/postgres/transfers"
+)
+
+$ErrorActionPreference = "Stop"
+$null = New-Item -ItemType Directory -Path $TempRoot -Force
+
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$dumpFile = Join-Path $TempRoot ("laws-collector-transfer-{0}.dump" -f $timestamp)
+
+Write-Host "Exporting source database to $dumpFile"
+pg_dump --format=custom --file "$dumpFile" "$SourceConnectionString"
+
+Write-Host "Restoring dump to target PostgreSQL"
+pg_restore --clean --if-exists --no-owner --no-privileges --dbname "$TargetConnectionString" "$dumpFile"
+
+Write-Host "Running post-restore sanity checks"
+$sanitySql = @"
+SELECT
+  (SELECT COUNT(*) FROM law_documents) AS law_documents_count,
+  (SELECT COUNT(*) FROM law_versions) AS law_versions_count,
+  (SELECT COUNT(*) FROM law_metadata) AS law_metadata_count;
+"@
+psql "$TargetConnectionString" -X -v ON_ERROR_STOP=1 -c "$sanitySql"
+
+Write-Host "Deployment to target PostgreSQL completed successfully."
+Write-Host "Transfer dump: $dumpFile"


### PR DESCRIPTION
### Motivation
- Provide a repeatable way to back up the local laws PostgreSQL database, validate core data completeness, and allow copying/restoring the DB into a new environment (including Azure Database for PostgreSQL).
- Ensure data-minimization and traceability by producing an aggregate JSON validation report and documenting GDPR / EU AI Act guardrails.

### Description
- Added `Deployment/Databases/law-collector/backup_and_validate_laws_db.ps1` which creates a `pg_dump` custom-format backup and runs validation checks for yearly coverage (default `1995..current`), embedding presence, and metadata presence, and writes a JSON report beside the backup.
- Added `Deployment/Databases/law-collector/copy_to_azure_postgres.ps1` which exports a source DB with `pg_dump`, restores it to a target PostgreSQL using `pg_restore --clean --if-exists`, and runs post-restore sanity row-count checks for `law_documents`, `law_versions`, and `law_metadata`.
- Added `Deployment/Databases/law-collector/README.md` containing prerequisites, example usage (including example `psql`/`pg_dump` commands), and the GDPR / EU AI Act guardrails applied to the scripts.

### Testing
- Environment/tooling check attempted: `pwsh -NoProfile -Command "Get-Command pg_dump | Out-Null"` failed because PowerShell (`pwsh`) is not present in the runner, so runtime script execution was not possible in this environment.
- Static verification confirmed the three new files exist at `Deployment/Databases/law-collector/` and contain the expected commands and SQL used for validation.
- No automated runtime validation of `pg_dump`/`pg_restore`/`psql` was executed; run the scripts in an environment with PowerShell 7+ and PostgreSQL client tools in `PATH` to perform full end-to-end tests (for example: `./Deployment/Databases/law-collector/backup_and_validate_laws_db.ps1 -ConnectionString "postgresql://user:pass@host:5432/laws_sk"`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03099e71248332af33df3379399edd)