### PR TITLE
Add interactive idea-task automation and skill for idea shaping

### DIFF
--- a/.codex/automations/README.md
+++ b/.codex/automations/README.md
@@ -45,6 +45,8 @@ prints token values.
 
 ## Current Automations
 
+Automation chain contract: `idea-task-agent` -> `prepare-task` -> `implementation-agent` -> review/merge -> `deployment-agent`. Implementation must start only from tasks that contain both readiness markers (`Idea Task Status: Ready for prepare-task.` and `Status: Ready for implementation.`).
+
 - `idea-task-agent`: interactive idea shaping pass for `/idea-task` prompts; asks focused questions, performs repository/compliance review, and outputs a draft ready for `prepare-task`.
 - `implementation-agent`: selects ready implementation tasks, moves them through project status, implements, fixes required validation failures, opens a PR, and moves successful work to In review.
 - `deployment-agent`: monitors failed deployment/build workflows and creates implementation-ready GitHub tasks for distinct unresolved failures.

--- a/.codex/automations/README.md
+++ b/.codex/automations/README.md
@@ -45,6 +45,7 @@ prints token values.
 
 ## Current Automations
 
+- `idea-task-agent`: interactive idea shaping pass for `/idea-task` prompts; asks focused questions, performs repository/compliance review, and outputs a draft ready for `prepare-task`.
 - `implementation-agent`: selects ready implementation tasks, moves them through project status, implements, fixes required validation failures, opens a PR, and moves successful work to In review.
 - `deployment-agent`: monitors failed deployment/build workflows and creates implementation-ready GitHub tasks for distinct unresolved failures.
 - `merge-agent`: closes out safe PRs by checking review status, checks, mergeability, linked task state, merge, issue comments, branch cleanup, and project status.

--- a/.codex/automations/idea-task-agent/automation.toml
+++ b/.codex/automations/idea-task-agent/automation.toml
@@ -1,0 +1,10 @@
+version = 1
+id = "idea-task-agent"
+kind = "manual"
+name = "Idea Task Agent"
+prompt = "Act as an idea-shaping agent for the aijurisdictionagents repository. Trigger context is usually '/idea-task [description]'. Do not implement code. Instead, inspect relevant repository files, ask up to three focused questions at a time, and produce an Idea Draft that is ready for the `prepare-task` skill. Evaluate GDPR and EU AI Act requirements before proposing implementation direction, including privacy-by-design, data minimization, retention/deletion, transparency, traceable logging, and human oversight for legal-risk outputs. If compliance conflicts exist, stop and provide compliant alternatives. Always include: Problem statement, Expected outcome, Scope, Related modules/files, Risks/technical debt, External dependencies, Observability expectations, Acceptance direction, Open questions, and final status (`Ready for prepare-task` or `Blocked`)."
+status = "ACTIVE"
+model = "gpt-5.5"
+reasoning_effort = "high"
+execution_environment = "worktree"
+cwds = ["__REPO_ROOT__"]

--- a/.codex/automations/implementation-agent/automation.toml
+++ b/.codex/automations/implementation-agent/automation.toml
@@ -9,7 +9,7 @@ Task source and hard eligibility gate:
 - Look at GitHub Project V2 https://github.com/users/mmaideveloper/projects/5.
 - Before selecting any task, verify GitHub CLI can read Project V2 metadata with `gh project item-list 5 --owner mmaideveloper --format json --limit 200`.
 - If Project V2 cannot be read, including missing `read:project` or `project` scopes, stop. Report the exact blocker and the command needed to refresh scopes, for example `gh auth refresh -s read:project -s project`. Do not select a task from issue search, issue comments, labels, title text, or readiness text alone.
-- A task is eligible only when the Project V2 Status field is exactly `Ready` and the issue readiness section contains exactly `Status: Ready for implementation.`.
+- A task is eligible only when the Project V2 Status field is exactly `Ready`, the prepared section contains exactly `Idea Task Status: Ready for prepare-task.`, and the issue readiness section contains exactly `Status: Ready for implementation.`.
 - Ignore and do not implement tasks in any other project status, including Backlog, In progress, In review, Done, Ready For Solution, or blank/missing status.
 - If a specific issue number is found or mentioned but its Project V2 Status is not exactly `Ready`, skip it and report that it was skipped because its status is not Ready.
 - Immediately before claiming a task, re-read its Project V2 item and confirm the Status is still exactly `Ready`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,9 @@ If the user asks to close a task:
 
 Custom project skills:
 
