### PR TITLE
Fix lifecycle runner imports for direct script execution

### DIFF
--- a/scripts/lifecycle_agent_run.py
+++ b/scripts/lifecycle_agent_run.py
@@ -7,6 +7,11 @@ import sys
 from dataclasses import asdict
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
 from aijurisdictionagents.lifecycle import (
     DEFAULT_STAGE_ORDER,
     LifecycleAutomationConfig,


### PR DESCRIPTION
### Motivation
- Tests that invoke `scripts/lifecycle_agent_run.py` via `subprocess` failed because the script could not import the local `aijurisdictionagents` package when executed from the repository root, so the runner must be able to resolve the `src/` package path.

### Description
- Add a small repo bootstrap in `scripts/lifecycle_agent_run.py` that inserts the repository `src/` directory into `sys.path` before importing `aijurisdictionagents`, enabling the script to run directly.

### Testing
- Ran `pytest -q tests/test_lifecycle_agent_run.py` which passed. 
- Ran the full test suite with `pytest -q` which also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0594e5c3608332ae5959496180fecd)