### PR TITLE
Add VoiceSessionOrchestrator with deduplication, silence timeout, tests, demo and docs

### DIFF
--- a/docs/mobile_voice_flow.md
+++ b/docs/mobile_voice_flow.md
@@ -1,0 +1,15 @@
+# Mobile STT/TTS plynuly command flow
+
+Tento dokument popisuje hlasovy orchestrator pre mobilnu aplikaciu:
+
+- priebezne prijima STT transkripty
+- deduplikuje partial/final vstupy
+- po 10 sekundach neaktivity pyta potvrdenie vykonania poziadavky
+- mapuje prikazy cez existujuci RuleEngine
+
+## GDPR + EU AI Act baseline
+
+- data minimization: orchestrator neuklada raw audio
+- transparency: klient dostane eventy `listening_started`, `silence_threshold_reached`
+- human oversight: pri tichu sa pyta na explicitne potvrdenie pred akciou
+- traceability: transcript id je stabilny kluc pre audit bez full raw audio obsahu

--- a/examples/mobile_voice_flow_demo.py
+++ b/examples/mobile_voice_flow_demo.py
@@ -1,0 +1,21 @@
+"""Minimal runnable demo for mobile voice flow behavior."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class VoiceState:
+    awaiting_confirmation: bool = False
+    pending_intent: str | None = None
+
+
+def run_demo() -> None:
+    state = VoiceState(pending_intent="create_case")
+    print("Listening...")
+    print("No speech for 10s -> asking confirmation")
+    state.awaiting_confirmation = True
+    print(f"Awaiting confirmation: {state.awaiting_confirmation}")
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/mobile_app/lib/chat/voice_session_orchestrator.dart
+++ b/mobile_app/lib/chat/voice_session_orchestrator.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+
+import 'rule_engine.dart';
+
+class VoiceSessionState {
+  const VoiceSessionState({
+    required this.isListening,
+    required this.awaitingConfirmation,
+    this.pendingIntent,
+    this.lastTranscriptId,
+  });
+
+  final bool isListening;
+  final bool awaitingConfirmation;
+  final String? pendingIntent;
+  final String? lastTranscriptId;
+}
+
+class VoiceSessionEvent {
+  const VoiceSessionEvent(this.type, {this.payload});
+
+  final String type;
+  final String? payload;
+}
+
+class VoiceSessionOrchestrator {
+  VoiceSessionOrchestrator({
+    required this.ruleEngine,
+    this.silenceThreshold = const Duration(seconds: 10),
+    void Function(VoiceSessionEvent event)? onEvent,
+  }) : _onEvent = onEvent;
+
+  final RuleEngine ruleEngine;
+  final Duration silenceThreshold;
+  final void Function(VoiceSessionEvent event)? _onEvent;
+
+  Timer? _silenceTimer;
+  String? _lastTranscriptId;
+  bool _awaitingConfirmation = false;
+  String? _pendingIntent;
+
+  VoiceSessionState get state => VoiceSessionState(
+        isListening: _silenceTimer != null,
+        awaitingConfirmation: _awaitingConfirmation,
+        pendingIntent: _pendingIntent,
+        lastTranscriptId: _lastTranscriptId,
+      );
+
+  void startListening() {
+    _restartTimer();
+    _emit(const VoiceSessionEvent('listening_started'));
+  }
+
+  void stopListening() {
+    _silenceTimer?.cancel();
+    _silenceTimer = null;
+    _emit(const VoiceSessionEvent('listening_stopped'));
+  }
+
+  RuleEngineAction onTranscript({
+    required String transcript,
+    required RuleEngineContext context,
+    required int timestampMs,
+    bool isFinal = true,
+  }) {
+    final normalized = transcript.trim().toLowerCase();
+    final transcriptId = '$timestampMs:$normalized';
+    if (_lastTranscriptId == transcriptId) {
+      return const IgnoreRuleAction();
+    }
+    _lastTranscriptId = transcriptId;
+    _restartTimer();
+
+    if (!isFinal) {
+      return const IgnoreRuleAction();
+    }
+
+    final action = ruleEngine.evaluate(input: transcript, context: context);
+    if (action is CreateCaseRuleAction) {
+      _pendingIntent = 'create_case';
+    }
+    if (action is SubmitMessageRuleAction) {
+      _pendingIntent = 'submit_message';
+    }
+    return action;
+  }
+
+  void confirmPendingIntent(bool confirmed) {
+    _awaitingConfirmation = false;
+    _emit(VoiceSessionEvent(
+      confirmed ? 'intent_confirmed' : 'intent_rejected',
+      payload: _pendingIntent,
+    ));
+    if (!confirmed) {
+      _pendingIntent = null;
+    }
+    _restartTimer();
+  }
+
+  void dispose() {
+    _silenceTimer?.cancel();
+  }
+
+  void _restartTimer() {
+    _silenceTimer?.cancel();
+    _silenceTimer = Timer(silenceThreshold, () {
+      _awaitingConfirmation = true;
+      _emit(const VoiceSessionEvent('silence_threshold_reached'));
+    });
+  }
+
+  void _emit(VoiceSessionEvent event) {
+    _onEvent?.call(event);
+  }
+}

--- a/mobile_app/lib/chat/voice_session_orchestrator.dart
+++ b/mobile_app/lib/chat/voice_session_orchestrator.dart
@@ -37,21 +37,26 @@ class VoiceSessionOrchestrator {
   Timer? _silenceTimer;
   String? _lastTranscriptId;
   bool _awaitingConfirmation = false;
+  bool _isListening = false;
   String? _pendingIntent;
 
   VoiceSessionState get state => VoiceSessionState(
-        isListening: _silenceTimer != null,
+        isListening: _isListening,
         awaitingConfirmation: _awaitingConfirmation,
         pendingIntent: _pendingIntent,
         lastTranscriptId: _lastTranscriptId,
       );
 
   void startListening() {
+    _isListening = true;
+    _awaitingConfirmation = false;
     _restartTimer();
     _emit(const VoiceSessionEvent('listening_started'));
   }
 
   void stopListening() {
+    _isListening = false;
+    _awaitingConfirmation = false;
     _silenceTimer?.cancel();
     _silenceTimer = null;
     _emit(const VoiceSessionEvent('listening_stopped'));
@@ -63,12 +68,17 @@ class VoiceSessionOrchestrator {
     required int timestampMs,
     bool isFinal = true,
   }) {
+    if (!_isListening) {
+      return const IgnoreRuleAction();
+    }
+
     final normalized = transcript.trim().toLowerCase();
     final transcriptId = '$timestampMs:$normalized';
     if (_lastTranscriptId == transcriptId) {
       return const IgnoreRuleAction();
     }
     _lastTranscriptId = transcriptId;
+    _awaitingConfirmation = false;
     _restartTimer();
 
     if (!isFinal) {
@@ -76,16 +86,17 @@ class VoiceSessionOrchestrator {
     }
 
     final action = ruleEngine.evaluate(input: transcript, context: context);
-    if (action is CreateCaseRuleAction) {
-      _pendingIntent = 'create_case';
-    }
-    if (action is SubmitMessageRuleAction) {
-      _pendingIntent = 'submit_message';
+    _pendingIntent = _resolvePendingIntent(action);
+    if (_pendingIntent != null) {
+      _emit(VoiceSessionEvent('intent_detected', payload: _pendingIntent));
     }
     return action;
   }
 
   void confirmPendingIntent(bool confirmed) {
+    if (!_isListening) {
+      return;
+    }
     _awaitingConfirmation = false;
     _emit(VoiceSessionEvent(
       confirmed ? 'intent_confirmed' : 'intent_rejected',
@@ -98,15 +109,35 @@ class VoiceSessionOrchestrator {
   }
 
   void dispose() {
+    _isListening = false;
     _silenceTimer?.cancel();
   }
 
   void _restartTimer() {
     _silenceTimer?.cancel();
+    if (!_isListening) {
+      return;
+    }
     _silenceTimer = Timer(silenceThreshold, () {
+      if (!_isListening) {
+        return;
+      }
       _awaitingConfirmation = true;
       _emit(const VoiceSessionEvent('silence_threshold_reached'));
     });
+  }
+
+  String? _resolvePendingIntent(RuleEngineAction action) {
+    if (action is CreateCaseRuleAction) {
+      return 'create_case';
+    }
+    if (action is SubmitMessageRuleAction || action is SendCurrentDraftRuleAction) {
+      return 'submit_message';
+    }
+    if (action is StoreProfileNameRuleAction) {
+      return 'update_profile_name';
+    }
+    return null;
   }
 
   void _emit(VoiceSessionEvent event) {

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ai_jurisdiction_mobile
-version: 0.1.5+68
+version: 0.1.5+69
 publish_to: none
 
 environment:

--- a/mobile_app/test/voice_session_orchestrator_test.dart
+++ b/mobile_app/test/voice_session_orchestrator_test.dart
@@ -12,6 +12,8 @@ void main() {
       submitMessageWhenNoRuleMatches: true,
     );
 
+    orchestrator.startListening();
+
     final first = orchestrator.onTranscript(
       transcript: 'Please create a new case',
       context: context,
@@ -41,4 +43,39 @@ void main() {
     expect(events, contains('silence_threshold_reached'));
     expect(orchestrator.state.awaitingConfirmation, isTrue);
   });
+
+  test('ignores transcripts when listening has not started', () {
+    final orchestrator = VoiceSessionOrchestrator(ruleEngine: const RuleEngine());
+    const context = RuleEngineContext(
+      awaitingProfileName: false,
+      awaitingCaseArchiveConfirmation: false,
+      awaitingCaseTitle: false,
+      submitMessageWhenNoRuleMatches: true,
+    );
+
+    final action = orchestrator.onTranscript(
+      transcript: 'Create a new case',
+      context: context,
+      timestampMs: 1,
+    );
+
+    expect(action, isA<IgnoreRuleAction>());
+  });
+
+  test('stops silence timer when listening stops', () async {
+    final events = <String>[];
+    final orchestrator = VoiceSessionOrchestrator(
+      ruleEngine: const RuleEngine(),
+      silenceThreshold: const Duration(milliseconds: 50),
+      onEvent: (event) => events.add(event.type),
+    );
+
+    orchestrator.startListening();
+    orchestrator.stopListening();
+    await Future<void>.delayed(const Duration(milliseconds: 90));
+
+    expect(events.where((e) => e == 'silence_threshold_reached'), isEmpty);
+    expect(orchestrator.state.isListening, isFalse);
+  });
+
 }

--- a/mobile_app/test/voice_session_orchestrator_test.dart
+++ b/mobile_app/test/voice_session_orchestrator_test.dart
@@ -1,0 +1,44 @@
+import 'package:ai_jurisdiction_mobile/chat/rule_engine.dart';
+import 'package:ai_jurisdiction_mobile/chat/voice_session_orchestrator.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('deduplicates repeated transcript ids', () {
+    final orchestrator = VoiceSessionOrchestrator(ruleEngine: const RuleEngine());
+    const context = RuleEngineContext(
+      awaitingProfileName: false,
+      awaitingCaseArchiveConfirmation: false,
+      awaitingCaseTitle: false,
+      submitMessageWhenNoRuleMatches: true,
+    );
+
+    final first = orchestrator.onTranscript(
+      transcript: 'Please create a new case',
+      context: context,
+      timestampMs: 1000,
+    );
+    final second = orchestrator.onTranscript(
+      transcript: 'Please create a new case',
+      context: context,
+      timestampMs: 1000,
+    );
+
+    expect(first, isA<CreateCaseRuleAction>());
+    expect(second, isA<IgnoreRuleAction>());
+  });
+
+  test('emits silence event after threshold', () async {
+    final events = <String>[];
+    final orchestrator = VoiceSessionOrchestrator(
+      ruleEngine: const RuleEngine(),
+      silenceThreshold: const Duration(milliseconds: 50),
+      onEvent: (event) => events.add(event.type),
+    );
+
+    orchestrator.startListening();
+    await Future<void>.delayed(const Duration(milliseconds: 90));
+
+    expect(events, contains('silence_threshold_reached'));
+    expect(orchestrator.state.awaitingConfirmation, isTrue);
+  });
+}


### PR DESCRIPTION
### Motivation

- Provide a mobile-side orchestrator to manage STT/TTS voice session flow, deduplicate transcripts, and require confirmation after inactivity. 
- Ensure GDPR / EU AI Act baseline behaviors such as data minimization and traceability are captured for mobile voice interactions. 
- Integrate with the existing rule engine to map transcripts to intents and surface events to the UI.

### Description

- Add `VoiceSessionOrchestrator` in `mobile_app/lib/chat/voice_session_orchestrator.dart` which deduplicates transcripts by stable `transcriptId`, evaluates rules via `RuleEngine`, tracks a pending intent, and starts a silence timer that emits `silence_threshold_reached` and toggles `awaitingConfirmation` after the configured `silenceThreshold`.
- Add a minimal runnable demo `examples/mobile_voice_flow_demo.py` and a documentation page `docs/mobile_voice_flow.md` describing the voice flow and GDPR/EU AI Act considerations.
- Add unit tests in `mobile_app/test/voice_session_orchestrator_test.dart` covering transcript deduplication and the silence timeout event, and bump mobile package version in `mobile_app/pubspec.yaml`.

### Testing

- Ran `flutter test` for `voice_session_orchestrator_test.dart` and the test verifying deduplication of repeated transcript ids passed. 
- The test asserting the silence threshold fires (with a shortened `Duration`) passed and the orchestrator's `state.awaitingConfirmation` became `true` as expected. 
- No other automated tests were modified or run in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06ee0e26c08332a051224a260572bc)