+- `idea-task` at `skills/idea-task/SKILL.md`
+  - Purpose: shape rough ideas into a validated draft, ask focused clarification questions, and hand off to `prepare-task` once ready.
+  - Script: chat skill (no launcher script required)
 - `api` at `skills/api/SKILL.md`
   - Purpose: start and health-check local `aijuristiction-api` (delegates to `juris-api` defaults: postgres + azurefoundry on port 8080).
   - Script: `.\skills\juris-api\scripts\start_juris_api.ps1`

--- a/skills/idea-task/SKILL.md
+++ b/skills/idea-task/SKILL.md
@@ -16,13 +16,14 @@ Use this skill before `prepare-task` when an idea is still ambiguous.
 
 - `$idea-task`
 - `/idea-task [description]`
+- `/idea-task -url "https://github.com/mmaideveloper/aijurisdictionagents/issues/<id>"`
 - `I have an idea, help me shape it first`
 
 Works in VS Code, Codex Web, and Codex Desktop repository chat.
 
 ## Workflow
 
-1. Parse the idea and restate it in one paragraph.
+1. Determine source: free-text idea or `-url` existing issue/task, then restate the idea in one paragraph.
 2. Review repository context relevant to the idea.
 3. Run GDPR + EU AI Act pre-check before suggesting implementation details.
 4. Ask up to three focused questions at a time.
@@ -37,7 +38,9 @@ Works in VS Code, Codex Web, and Codex Desktop repository chat.
 7. Decide status:
    - `Ready for prepare-task`
    - `Blocked` (with reasons)
-8. If ready, recommend running `$prepare-task` with the generated draft.
+8. Emit exact marker line for downstream automations:
+   - `Idea Task Status: Ready for prepare-task.` when ready.
+9. If ready, recommend running `$prepare-task` with the generated draft or task URL.
 
 ## Question Priorities
 

--- a/skills/idea-task/SKILL.md
+++ b/skills/idea-task/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: idea-task
+description: Interactive idea shaping skill that turns a rough idea into a validated concept draft before prepare-task formalizes it into a Ready implementation task. Use when the user asks for early brainstorming, architecture/risk review, task decomposition, technical debt discovery, or asks questions such as '/idea-task [description]'.
+---
+
+# Idea Task
+
+## Purpose
+
+Use this skill before `prepare-task` when an idea is still ambiguous.
+
+`idea-task` does discovery and risk shaping.
+`prepare-task` does implementation-ready formalization and GitHub project readiness.
+
+## Invocation
+
+- `$idea-task`
+- `/idea-task [description]`
+- `I have an idea, help me shape it first`
+
+Works in VS Code, Codex Web, and Codex Desktop repository chat.
+
+## Workflow
+
+1. Parse the idea and restate it in one paragraph.
+2. Review repository context relevant to the idea.
+3. Run GDPR + EU AI Act pre-check before suggesting implementation details.
+4. Ask up to three focused questions at a time.
+5. Maintain an `Open Questions` list and close items as answered.
+6. Produce an `Idea Draft` with:
+   - problem and outcome
+   - in-scope/out-of-scope
+   - likely modules/files
+   - risks and technical debt hotspots
+   - observability, logging, and rollback expectations
+   - compliance notes
+7. Decide status:
+   - `Ready for prepare-task`
+   - `Blocked` (with reasons)
+8. If ready, recommend running `$prepare-task` with the generated draft.
+
+## Question Priorities
+
+Ask only what is needed to remove ambiguity:
+
+- user outcome and success metric
+- impacted channels (API, chat simulator, mobile, web)
+- data classes, retention/deletion, consent/transparency
+- external API dependencies and fallback behavior
+- acceptance test shape and release constraints
+
+## Output Template
+
+Use `references/idea-draft-template.md`.
+
+## Guardrails
+
+- Do not start code implementation in this skill.
+- Stop and surface compliant alternatives if GDPR/EU AI Act conflicts exist.
+- Keep answers concise, concrete, and directly actionable by `prepare-task`.

--- a/skills/idea-task/agents/openai.yaml
+++ b/skills/idea-task/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Idea Task"
+  short_description: "Shape rough ideas before prepare-task"
+  default_prompt: "Use /idea-task to review my idea, inspect repository context, ask the missing questions, identify risks/compliance gaps, and output an idea draft that is ready for /prepare-task."

--- a/skills/idea-task/references/idea-draft-template.md
+++ b/skills/idea-task/references/idea-draft-template.md
@@ -43,3 +43,4 @@
 
 ## Status
 - Ready for prepare-task | Blocked
+- Idea Task Status: Ready for prepare-task. (include this exact line only when ready)

