### PR TITLE
Add Speech-to-Text utility page to chat simulator (v0.1.26)

### DIFF
--- a/api/chat-simulator-app/README.md
+++ b/api/chat-simulator-app/README.md
@@ -38,6 +38,8 @@ The simulator now supports:
 - showing the selected case documents immediately after case selection, including document metadata/status from the API
 - previewing selected existing case documents inline in the simulator (`PDF` iframe preview for PDFs, text preview for text-based files, open/download fallback for binary files)
 - listing API document templates in the **Document Templates** panel and generating a preview PDF from each template through `GET /v1/document-templates/{template_key}/preview/pdf`
+- opening a dedicated **Speech to Text** page (`/speech-to-text`) for fast manual microphone checks before mobile app changes
+  - works in-browser via Web Speech API and gives instant transcript/output without starting full mobile runtime
 - deleting all persisted cases for the active simulator user with one button when the API reaches the active-case limit (`Maximum number of cases reached (5)`)
   - this action now runs through the internal simulator backend, so it does not depend on browser-side cross-origin delete requests
 - inspecting persisted document debug data from the API, including stored vectors, chunk counts, and the exact prompt chunks selected for the current query

--- a/api/chat-simulator-app/app/main.py
+++ b/api/chat-simulator-app/app/main.py
@@ -25,7 +25,7 @@ SIMULATOR_PACKAGE = "chat-simulator-app"
 
 app = FastAPI(
     title="AI Juristiction Chat Simulator App",
-    version="0.1.25",
+    version="0.1.26",
     description="Standalone chat simulator application for validating core chat APIs.",
 )
 
@@ -103,6 +103,11 @@ def simulator_page() -> HTMLResponse:
 @app.get("/email-tests", include_in_schema=False)
 def email_tests_page() -> HTMLResponse:
     return _render_static_page("email-tests.html")
+
+
+@app.get("/speech-to-text", include_in_schema=False)
+def speech_to_text_page() -> HTMLResponse:
+    return _render_static_page("speech-to-text.html")
 
 
 @app.post("/internal/email-tests/send")

--- a/api/chat-simulator-app/pyproject.toml
+++ b/api/chat-simulator-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chat-simulator-app"
-version = "0.1.25"
+version = "0.1.26"
 description = "Standalone chat simulator UI for testing aijuristiction-api chat endpoints"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/chat-simulator-app/static/index.html
+++ b/api/chat-simulator-app/static/index.html
@@ -14,6 +14,7 @@
           <p>Start a chat session, submit your case instruction, and watch streamed core messages in real-time.</p>
           <section class="quick-actions" aria-label="Simulator pages">
             <a class="page-action" href="/email-tests">Email Validation Tests</a>
+            <a class="page-action" href="/speech-to-text">Speech to Text</a>
           </section>
 
           <section class="grid">

--- a/api/chat-simulator-app/static/speech-to-text.html
+++ b/api/chat-simulator-app/static/speech-to-text.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Speech to Text Tester</title>
+    <link rel="stylesheet" href="/static/simulator.css?v=__SIMULATOR_VERSION__" />
+  </head>
+  <body>
+    <main class="shell">
+      <div class="simulator-layout">
+        <div class="simulator-controls">
+          <h1>Speech to Text Tester</h1>
+          <p>Fast browser-only speech check for command phrases and transcript quality.</p>
+          <section class="quick-actions" aria-label="Simulator pages">
+            <a class="page-action" href="/chat-simulator">Back to Chat Simulator</a>
+          </section>
+          <section class="row">
+            <button id="startListening" type="button">Start Listening</button>
+            <button id="stopListening" class="secondary" type="button">Stop</button>
+            <pre id="sttStatus">Idle.</pre>
+          </section>
+          <section class="row">
+            <label for="sttTranscript">Transcript</label>
+            <textarea id="sttTranscript" placeholder="Speech transcript appears here..."></textarea>
+          </section>
+          <section class="row">
+            <h2>Command Hints</h2>
+            <pre>Try: Send, send message, I am done, this is the end, Posli, to je vsetko, cakam na odpoved.</pre>
+          </section>
+        </div>
+      </div>
+    </main>
+    <script>
+      const statusEl = document.getElementById('sttStatus');
+      const transcriptEl = document.getElementById('sttTranscript');
+      const startBtn = document.getElementById('startListening');
+      const stopBtn = document.getElementById('stopListening');
+      const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+      if (!SpeechRecognition) {
+        statusEl.textContent = 'SpeechRecognition API is unavailable in this browser.';
+        startBtn.disabled = true;
+        stopBtn.disabled = true;
+      } else {
+        const recognition = new SpeechRecognition();
+        recognition.lang = 'en-US';
+        recognition.interimResults = true;
+        recognition.continuous = true;
+        recognition.onstart = () => { statusEl.textContent = 'Listening...'; };
+        recognition.onend = () => { statusEl.textContent = 'Stopped.'; };
+        recognition.onerror = (event) => { statusEl.textContent = `Error: ${event.error}`; };
+        recognition.onresult = (event) => {
+          let text = '';
+          for (let i = event.resultIndex; i < event.results.length; i += 1) {
+            text += event.results[i][0].transcript;
+          }
+          transcriptEl.value = `${transcriptEl.value} ${text}`.trim();
+        };
+        startBtn.addEventListener('click', () => recognition.start());
+        stopBtn.addEventListener('click', () => recognition.stop());
+      }
+    </script>
+  </body>
+</html>

