### PR TITLE
Fix Flutter analyzer failure: remove unused speech handler, bump build number, update docs

### DIFF
--- a/docs/MOBILE_TECHNICAL_DESIGN.md
+++ b/docs/MOBILE_TECHNICAL_DESIGN.md
@@ -62,6 +62,7 @@ GitHub Actions workflow `.github/workflows/mobile_flutter_build.yml`:
 - Trigger on changes in `mobile_app/**` and workflow file.
 - Build Android APK artifact for download.
 - Build web output artifact as deployable static package.
+- Run `flutter analyze --no-fatal-infos`; keep analyzer warnings at zero because warnings fail the workflow.
 
 This provides quick distribution for testers and a deployable web preview while native store deployment credentials are not configured.
 

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -6171,29 +6171,6 @@ class _ChatHomePageState extends State<ChatHomePage>
         parseSpokenCaseCreationCommand(recognizedText) != null;
   }
 
-  Future<void> _processFinalSpeechResultImmediately(
-    String recognizedText,
-  ) async {
-    final normalizedText = recognizedText.trim();
-    if (normalizedText.isEmpty || _lastHandledSpeechText == normalizedText) {
-      return;
-    }
-    _cancelSpeechSendPrompt();
-    if (_isListening) {
-      await _stopSpeechListening(
-        submitAfterStop: false,
-        processStoppedInput: false,
-      );
-      if (!mounted) {
-        return;
-      }
-    }
-    await _handleCompletedSpeechInput(
-      normalizedText,
-      submitAfterRecognition: true,
-    );
-  }
-
   Future<void> _processQueuedSpeechActionsImmediately() async {
     _cancelSpeechSendPrompt();
     if (_isListening) {

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ai_jurisdiction_mobile
-version: 0.1.5+77
+version: 0.1.5+78
 publish_to: none
 
 environment:


### PR DESCRIPTION
### Motivation
- CI mobile build was failing because `flutter analyze --no-fatal-infos` reported an `unused_element` warning for an unused private speech handler, which causes the workflow to exit with code 1.
- Keep mobile versioning consistent by bumping only the build revision per project rules after the code change.
- Make the build requirement explicit in docs so future changes do not reintroduce analyzer-breaking warnings.

### Description
- Removed the unused private function `_processFinalSpeechResultImmediately` from `mobile_app/lib/main.dart` to eliminate the `unused_element` analyzer warning.
- Bumped the mobile app build revision from `0.1.5+77` to `0.1.5+78` in `mobile_app/pubspec.yaml` following the mobile app versioning rule.
- Updated `docs/MOBILE_TECHNICAL_DESIGN.md` to document that the GitHub Actions mobile workflow runs `flutter analyze --no-fatal-infos` and requires zero analyzer warnings.

### Testing
- Attempted to run `cd mobile_app && flutter analyze --no-fatal-infos`, but the container lacks the Flutter CLI and the command failed with `/bin/bash: flutter: command not found` so analyzer could not be executed here.
- No other automated tests were run in this environment; CI should now pass the analyzer step once executed in the GitHub Actions runner that has Flutter installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae189ec248332a66e8295dec959ab)