--- a/skills/idea-task/references/idea-draft-template.md
+++ b/skills/idea-task/references/idea-draft-template.md
@@ -1,0 +1,45 @@
+# Idea Draft
+
+## Problem Statement
+
+## Expected Outcome
+
+## Scope
+- In scope:
+- Out of scope:
+
+## Repository Context Reviewed
+- Related modules/files:
+- Existing patterns to reuse:
+
+## Architecture and Dependency Notes
+- Internal components:
+- External APIs/services:
+
+## Compliance (GDPR + EU AI Act)
+- Personal data involved:
+- Consent/transparency requirements:
+- Retention/deletion requirements:
+- Human oversight for legal-risk outputs:
+- Compliance blockers:
+
+## Risks and Technical Debt
+- Risk 1:
+- Risk 2:
+- Tech debt hotspots:
+
+## Observability and Operations
+- Required logs/metrics/traces:
+- Failure detection signals:
+- Rollback expectations:
+
+## Acceptance Direction (pre-prepare-task)
+- What must be true to continue:
+
+## Open Questions
+1.
+2.
+3.
+
+## Status
+- Ready for prepare-task | Blocked

--- a/skills/prepare-task/SKILL.md
+++ b/skills/prepare-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prepare-task
-description: Prepare an idea or GitHub Project task for implementation in this repository. Use when the user asks to refine an idea, prepare a task, make a GitHub Project item ready, update a task description, create a task from an idea, or ask the necessary technical/product/compliance questions before implementation. Also use in normal chat when the user starts with slash-style triggers such as "/prepare-task [description]", "/prepare-task -url [issue-url]", the accepted typo "/prepar-task [description]", "/prepar-task -url [issue-url]", or phrases like "here is my idea", "I have an idea for a feature", "new feature idea", "can you prepare this task", or "turn this into a GitHub task". Works with conversational idea intake, existing GitHub issue/project task descriptions, or new ideas that need to become implementation-ready work items.
+description: Convert an already shaped idea into an implementation-ready GitHub Project task. Prefer tasks reviewed by `/idea-task` first. Use when the user asks to finalize a prepared idea, validate readiness, or mark a project task Ready after technical/compliance details are complete. Accepts `/prepare-task [description]` and `/prepare-task -url [issue-url]`, but if the idea was not reviewed by `/idea-task`, run the idea-task interview subset first and mark the task as not ready until that gap is resolved.
 ---
 
 # Prepare Task
@@ -8,6 +8,17 @@ description: Prepare an idea or GitHub Project task for implementation in this r
 ## Overview
 
 Turn a loose idea or existing GitHub Project task into an implementation-ready task description. In chat, run an interview flow: collect the idea, review repository context, ask only necessary questions, draft the task, and ask for explicit confirmation before creating or updating a GitHub issue/project item.
+
+## Consistency Contract with `/idea-task`
+
+- `prepare-task` is phase 2; `idea-task` is phase 1.
+- Accepted sources for `prepare-task`:
+  1. `/idea-task` output draft (`Status: Ready for prepare-task`).
+  2. Existing issue URL that already contains an idea-task prepared section.
+  3. Raw idea text only if `prepare-task` first runs the missing idea-task questions inline.
+- Do not mark implementation readiness until both lines exist in the prepared section:
+  - `Idea Task Status: Ready for prepare-task.`
+  - `Status: Ready for implementation.`
 
 
 ## How to Execute This Skill (VS Code, Codex Web, Codex Desktop)
@@ -175,6 +186,7 @@ A task is ready for implementation only when:
 - Test and documentation requirements are specific.
 - The minimal runnable example requirement is named, defaulting to `python examples/minimal_demo.py`.
 - No blocking questions remain.
+- Idea phase evidence is present: `Idea Task Status: Ready for prepare-task.`
 - Cross-channel parity (chat simulator/API/mobile/frontend) is explicit for all in-scope channels.
 
 ## Minimal Example


### PR DESCRIPTION
### Motivation
- Introduce an interactive pre-implementation step to shape ambiguous ideas into validated drafts before `prepare-task` converts them to implementation-ready work.  
- Provide explicit GDPR and EU AI Act pre-checks and compliance guidance during early discovery to prevent blocked or non-compliant implementation proposals.  
- Document and expose the capability in automations and agent/skills lists so contributors can invoke it consistently across Codex environments.  

### Description
- Add a new automation configuration at `.codex/automations/idea-task-agent/automation.toml` that defines the `idea-task-agent` as a manual agent with a focused prompt and compliance checks.  
- Add a new skill under `skills/idea-task/` including `SKILL.md`, `agents/openai.yaml`, and a `references/idea-draft-template.md` to specify workflow, invocation, output template, and guardrails.  
- Update `.codex/automations/README.md` and `AGENTS.md` to list and describe the new `idea-task` skill and automation.  

### Testing
- No automated tests were run for these content/configuration changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05b294789883328fc2a8f2137bf20c)