### PR TITLE
[codex] Add branded non-OTP email templates

### DIFF
--- a/api/aijuristiction-api/app/services/email.py
+++ b/api/aijuristiction-api/app/services/email.py
@@ -6,7 +6,7 @@ import logging
 import os
 import smtplib
 from email.message import EmailMessage
-from typing import Any
+from typing import Any, cast
 
 logger = logging.getLogger("aijuristiction-api.email")
 
@@ -85,7 +85,7 @@ class EmailNotificationService:
         html_part: EmailMessage | None = None
         if html_body:
             message.add_alternative(html_body, subtype="html")
-            html_part = message.get_body(preferencelist=("html",))
+            html_part = cast(EmailMessage | None, message.get_body(preferencelist=("html",)))
         for attachment in attachments:
             _add_attachment(message=message, html_part=html_part, attachment=attachment)
 

--- a/api/aijuristiction-api/app/services/email.py
+++ b/api/aijuristiction-api/app/services/email.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import base64
 import logging
 import os
 import smtplib
@@ -46,22 +47,25 @@ class EmailNotificationService:
         html_body: str | None = None,
         attachments: list[dict[str, Any]] | None = None,
     ) -> None:
+        prepared_attachments = attachments or []
         if self.transport == "smtp":
             self._send_via_smtp(
                 recipient=recipient,
                 subject=subject,
                 body=body,
                 html_body=html_body,
-                attachments=attachments or [],
+                attachments=prepared_attachments,
             )
             return
         logger.info(
-            "Email notification (%s): from=%s to=%s subject=%s body=%s",
+            "Email notification (%s): from=%s to=%s subject=%s body_chars=%s html=%s attachments=%s",
             self.transport,
             self.sender,
             recipient,
             subject,
-            body,
+            len(body),
+            bool(html_body),
+            len(prepared_attachments),
         )
 
     def _send_via_smtp(
@@ -78,16 +82,12 @@ class EmailNotificationService:
         message["To"] = recipient
         message["Subject"] = subject
         message.set_content(body)
+        html_part: EmailMessage | None = None
         if html_body:
             message.add_alternative(html_body, subtype="html")
+            html_part = message.get_body(preferencelist=("html",))
         for attachment in attachments:
-            filename = str(attachment.get("filename") or "attachment.bin")
-            mime_type = str(attachment.get("mime_type") or "application/octet-stream")
-            payload = attachment.get("content")
-            if not isinstance(payload, (bytes, bytearray)):
-                continue
-            maintype, _, subtype = mime_type.partition("/")
-            message.add_attachment(bytes(payload), maintype=maintype or "application", subtype=subtype or "octet-stream", filename=filename)
+            _add_attachment(message=message, html_part=html_part, attachment=attachment)
 
         with smtplib.SMTP(self.smtp_host, self.smtp_port, timeout=10) as smtp:
             if self.smtp_use_tls:
@@ -95,6 +95,63 @@ class EmailNotificationService:
             if self.smtp_username and self.smtp_password:
                 smtp.login(self.smtp_username, self.smtp_password)
             smtp.send_message(message)
+
+
+def _add_attachment(
+    *,
+    message: EmailMessage,
+    html_part: EmailMessage | None,
+    attachment: dict[str, Any],
+) -> None:
+    filename = str(attachment.get("filename") or "attachment.bin")
+    mime_type = str(attachment.get("mime_type") or "application/octet-stream")
+    payload = _attachment_payload(attachment)
+    if payload is None:
+        return
+    maintype, subtype = _split_mime_type(mime_type)
+    content_id = _attachment_content_id(attachment)
+    if html_part is not None and content_id:
+        html_part.add_related(
+            payload,
+            maintype=maintype,
+            subtype=subtype,
+            cid=_format_content_id(content_id),
+            filename=filename,
+        )
+        return
+    message.add_attachment(payload, maintype=maintype, subtype=subtype, filename=filename)
+
+
+def _attachment_payload(attachment: dict[str, Any]) -> bytes | None:
+    payload = attachment.get("content")
+    if isinstance(payload, (bytes, bytearray)):
+        return bytes(payload)
+    encoded = attachment.get("content_base64")
+    if isinstance(encoded, str) and encoded.strip():
+        try:
+            return base64.b64decode(encoded.encode("utf-8"), validate=True)
+        except Exception:
+            return None
+    return None
+
+
+def _split_mime_type(mime_type: str) -> tuple[str, str]:
+    maintype, separator, subtype = mime_type.partition("/")
+    if not separator:
+        return "application", "octet-stream"
+    return maintype or "application", subtype or "octet-stream"
+
+
+def _attachment_content_id(attachment: dict[str, Any]) -> str | None:
+    raw = attachment.get("content_id")
+    if not isinstance(raw, str):
+        return None
+    content_id = raw.strip().strip("<>")
+    return content_id or None
+
+
+def _format_content_id(content_id: str) -> str:
+    return f"<{content_id.strip().strip('<>')}>"
 
 
 def _optional_env(name: str) -> str | None:

--- a/api/aijuristiction-api/app/services/email_scheduler.py
+++ b/api/aijuristiction-api/app/services/email_scheduler.py
@@ -110,7 +110,7 @@ def _decode_attachments(raw: object) -> list[dict[str, Any]]:
     return decoded
 
 
-def _optional_metadata_str(item: dict[str, object], key: str) -> str | None:
+def _optional_metadata_str(item: dict[Any, Any], key: str) -> str | None:
     value = item.get(key)
     if not isinstance(value, str):
         return None

--- a/api/aijuristiction-api/app/services/email_scheduler.py
+++ b/api/aijuristiction-api/app/services/email_scheduler.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from app.services.email import EmailNotificationService
 from app.services.email_queue import EmailQueueStore
+from app.services.email_templates import ensure_branded_email_metadata
 
 logger = logging.getLogger("aijuristiction-api.email.scheduler")
 
@@ -39,12 +40,17 @@ class EmailScheduler:
         processed = 0
         for item in queued:
             try:
+                metadata = ensure_branded_email_metadata(
+                    subject=item.subject,
+                    body=item.body,
+                    metadata=item.metadata,
+                )
                 self.email_service.send_email(
                     recipient=item.recipient,
                     subject=item.subject,
                     body=item.body,
-                    html_body=_metadata_str(item.metadata, "html_body"),
-                    attachments=_decode_attachments(item.metadata.get("attachments")),
+                    html_body=_metadata_str(metadata, "html_body"),
+                    attachments=_decode_attachments(metadata.get("attachments")),
                 )
                 self.queue_store.mark_sent(email_id=item.email_id)
                 processed += 1
@@ -75,10 +81,10 @@ def _metadata_str(metadata: object, key: str) -> str | None:
     return str(value) if isinstance(value, str) and value.strip() else None
 
 
-def _decode_attachments(raw: object) -> list[dict[str, object]]:
+def _decode_attachments(raw: object) -> list[dict[str, Any]]:
     if not isinstance(raw, list):
         return []
-    decoded: list[dict[str, object]] = []
+    decoded: list[dict[str, Any]] = []
     for item in raw:
         if not isinstance(item, dict):
             continue
@@ -89,11 +95,24 @@ def _decode_attachments(raw: object) -> list[dict[str, object]]:
             payload = base64.b64decode(content.encode("utf-8"), validate=True)
         except Exception:
             continue
-        decoded.append(
-            {
-                "filename": str(item.get("filename") or "attachment.bin"),
-                "mime_type": str(item.get("mime_type") or "application/octet-stream"),
-                "content": payload,
-            }
-        )
+        decoded_item: dict[str, Any] = {
+            "filename": str(item.get("filename") or "attachment.bin"),
+            "mime_type": str(item.get("mime_type") or "application/octet-stream"),
+            "content": payload,
+        }
+        content_id = _optional_metadata_str(item, "content_id")
+        if content_id is not None:
+            decoded_item["content_id"] = content_id
+        disposition = _optional_metadata_str(item, "disposition")
+        if disposition is not None:
+            decoded_item["disposition"] = disposition
+        decoded.append(decoded_item)
     return decoded
+
+
+def _optional_metadata_str(item: dict[str, object], key: str) -> str | None:
+    value = item.get(key)
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None

--- a/api/aijuristiction-api/app/services/email_templates.py
+++ b/api/aijuristiction-api/app/services/email_templates.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from html import escape
+from typing import Any
+
+HEADER_CID = "jurisdigta-email-header@jurisdigta"
+FOOTER_CID = "jurisdigta-email-footer@jurisdigta"
+_BRANDED_TEMPLATE_VERSION = "jurisdigta-email-v1"
+_OTP_EVENTS = {"registration_code", "sign_in_code", "otp", "one_time_code"}
+
+_HEADER_SVG = """<svg xmlns="http://www.w3.org/2000/svg" width="900" height="210" viewBox="0 0 900 210" role="img" aria-label="JurisDigta header"><rect width="900" height="210" fill="#f8fafc"/><path d="M0 0h900v24H0z" fill="#1b7f8e"/><path d="M0 186h900v24H0z" fill="#d6a84f"/><rect x="64" y="54" width="96" height="96" rx="18" fill="#ffffff" stroke="#1b7f8e" stroke-width="6"/><path d="M112 82v42M88 104l24-10 24 10M88 104l-12 22M136 104l12 22" fill="none" stroke="#172033" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/><circle cx="76" cy="126" r="9" fill="#d6a84f"/><circle cx="148" cy="126" r="9" fill="#d6a84f"/><circle cx="112" cy="94" r="9" fill="#1b7f8e"/><rect x="96" y="126" width="32" height="20" rx="3" fill="#172033"/><text x="190" y="98" font-family="Georgia, 'Times New Roman', serif" font-size="42" font-weight="700" fill="#172033">JurisDigta</text><text x="192" y="134" font-family="Arial, sans-serif" font-size="20" fill="#475569">Professional legal workflow notification</text></svg>"""
+
+_FOOTER_SVG = """<svg xmlns="http://www.w3.org/2000/svg" width="900" height="150" viewBox="0 0 900 150" role="img" aria-label="JurisDigta footer"><rect width="900" height="150" fill="#172033"/><path d="M0 0h900v8H0z" fill="#d6a84f"/><text x="64" y="58" font-family="Georgia, 'Times New Roman', serif" font-size="25" font-weight="700" fill="#ffffff">JurisDigta</text><text x="64" y="91" font-family="Arial, sans-serif" font-size="16" fill="#cbd5e1">AI-assisted legal documents require user or professional review before filing, signing, or reliance.</text><text x="64" y="120" font-family="Arial, sans-serif" font-size="14" fill="#94a3b8">Privacy by design | GDPR-aware workflows | EU AI Act human oversight</text></svg>"""
+
+
+@dataclass(frozen=True)
+class BrandedEmail:
+    subject: str
+    text_body: str
+    html_body: str
+    inline_attachments: list[dict[str, str]]
+
+    def metadata(self, **values: Any) -> dict[str, Any]:
+        metadata: dict[str, Any] = dict(values)
+        metadata["html_body"] = self.html_body
+        metadata["attachments"] = list(self.inline_attachments)
+        metadata["template"] = _BRANDED_TEMPLATE_VERSION
+        return metadata
+
+
+def build_welcome_email(*, full_name: str) -> BrandedEmail:
+    name = _display_name(full_name)
+    subject = "Welcome to AI Jurisdiction"
+    body = (
+        f"Hello {name},\n\n"
+        "your account was created successfully. "
+        "You can now sign in and start working with your legal assistant.\n\n"
+        "Generated legal outputs should be reviewed before filing, signing, or relying on them.\n"
+    )
+    html = _render_branded_layout(
+        title="Welcome to JurisDigta",
+        greeting=f"Hello {name},",
+        paragraphs=[
+            "Your account was created successfully.",
+            "You can now sign in and continue your legal workflow with privacy-aware document support.",
+            "Generated legal outputs should be reviewed before filing, signing, or relying on them.",
+        ],
+        details=[("Account status", "Ready to use")],
+    )
+    return _email(subject=subject, text_body=body, html_body=html)
+
+
+def build_subscription_change_email(*, full_name: str, plan_code: str) -> BrandedEmail:
+    name = _display_name(full_name)
+    plan = _display_value(plan_code)
+    subject = "Subscription change requested"
+    body = (
+        f"Hello {name},\n\n"
+        f"your subscription change request to plan '{plan}' was recorded and is now pending.\n"
+    )
+    html = _render_branded_layout(
+        title="Subscription Change Requested",
+        greeting=f"Hello {name},",
+        paragraphs=["Your subscription change request was recorded and is now pending."],
+        details=[("Requested plan", plan), ("Status", "Pending")],
+    )
+    return _email(subject=subject, text_body=body, html_body=html)
+
+
+def build_subscription_status_email(*, full_name: str, plan_code: str, status: str) -> BrandedEmail:
+    name = _display_name(full_name)
+    plan = _display_value(plan_code)
+    normalized_status = _display_value(status)
+    if status == "paid":
+        subject = "Payment confirmed"
+        paragraphs = ["Payment for your subscription was confirmed and your plan is active."]
+        body = f"Hello {name},\n\npayment for your '{plan}' subscription was confirmed and your plan is active.\n"
+    elif status == "failed":
+        subject = "Payment failed"
+        paragraphs = ["Payment for your subscription failed. Please retry your payment method."]
+        body = f"Hello {name},\n\npayment for your '{plan}' subscription failed. Please retry your payment method.\n"
+    else:
+        subject = "Subscription status changed"
+        paragraphs = ["Your subscription status changed."]
+        body = f"Hello {name},\n\nyour subscription '{plan}' status changed to '{normalized_status}'.\n"
+    html = _render_branded_layout(
+        title=subject,
+        greeting=f"Hello {name},",
+        paragraphs=paragraphs,
+        details=[("Plan", plan), ("Status", normalized_status)],
+    )
+    return _email(subject=subject, text_body=body, html_body=html)
+
+
+def build_case_documents_email(*, case_subject: str, version: str, correlation_id: str) -> BrandedEmail:
+    subject_value = _display_value(case_subject) or "Generated legal documents"
+    version_value = _display_value(version) or "v1"
+    correlation_value = _display_value(correlation_id)
+    subject = f"Legal document package | {subject_value}"
+    body = (
+        "Dear client,\n\n"
+        f"Please find attached generated documents for case '{subject_value}'.\n\n"
+        "Review the generated legal documents before filing, signing, or relying on them.\n\n"
+        "Regards,\nJurisDigta Legal Team\n\n"
+        f"Case Subject: {subject_value}\nVersion: {version_value}\nCorrelation ID: {correlation_value}\n"
+    )
+    html = _render_branded_layout(
+        title="Legal Document Package",
+        greeting="Dear client,",
+        paragraphs=[
+            "Please find attached generated documents for the referenced case subject.",
+            "Review the generated legal documents before filing, signing, or relying on them.",
+        ],
+        details=[
+            ("Case subject", subject_value),
+            ("Version", version_value),
+            ("Correlation ID", correlation_value),
+        ],
+    )
+    return _email(subject=subject, text_body=body, html_body=html)
+
+
+def build_generic_branded_email(*, subject: str, body: str) -> BrandedEmail:
+    clean_subject = _display_value(subject) or "JurisDigta notification"
+    paragraphs = [paragraph for paragraph in _plain_text_paragraphs(body) if paragraph]
+    if not paragraphs:
+        paragraphs = ["This notification was generated by JurisDigta."]
+    html = _render_branded_layout(
+        title=clean_subject,
+        greeting=None,
+        paragraphs=paragraphs,
+        details=[],
+    )
+    return _email(subject=clean_subject, text_body=body, html_body=html)
+
+
+def ensure_branded_email_metadata(*, subject: str, body: str, metadata: dict[str, Any]) -> dict[str, Any]:
+    if _is_otp_metadata(subject=subject, metadata=metadata):
+        return metadata
+    if _metadata_has_current_branding(metadata):
+        return metadata
+
+    prepared = dict(metadata)
+    existing_attachments = _metadata_attachments(prepared)
+    existing_html = prepared.get("html_body")
+    if isinstance(existing_html, str) and existing_html.strip():
+        email = _email(
+            subject=subject,
+            text_body=body,
+            html_body=_wrap_existing_html(subject=subject, html_body=existing_html),
+        )
+    else:
+        email = build_generic_branded_email(subject=subject, body=body)
+    prepared["html_body"] = email.html_body
+    prepared["attachments"] = list(email.inline_attachments) + existing_attachments
+    prepared["template"] = _BRANDED_TEMPLATE_VERSION
+    return prepared
+
+
+def _is_otp_metadata(*, subject: str, metadata: dict[str, Any]) -> bool:
+    event = str(metadata.get("event") or "").strip().lower()
+    if event in _OTP_EVENTS:
+        return True
+    normalized_subject = subject.strip().lower()
+    return " code" in normalized_subject or normalized_subject.endswith("code")
+
+
+def _metadata_has_current_branding(metadata: dict[str, Any]) -> bool:
+    if metadata.get("template") != _BRANDED_TEMPLATE_VERSION:
+        return False
+    html_body = metadata.get("html_body")
+    attachments = _metadata_attachments(metadata)
+    return (
+        isinstance(html_body, str)
+        and f"cid:{HEADER_CID}" in html_body
+        and f"cid:{FOOTER_CID}" in html_body
+        and any(item.get("content_id") == HEADER_CID for item in attachments)
+        and any(item.get("content_id") == FOOTER_CID for item in attachments)
+    )
+
+
+def _metadata_attachments(metadata: dict[str, Any]) -> list[dict[str, Any]]:
+    attachments = metadata.get("attachments")
+    if not isinstance(attachments, list):
+        return []
+    return [dict(item) for item in attachments if isinstance(item, dict)]
+
+
+def _wrap_existing_html(*, subject: str, html_body: str) -> str:
+    return _render_branded_layout(
+        title=_display_value(subject) or "JurisDigta notification",
+        greeting=None,
+        paragraphs=[],
+        details=[],
+        raw_html=html_body,
+    )
+
+
+def _email(*, subject: str, text_body: str, html_body: str) -> BrandedEmail:
+    return BrandedEmail(
+        subject=subject,
+        text_body=text_body,
+        html_body=html_body,
+        inline_attachments=_inline_attachments(),
+    )
+
+
+def _render_branded_layout(
+    *,
+    title: str,
+    greeting: str | None,
+    paragraphs: list[str],
+    details: list[tuple[str, str]],
+    raw_html: str | None = None,
+) -> str:
+    detail_rows = "".join(
+        "<tr>"
+        f"<th style=\"padding:10px 12px;text-align:left;border-bottom:1px solid #e2e8f0;color:#475569;font-size:13px;\">{escape(label)}</th>"
+        f"<td style=\"padding:10px 12px;border-bottom:1px solid #e2e8f0;color:#172033;font-size:13px;\">{escape(value)}</td>"
+        "</tr>"
+        for label, value in details
+        if label and value
+    )
+    details_table = (
+        "<table role=\"presentation\" style=\"width:100%;border-collapse:collapse;margin:18px 0;border:1px solid #e2e8f0;\">"
+        f"{detail_rows}</table>"
+        if detail_rows
+        else ""
+    )
+    paragraph_html = "".join(
+        f"<p style=\"margin:0 0 14px;color:#334155;font-size:15px;line-height:1.6;\">{escape(paragraph)}</p>"
+        for paragraph in paragraphs
+    )
+    greeting_html = (
+        f"<p style=\"margin:0 0 14px;color:#172033;font-size:16px;line-height:1.6;font-weight:700;\">{escape(greeting)}</p>"
+        if greeting
+        else ""
+    )
+    raw_section = (
+        f"<div style=\"margin:0 0 18px;color:#334155;font-size:15px;line-height:1.6;\">{raw_html}</div>"
+        if raw_html
+        else ""
+    )
+    return f"""<!doctype html>
+<html lang="en">
+  <body style="margin:0;background:#eef2f7;padding:24px;font-family:Arial,Helvetica,sans-serif;">
+    <table role="presentation" style="width:100%;border-collapse:collapse;">
+      <tr>
+        <td align="center">
+          <table role="presentation" style="width:100%;max-width:760px;border-collapse:collapse;background:#ffffff;border:1px solid #dbe3ef;">
+            <tr><td><img src="cid:{HEADER_CID}" width="760" alt="JurisDigta" style="display:block;width:100%;height:auto;border:0;" /></td></tr>
+            <tr>
+              <td style="padding:28px 34px 26px;">
+                <h1 style="margin:0 0 18px;color:#172033;font-family:Georgia,'Times New Roman',serif;font-size:26px;line-height:1.25;">{escape(title)}</h1>
+                {greeting_html}
+                {paragraph_html}
+                {raw_section}
+                {details_table}
+                <p style="margin:18px 0 0;color:#475569;font-size:13px;line-height:1.55;">This email intentionally excludes unnecessary legal case detail. Keep account access private and contact support if the message is unexpected.</p>
+              </td>
+            </tr>
+            <tr><td><img src="cid:{FOOTER_CID}" width="760" alt="JurisDigta privacy and review footer" style="display:block;width:100%;height:auto;border:0;" /></td></tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>"""
+
+
+def _inline_attachments() -> list[dict[str, str]]:
+    return [
+        _inline_svg_attachment(
+            filename="jurisdigta-email-header.svg",
+            content_id=HEADER_CID,
+            content=_HEADER_SVG,
+        ),
+        _inline_svg_attachment(
+            filename="jurisdigta-email-footer.svg",
+            content_id=FOOTER_CID,
+            content=_FOOTER_SVG,
+        ),
+    ]
+
+
+def _inline_svg_attachment(*, filename: str, content_id: str, content: str) -> dict[str, str]:
+    return {
+        "filename": filename,
+        "mime_type": "image/svg+xml",
+        "content_base64": base64.b64encode(content.encode("utf-8")).decode("ascii"),
+        "content_id": content_id,
+        "disposition": "inline",
+    }
+
+
+def _plain_text_paragraphs(body: str) -> list[str]:
+    normalized = body.replace("\r\n", "\n").replace("\r", "\n")
+    return [" ".join(part.split()) for part in normalized.split("\n\n")]
+
+
+def _display_name(value: str) -> str:
+    return _display_value(value) or "client"
+
+
+def _display_value(value: str) -> str:
+    return " ".join(str(value or "").strip().split())

--- a/api/aijuristiction-api/app/users/notifications.py
+++ b/api/aijuristiction-api/app/users/notifications.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from app.services.email_scheduler import EmailScheduler
+from app.services.email_templates import (
+    build_subscription_change_email,
+    build_subscription_status_email,
+    build_welcome_email,
+)
 
 from aijurisdictionagents.api_db import User, UserSubscription
 
@@ -10,72 +16,54 @@ logger = logging.getLogger("aijuristiction-api.users.notifications")
 
 
 def queue_registration_email(*, scheduler: EmailScheduler, user: User) -> None:
+    email = build_welcome_email(full_name=user.full_name)
     _queue_email_safely(
         scheduler=scheduler,
         recipient=user.email,
-        subject="Welcome to AI Jurisdiction",
-        body=(
-            f"Hello {user.full_name},\n\n"
-            "your account was created successfully. "
-            "You can now sign in and start working with your legal assistant.\n"
-        ),
+        subject=email.subject,
+        body=email.text_body,
         context="registration",
-        metadata={"event": "registration", "user_id": user.user_id},
+        metadata=email.metadata(event="registration", user_id=user.user_id),
     )
 
 
 def queue_subscription_change_email(*, scheduler: EmailScheduler, user: User, item: UserSubscription) -> None:
+    email = build_subscription_change_email(full_name=user.full_name, plan_code=item.plan_code)
     _queue_email_safely(
         scheduler=scheduler,
         recipient=user.email,
-        subject="Subscription change requested",
-        body=(
-            f"Hello {user.full_name},\n\n"
-            f"your subscription change request to plan '{item.plan_code}' was recorded and is now pending.\n"
-        ),
+        subject=email.subject,
+        body=email.text_body,
         context="subscription_change",
-        metadata={"event": "subscription_change", "subscription_id": item.subscription_id},
+        metadata=email.metadata(event="subscription_change", subscription_id=item.subscription_id),
     )
 
 
 def queue_subscription_status_email(*, scheduler: EmailScheduler, user: User, item: UserSubscription) -> None:
+    email = build_subscription_status_email(
+        full_name=user.full_name,
+        plan_code=item.plan_code,
+        status=item.status,
+    )
     if item.status == "paid":
-        _queue_email_safely(
-            scheduler=scheduler,
-            recipient=user.email,
-            subject="Payment confirmed",
-            body=(
-                f"Hello {user.full_name},\n\n"
-                f"payment for your '{item.plan_code}' subscription was confirmed and your plan is active.\n"
-            ),
-            context="subscription_payment",
-            metadata={"event": "subscription_payment", "subscription_id": item.subscription_id},
-        )
-        return
-    if item.status == "failed":
-        _queue_email_safely(
-            scheduler=scheduler,
-            recipient=user.email,
-            subject="Payment failed",
-            body=(
-                f"Hello {user.full_name},\n\n"
-                f"payment for your '{item.plan_code}' subscription failed. Please retry your payment method.\n"
-            ),
-            context="subscription_payment_failed",
-            metadata={"event": "subscription_payment_failed", "subscription_id": item.subscription_id},
-        )
-        return
-
+        event = "subscription_payment"
+        context = "subscription_payment"
+    elif item.status == "failed":
+        event = "subscription_payment_failed"
+        context = "subscription_payment_failed"
+    else:
+        event = "subscription_status"
+        context = "subscription_status"
+    metadata = email.metadata(event=event, subscription_id=item.subscription_id)
+    if item.status not in {"paid", "failed"}:
+        metadata["status"] = item.status
     _queue_email_safely(
         scheduler=scheduler,
         recipient=user.email,
-        subject="Subscription status changed",
-        body=(
-            f"Hello {user.full_name},\n\n"
-            f"your subscription '{item.plan_code}' status changed to '{item.status}'.\n"
-        ),
-        context="subscription_status",
-        metadata={"event": "subscription_status", "subscription_id": item.subscription_id, "status": item.status},
+        subject=email.subject,
+        body=email.text_body,
+        context=context,
+        metadata=metadata,
     )
 
 
@@ -85,7 +73,7 @@ def _queue_email_safely(
     recipient: str,
     subject: str,
     body: str,
-    metadata: dict[str, str],
+    metadata: dict[str, Any],
     context: str,
 ) -> None:
     try:

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260425"
+version = "1.0.260426"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_email_templates.py
+++ b/api/aijuristiction-api/tests/test_email_templates.py
@@ -86,8 +86,8 @@ def test_scheduler_brands_legacy_non_otp_email_and_keeps_code_plain() -> None:
     assert second_email["attachments"] == []
 
 
-def test_smtp_sender_attaches_inline_assets_as_related(monkeypatch) -> None:
-    delivered = []
+def test_smtp_sender_attaches_inline_assets_as_related(monkeypatch: Any) -> None:
+    delivered: list[Any] = []
 
     class FakeSMTP:
         def __init__(self, host: str, port: int, timeout: int) -> None:
@@ -98,7 +98,7 @@ def test_smtp_sender_attaches_inline_assets_as_related(monkeypatch) -> None:
         def __enter__(self) -> "FakeSMTP":
             return self
 
-        def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
+        def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
             return None
 
         def starttls(self) -> None:
@@ -107,7 +107,7 @@ def test_smtp_sender_attaches_inline_assets_as_related(monkeypatch) -> None:
         def login(self, username: str, password: str) -> None:
             return None
 
-        def send_message(self, message) -> None:  # type: ignore[no-untyped-def]
+        def send_message(self, message: Any) -> None:
             delivered.append(message)
 
     monkeypatch.setattr("app.services.email.smtplib.SMTP", FakeSMTP)

--- a/api/aijuristiction-api/tests/test_email_templates.py
+++ b/api/aijuristiction-api/tests/test_email_templates.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from app.services.email import EmailNotificationService
-from app.services.email_queue import QueuedEmail
+from app.services.email_queue import EmailQueueStore, QueuedEmail
 from app.services.email_scheduler import EmailScheduler
 from app.services.email_templates import (
     FOOTER_CID,
@@ -72,8 +72,8 @@ def test_scheduler_brands_legacy_non_otp_email_and_keeps_code_plain() -> None:
             sent.append(kwargs)
 
     scheduler = EmailScheduler(
-        queue_store=FakeQueueStore(),
-        email_service=FakeEmailService(),  # type: ignore[arg-type]
+        queue_store=cast(EmailQueueStore, FakeQueueStore()),
+        email_service=cast(EmailNotificationService, FakeEmailService()),
     )
 
     assert scheduler.run_once(limit=10) == 2

--- a/api/aijuristiction-api/tests/test_email_templates.py
+++ b/api/aijuristiction-api/tests/test_email_templates.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.email import EmailNotificationService
+from app.services.email_queue import QueuedEmail
+from app.services.email_scheduler import EmailScheduler
+from app.services.email_templates import (
+    FOOTER_CID,
+    HEADER_CID,
+    build_welcome_email,
+    ensure_branded_email_metadata,
+)
+
+
+def test_branded_metadata_adds_inline_cid_assets_and_skips_otp() -> None:
+    metadata = ensure_branded_email_metadata(
+        subject="Payment confirmed",
+        body="Hello, payment was confirmed.",
+        metadata={"event": "subscription_payment"},
+    )
+
+    assert f"cid:{HEADER_CID}" in metadata["html_body"]
+    assert f"cid:{FOOTER_CID}" in metadata["html_body"]
+    assert metadata["template"] == "jurisdigta-email-v1"
+    assert any(item["content_id"] == HEADER_CID for item in metadata["attachments"])
+    assert any(item["content_id"] == FOOTER_CID for item in metadata["attachments"])
+
+    otp_metadata = {"event": "sign_in_code"}
+    assert (
+        ensure_branded_email_metadata(
+            subject="Your login code",
+            body="your one time login code is: 123456",
+            metadata=otp_metadata,
+        )
+        is otp_metadata
+    )
+
+
+def test_scheduler_brands_legacy_non_otp_email_and_keeps_code_plain() -> None:
+    sent: list[dict[str, Any]] = []
+
+    class FakeQueueStore:
+        def claim_pending(self, *, limit: int = 50) -> list[QueuedEmail]:
+            return [
+                QueuedEmail(
+                    "email-1",
+                    "paid@example.com",
+                    "Payment confirmed",
+                    "Hello, payment was confirmed.",
+                    {"event": "subscription_payment"},
+                    0,
+                ),
+                QueuedEmail(
+                    "email-2",
+                    "otp@example.com",
+                    "Your login code",
+                    "your one time login code is: 123456",
+                    {"event": "sign_in_code"},
+                    0,
+                ),
+            ]
+
+        def mark_sent(self, *, email_id: str) -> None:
+            sent.append({"marked_sent": email_id})
+
+        def mark_failed_attempt(self, *, email_id: str, error_message: str) -> None:  # pragma: no cover
+            raise AssertionError(error_message)
+
+    class FakeEmailService:
+        def send_email(self, **kwargs: Any) -> None:
+            sent.append(kwargs)
+
+    scheduler = EmailScheduler(
+        queue_store=FakeQueueStore(),
+        email_service=FakeEmailService(),  # type: ignore[arg-type]
+    )
+
+    assert scheduler.run_once(limit=10) == 2
+
+    first_email = sent[0]
+    assert f"cid:{HEADER_CID}" in first_email["html_body"]
+    assert any(item["content_id"] == HEADER_CID for item in first_email["attachments"])
+    second_email = sent[2]
+    assert second_email["html_body"] is None
+    assert second_email["attachments"] == []
+
+
+def test_smtp_sender_attaches_inline_assets_as_related(monkeypatch) -> None:
+    delivered = []
+
+    class FakeSMTP:
+        def __init__(self, host: str, port: int, timeout: int) -> None:
+            self.host = host
+            self.port = port
+            self.timeout = timeout
+
+        def __enter__(self) -> "FakeSMTP":
+            return self
+
+        def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
+            return None
+
+        def starttls(self) -> None:
+            return None
+
+        def login(self, username: str, password: str) -> None:
+            return None
+
+        def send_message(self, message) -> None:  # type: ignore[no-untyped-def]
+            delivered.append(message)
+
+    monkeypatch.setattr("app.services.email.smtplib.SMTP", FakeSMTP)
+    email = build_welcome_email(full_name="Test User")
+    service = EmailNotificationService(
+        sender="no-reply@jurisdigta.eu",
+        transport="smtp",
+        smtp_host="smtp.example.test",
+        smtp_port=587,
+        smtp_username=None,
+        smtp_password=None,
+        smtp_use_tls=False,
+    )
+
+    service.send_email(
+        recipient="recipient@example.com",
+        subject=email.subject,
+        body=email.text_body,
+        html_body=email.html_body,
+        attachments=email.inline_attachments,
+    )
+
+    assert len(delivered) == 1
+    raw = delivered[0].as_string()
+    assert "multipart/related" in raw
+    assert f"Content-ID: <{HEADER_CID}>" in raw
+    assert f"Content-ID: <{FOOTER_CID}>" in raw
+    assert f"cid:{HEADER_CID}" in raw
+    assert "image/svg+xml" in raw

--- a/docs/EMAIL_SETUP.md
+++ b/docs/EMAIL_SETUP.md
@@ -16,7 +16,27 @@ EMAIL_SMTP_USERNAME=no-reply@jurisdigta.eu
 EMAIL_SMTP_PASSWORD=<set from environment or secret store>
 ```
 
-For local queue-only testing, keep `EMAIL_TRANSPORT=log`. The API still writes messages to the email outbox, but the scheduler logs the email instead of sending it.
+For local queue-only testing, keep `EMAIL_TRANSPORT=log`. The API still writes messages to the email outbox, but the scheduler logs only safe delivery metadata instead of the full email body.
+
+## Branded non-OTP templates
+
+Non-OTP outbound emails use the JurisDigta branded HTML template in `api/aijuristiction-api/app/services/email_templates.py` with a readable plain-text fallback. The template uses inline CID SVG header and footer assets so mail clients do not load remote tracking images.
+
+Styled templates currently cover:
+
+- account welcome / registration-complete notification
+- subscription change requested
+- subscription status and payment notifications
+- generated case-document package delivery
+- legacy non-OTP outbox messages normalized by the email scheduler before delivery
+
+OTP and one-time-code emails remain plain text. This avoids placing verification codes in richer HTML previews or related image payloads and keeps code messages minimal.
+
+Privacy and compliance rules for templates:
+
+- Do not include SMTP secrets, API keys, raw legal document text, or unnecessary special-category personal data in templates.
+- Keep generated legal-document emails limited to package metadata and attachments; the footer reminds recipients that AI-assisted legal documents require review before filing, signing, or reliance.
+- The log transport records recipient, subject, body length, HTML presence, and attachment count, not full HTML or OTP body content.
 
 ## Local scheduler
 
@@ -87,6 +107,7 @@ The page can trigger:
 - registration test email
 - mobile-app OTP test email
 - payment confirmation test email
+- generated documents email
 
 Use **Transport** to choose how the simulator sends the test message:
 

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -8,3 +8,8 @@ for text in [
 ]:
     result = agent.recognize(text)
     print(text, "=>", result)
+
+print(
+    "email_templates => non-OTP outbound emails use branded HTML with plain-text fallback; "
+    "OTP/code emails remain plain text."
+)


### PR DESCRIPTION
## Summary
- Add a shared JurisDigta branded email renderer for non-OTP API notifications with inline CID SVG header/footer assets and plain-text fallbacks.
- Wire the email scheduler to normalize legacy non-OTP outbox messages before delivery while leaving OTP/code emails plain text.
- Update SMTP delivery to attach CID assets as related MIME parts and stop log transport from writing full email bodies.
- Add focused tests for template metadata, scheduler fallback branding, OTP exclusion, and SMTP related inline assets.
- Update email setup docs and the minimal runnable demo note.

## Scope
- API email services, user notification enqueue paths, docs, and minimal demo only.
- No new environment variables, database migrations, workflow inputs, or mobile/frontend changes.
- GDPR/EU AI Act posture: no remote tracking images, no new personal-data storage, plain-text OTP/code emails, safer log output, and legal-document review warning in branded footer.

## Validation
- Not run locally: PowerShell and Node execution are blocked in this Codex session by `windows sandbox failed: CreateProcessWithLogonW failed: 1326`.
- CI should run the API lint/type/test gates for this API change.

Closes #318