### PR TITLE
Include new User MCP key fields in chat test fixtures

### DIFF
--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -855,6 +855,8 @@ def test_document_export_uses_user_profile_defaults_for_missing_party_data() -> 
         social_security_number="800102/1234",
         data_processing_consent_at=None,
         data_processing_consent_version=None,
+        mcp_api_key_hash=None,
+        mcp_api_key_expires_at=None,
     )
 
     title, lines = _build_document_export_content(
@@ -971,6 +973,8 @@ def test_document_export_extracts_rental_data_from_draft_text_and_profile() -> N
         social_security_number=None,
         data_processing_consent_at=None,
         data_processing_consent_version=None,
+        mcp_api_key_hash=None,
+        mcp_api_key_expires_at=None,
     )
 
     _title, lines = _build_document_export_content(
@@ -1033,6 +1037,8 @@ def test_document_export_does_not_use_phone_number_as_profile_name() -> None:
         social_security_number=None,
         data_processing_consent_at=None,
         data_processing_consent_version=None,
+        mcp_api_key_hash=None,
+        mcp_api_key_expires_at=None,
     )
 
     _title, lines = _build_document_export_content(


### PR DESCRIPTION
### Motivation
- CI unit tests failed because the `User` model constructor now requires `mcp_api_key_hash` and `mcp_api_key_expires_at`, causing test fixtures to raise `TypeError` when instantiating `User` in document-export tests.

### Description
- Updated three `User(...)` fixtures in `api/aijuristiction-api/tests/test_chat.py` to pass `mcp_api_key_hash=None` and `mcp_api_key_expires_at=None` so test construction matches the current `User` signature.

### Testing
- Ran the focused regression command `cd api/aijuristiction-api && pytest tests/test_chat.py -k 'document_export_uses_user_profile_defaults_for_missing_party_data or document_export_extracts_rental_data_from_draft_text_and_profile or document_export_does_not_use_phone_number_as_profile_name'` and the three tests passed.
- Ran the full chat test suite `cd api/aijuristiction-api && pytest tests/test_chat.py` and it completed successfully with all tests passing (109 passed, 2 warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05b16e85a88332b30833ed92aa3413)