### PR TITLE
Auto-resume speech on Android, expand input on mic enable, update status strings and bump version

### DIFF
--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -18,6 +18,9 @@ The current mobile build is kept compatible with Flutter analyzer changes in the
 - Confirmation parsing also accepts common corrupted STT/encoding forms such as `�no` and `Ã¡no`, so a spoken Slovak yes clears the pending prompt instead of leaving the app waiting and asking again later.
 - While waiting for that confirmation, the prompt is not repeated automatically; the app waits for `yes`/`áno` or `no`/`nie` so assistant TTS cannot loop on its own echo.
 - Tapping the microphone while listening or waiting for confirmation is treated as an explicit user stop: speech input is disabled and will not auto-restart until the user enables it again.
+- On Android, when the speech recognizer auto-stops unexpectedly while speech input remains enabled, the app now shows a short polite status message and re-starts listening automatically.
+- Enabling the microphone now opens/expands the input box immediately (same visual behavior as tapping the input), keeps partial dictated transcript, and appends recognized speech to existing typed text.
+- While microphone mode is enabled, the expanded input stays open until the user disables microphone, sends the message, or taps outside the input area.
 - During assistant speech, STT fragments are not used for automatic barge-in. The assistant finishes unless the user explicitly taps the microphone button.
 - Voice session handling now runs through `VoiceSessionOrchestrator`, which tracks listening, processing, and confirmation states, applies idempotency keys to STT transcripts, and dispatches `RuleEngineAction` values through an action queue.
 - The speech flow also understands spoken send commands such as `Send`, `send message`, `I am done`, `this is end`, `this is the end`, `Posli`, `Prosim odosli spravu`, `to je vsetko`, `cakam na odpoved`, `Senden`, or `Nachricht senden`, and submits the current dictated message immediately.

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -290,7 +290,7 @@ class AppStrings {
       'speech_input_disabled_message':
           'Vstup hlasom je vypnutý. Zapnite ho tlačidlom Vstup hlasom.',
       'speech_input_auto_stopped':
-          'Hlasový vstup sa pozastavil. Klepnite na mikrofón pre pokračovanie.',
+          'Hlasový vstup sa krátko prerušil. Pokračujem v počúvaní.',
       'speech_send_confirmation_prompt':
           'Už minútu som nezachytila ďalšiu reč. Ak chcete správu odoslať, povedzte Posli. Ak ju chcete zmazať, povedzte Zrus vsetko.',
       'speech_answer_confirmation_prompt':
@@ -561,7 +561,7 @@ class AppStrings {
       'speech_input_disabled_message':
           'Speech input is turned off. Use the Speech input button to enable it.',
       'speech_input_auto_stopped':
-          'Speech input paused. Tap the microphone to continue.',
+          'Speech input paused briefly. I am continuing to listen.',
       'speech_send_confirmation_prompt':
           'I have not heard anything else for one minute. Say Send to send the message, or say Cancel everything to clear it.',
       'speech_answer_confirmation_prompt':
@@ -837,7 +837,7 @@ class AppStrings {
       'speech_input_disabled_message':
           'Spracheingabe ist ausgeschaltet. Aktivieren Sie sie mit der Schaltfläche Spracheingabe.',
       'speech_input_auto_stopped':
-          'Die Spracheingabe wurde pausiert. Tippen Sie auf das Mikrofon, um fortzufahren.',
+          'Die Spracheingabe wurde kurz unterbrochen. Ich höre weiter zu.',
       'speech_send_confirmation_prompt':
           'Ich habe eine Minute lang nichts Weiteres gehört. Sagen Sie Senden, um die Nachricht zu senden, oder Alles abbrechen, um sie zu löschen.',
       'speech_answer_confirmation_prompt':
@@ -4816,6 +4816,17 @@ class _ChatHomePageState extends State<ChatHomePage>
     }
   }
 
+  Future<void> _resumeSpeechListeningAfterAutoStop() async {
+    if (!mounted || !_speechInputEnabled || _isListening) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 350));
+    if (!mounted || !_speechInputEnabled || _isListening) {
+      return;
+    }
+    await _startSpeechListening(resetHandledText: false);
+  }
+
   void _scheduleSpeechSendPrompt() {
     _speechSendPromptTimer?.cancel();
     _speechSendPromptTimer = null;
@@ -6426,6 +6437,7 @@ class _ChatHomePageState extends State<ChatHomePage>
           shouldSubmit = false;
         } else if (_lastFinalSpeechResult == null) {
           _showSnackbar(_strings.t('speech_input_auto_stopped'));
+          unawaited(_resumeSpeechListeningAfterAutoStop());
         }
       }
       _processSpeechOnStop = true;
@@ -7442,6 +7454,14 @@ class _ChatHomePageState extends State<ChatHomePage>
         _lastDictatedSpeechDraft = null;
       }
     });
+
+    if (nextValue) {
+      _setInputComposerExpanded(true);
+      _inputFocusNode.requestFocus();
+      if (!_isListening) {
+        await _startSpeechListening(resetHandledText: true);
+      }
+    }
 
     if (nextValue && speakReadyMessage) {
       await _speaker.stop();

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ai_jurisdiction_mobile
-version: 0.1.5+95
+version: 0.1.5+96
 publish_to: none
 
 environment:


### PR DESCRIPTION
### Motivation

- Improve speech UX by automatically resuming listening when the Android recognizer auto-stops and reduce user confusion with a polite status message. 
- Make microphone enable immediate and visible by expanding and focusing the input composer and preserving partial dictated text. 
- Provide clearer localized copy and prepare a new mobile build.

### Description

- Added `_resumeSpeechListeningAfterAutoStop` and invoke it when speech stops automatically with no final result so the app shows a short status and restarts listening. 
- When speech input is enabled, the input composer is expanded, focus is requested, and `_startSpeechListening` is started (preserving handled text where applicable). 
- Updated `speech_input_auto_stopped` localization strings in Slovak, English and German to the new wording. 
- Updated README to document the new Android auto-restart, expanded input behavior, and microphone mode persistence. 
- Bumped mobile package `version` in `pubspec.yaml` from `0.1.5+95` to `0.1.5+96`.

### Testing

- Ran `flutter analyze` and the analyzer passed. 
- Ran `flutter test` and unit/widget tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a153085f648833289849f82ae7e4731)