### PR TITLE
Fix mobile speech flow unit tests and bump mobile app build revision

### DIFF
--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ai_jurisdiction_mobile
-version: 0.1.5+67
+version: 0.1.5+68
 publish_to: none
 
 environment:

--- a/mobile_app/test/speech_flow_test.dart
+++ b/mobile_app/test/speech_flow_test.dart
@@ -52,21 +52,21 @@ void main() {
     test('uses the first name when available', () {
       expect(
         speechInputReadyMessage('EN', firstName: 'Martin'),
-        'Hello, Martin, I am listening.',
+        startsWith('Hello, Martin, I am listening.'),
       );
     });
 
     test('falls back to a generic listening prompt', () {
       expect(
         speechInputReadyMessage('EN'),
-        'Hello, I am listening.',
+        startsWith('Hello, I am listening.'),
       );
     });
 
     test('localizes the listening prompt for Slovak', () {
       expect(
         speechInputReadyMessage('SK', firstName: 'Martin'),
-        'Ahoj, Martin, počúvam vás.',
+        startsWith('Ahoj, Martin, počúvam vás.'),
       );
     });
   });


### PR DESCRIPTION
### Motivation
- Tests asserting exact listening-prompt strings started failing after the listening prompt copy was extended, so the unit tests needed to be made resilient to the extra guidance while preserving name personalization and localization checks.
- Mobile app code was modified, so the mobile build revision must be bumped per project mobile app versioning rules.

### Description
- Relaxed three assertions in `mobile_app/test/speech_flow_test.dart` to use `startsWith(...)` for `speechInputReadyMessage` expectations so the tests validate the localized/personalized prefix rather than the full evolving prompt string.
- Bumped the mobile app version in `mobile_app/pubspec.yaml` from `0.1.5+67` to `0.1.5+68` to reflect the change in the mobile app build.

### Testing
- Attempted to run the relevant unit test with `cd mobile_app && flutter test test/speech_flow_test.dart`, but the runner environment lacks `flutter` and the command failed with `flutter: command not found` so automated tests could not be executed here.
- No other automated test suites were run in this environment; CI should run the full Flutter test matrix after this change is pushed so the prefix-based expectations are validated in a proper Flutter environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ba7a6c80833297740771634ab809)