--- a/api/chat-simulator-app/tests/test_app.py
+++ b/api/chat-simulator-app/tests/test_app.py
@@ -20,18 +20,20 @@ def test_version() -> None:
     assert response.status_code == 200
     assert response.json() == {
         'service': 'chat-simulator-app',
-        'version': '0.1.25',
-        'simulator_version': '0.1.25',
+        'version': '0.1.26',
+        'simulator_version': '0.1.26',
     }
 
 
 def test_simulator_page_and_assets() -> None:
     page = client.get('/chat-simulator')
     assert page.status_code == 200
-    assert '/static/simulator.js?v=0.1.25' in page.text
-    assert '/static/simulator.css?v=0.1.25' in page.text
+    assert '/static/simulator.js?v=0.1.26' in page.text
+    assert '/static/simulator.css?v=0.1.26' in page.text
     assert '/email-tests' in page.text
     assert 'Email Validation Tests' in page.text
+    assert '/speech-to-text' in page.text
+    assert 'Speech to Text' in page.text
     assert 'Start Stream' in page.text
     assert 'Upload documents' in page.text
     assert 'Persisted Case Debug' in page.text
@@ -133,7 +135,7 @@ def test_simulator_page_and_assets() -> None:
 def test_email_tests_page_and_assets() -> None:
     page = client.get('/email-tests')
     assert page.status_code == 200
-    assert '/static/email-tests.js?v=0.1.25' in page.text
+    assert '/static/email-tests.js?v=0.1.26' in page.text
     assert 'Email Validation Tests' in page.text
     assert 'id="emailTransport"' in page.text
     assert '<option value="log" selected>log</option>' in page.text
@@ -237,3 +239,12 @@ def test_read_testcase_supports_case_descripton_typo_and_embeds_documents() -> N
     assert document['sourcePath'] == 'najomna-zmluva-byt-sample.pdf'
     assert document['mimeType'] == 'application/pdf'
     assert len(document['contentBase64']) > 100
+
+
+def test_speech_to_text_page() -> None:
+    page = client.get('/speech-to-text')
+    assert page.status_code == 200
+    assert 'Speech to Text Tester' in page.text
+    assert 'id="startListening"' in page.text
+    assert 'id="sttTranscript"' in page.text
+    assert 'SpeechRecognition' in page.text


### PR DESCRIPTION
### Motivation
- Provide a fast, browser-only surface for validating microphone capture and command-phrase recognition without running the full mobile app build/run cycle.
- Keep testing local and privacy-safe by relying on the browser Web Speech API so no raw audio is uploaded to the backend in this change, addressing basic GDPR/EU AI Act concerns for rapid manual checks.

### Description
- Added a new static page `static/speech-to-text.html` served at `GET /speech-to-text` that uses the Web Speech API for continuous interim transcripts and simple start/stop controls.
- Linked the new page from the simulator main UI by updating `static/index.html` quick-actions.
- Added a new endpoint in the simulator app to serve the page and bumped the app runtime version to `0.1.26` in `app/main.py`.
- Bumped package `version` in `pyproject.toml`, updated `tests/test_app.py` to cover the new page and updated versioned asset URLs, and updated the simulator `README.md` to document the new page.

### Testing
- Installed dev deps and editable package with `cd api/chat-simulator-app && python -m pip install -e '.[dev]'` and the install completed successfully.
- Ran `cd api/chat-simulator-app && pytest -q` and all simulator tests passed after adjustments to expectations (final result: all tests green).
- Changes were committed and included a new unit test `test_speech_to_text_page` which verifies the page renders and contains the expected controls and script hooks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e65e61588332bb2530c08e4e97ef)