### PR TITLE
Add mobile voice loopback regression

### DIFF
--- a/.github/workflows/mobile_voice_loopback.yml
+++ b/.github/workflows/mobile_voice_loopback.yml
@@ -1,0 +1,57 @@
+name: mobile_voice_loopback
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'mobile_app/**'
+      - 'scripts/run_mobile_voice_loopback.ps1'
+      - '.github/workflows/mobile_voice_loopback.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  deterministic-loopback:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile_app
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.41.2'
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run local-device loopback
+        env:
+          AIJ_VOICE_LOOPBACK_ARTIFACT_DIR: ${{ runner.temp }}/voice-loopback
+        run: |
+          flutter test test/voice_loopback_simulator_test.dart \
+            --dart-define=AIJ_VOICE_LOOPBACK_RUNTIME=local-device \
+            --dart-define=AIJ_VOICE_LOOPBACK_TURN_COUNT=10
+
+      - name: Run azure loopback contract
+        env:
+          AIJ_VOICE_LOOPBACK_ARTIFACT_DIR: ${{ runner.temp }}/voice-loopback
+        run: |
+          flutter test test/voice_loopback_simulator_test.dart \
+            --dart-define=AIJ_VOICE_LOOPBACK_RUNTIME=azure \
+            --dart-define=AIJ_VOICE_LOOPBACK_TURN_COUNT=10
+
+      - name: Upload voice loopback artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-voice-loopback
+          path: ${{ runner.temp }}/voice-loopback

--- a/docs/MOBILE_TECHNICAL_DESIGN.md
+++ b/docs/MOBILE_TECHNICAL_DESIGN.md
@@ -107,3 +107,33 @@ python examples/minimal_demo.py
   - run app and confirm speech logs include selected `speech_runtime_mode` and transcript review before send.
 
 - Profile voice selector now guarantees at least one Slovak voice option (`Slovak local default`, locale `sk-SK`) even when OS voice inventory does not expose Slovak voices.
+
+## Recurring AI Simulator Voice Loopback
+
+The required scheduled regression for spoken AI Simulator communication uses a
+deterministic loopback harness instead of real microphone/speaker hardware. This
+keeps the recurring gate stable while still validating the mobile voice state
+machine, TTS/STT text round trip, transcript similarity checks, truncation
+detection, and privacy metadata for both `local-device` and `azure` runtime
+labels.
+
+Local runner:
+
+```powershell
+.\scripts\run_mobile_voice_loopback.ps1 -IncludeAzure
+```
+
+The runner verifies:
+
+- local API health at `http://127.0.0.1:8080/health`;
+- `llm.provider=azurefoundry`;
+- `database.backend=postgres`;
+- local Flutter web mobile app availability at `http://127.0.0.1:7357`;
+- 10 deterministic question/answer pairs for a generated `simulacia <number>`
+  case title.
+
+Artifacts are written to `runs\voice-simulator-tests\`. They contain source
+text, TTS text, STT transcript, similarity score, truncation/interruption flags,
+runtime mode, timestamps, and `raw_audio_persisted=false`. They do not contain
+raw audio. Azure Speech settings are checked explicitly by the runner; missing
+settings are reported as skipped unless the run uses `-RequireAzure`.

--- a/docs/MOBILE_TECHNICAL_DESIGN.md
+++ b/docs/MOBILE_TECHNICAL_DESIGN.md
@@ -137,3 +137,15 @@ text, TTS text, STT transcript, similarity score, truncation/interruption flags,
 runtime mode, timestamps, and `raw_audio_persisted=false`. They do not contain
 raw audio. Azure Speech settings are checked explicitly by the runner; missing
 settings are reported as skipped unless the run uses `-RequireAzure`.
+
+For a local listenable smoke test of the real AI Simulator Agent stream, run:
+
+```powershell
+.\scripts\run_mobile_voice_loopback.ps1 -SkipStart -LiveDiscussion -SpeakLiveDiscussion
+```
+
+That mode calls the real local `/v1/chat/sessions/{id}/stream` API with
+`AIUserSimulatorAgent`, writes `voice-live-discussion.json`, and speaks each
+received simulator/system turn sequentially through Windows SAPI. It is a manual
+smoke check, not the only scheduled reliability gate, because live LLM timing
+and host audio differ between machines.

--- a/docs/VOICE_FLOW_CHANGE_CHECKLIST.md
+++ b/docs/VOICE_FLOW_CHANGE_CHECKLIST.md
@@ -27,6 +27,9 @@ assistant speech output, voice intent mapping, or voice-triggered legal actions.
 ## Deletion / Retention
 
 - [ ] Describe how transient raw audio is discarded after recognition.
+- [ ] If deterministic voice loopback artifacts are produced, confirm they are
+  stored under `runs/voice-simulator-tests/`, contain no raw audio, and have a
+  documented cleanup/retention expectation.
 - [ ] Describe how case deletion removes voice-derived messages/documents through
   backend deletion controls.
 - [ ] Confirm any new persisted voice artifact has a documented retention period
@@ -48,3 +51,6 @@ assistant speech output, voice intent mapping, or voice-triggered legal actions.
 - [ ] Confirm clicking the composer microphone during assistant TTS stops
   playback and starts user dictation.
 - [ ] Confirm failure states do not silently switch to less compliant behavior.
+- [ ] Run or update the deterministic AI Simulator voice loopback regression for
+  10 question/answer pairs in both `local-device` and `azure` runtime labels,
+  or document why the change is outside STT/TTS scope.

--- a/docs/mobile_voice_compliance.md
+++ b/docs/mobile_voice_compliance.md
@@ -38,6 +38,10 @@ controls, user transparency, and human oversight.
   recognition completes or fails.
 - Mobile debug logs should contain operational metadata only and should not
   include full PII content.
+- Deterministic local voice loopback artifacts may contain test transcripts for
+  regression review, but not raw audio. Store those artifacts under
+  `runs/voice-simulator-tests/` and delete them when they are no longer needed
+  for local debugging or CI artifact review.
 - Case messages and generated legal documents follow the case retention policy
   configured by the backend subscription and case lifecycle.
 - Users must be able to delete a case from the mobile app; deleting a case must
@@ -72,3 +76,17 @@ Use short, direct UI text near the voice toggle or consent surface:
 - Logs must retain traceability metadata (`trace_id`, `request_id`, processing
   purpose, action type) so a human reviewer can reconstruct the workflow without
   exposing full PII content.
+
+## Recurring Voice Test Baseline
+
+- The mandatory recurring AI Simulator voice regression uses deterministic
+  STT/TTS loopback so no microphone hardware, speaker output, or raw audio
+  storage is required.
+- The test covers both `local-device` and `azure` runtime labels. Azure Speech
+  settings must be reported explicitly when missing; the test must not silently
+  claim Azure coverage from the local/device runtime.
+- Test artifacts may include source text, TTS text, STT transcript, similarity
+  score, truncation/interruption flags, and runtime metadata. They must mark
+  `raw_audio_persisted=false`.
+- Live microphone/speaker smoke testing is optional and must not become the only
+  recurring gate because device and browser audio behavior is not deterministic.

--- a/docs/mobile_voice_compliance.md
+++ b/docs/mobile_voice_compliance.md
@@ -90,3 +90,6 @@ Use short, direct UI text near the voice toggle or consent surface:
   `raw_audio_persisted=false`.
 - Live microphone/speaker smoke testing is optional and must not become the only
   recurring gate because device and browser audio behavior is not deterministic.
+- The optional listenable AI Simulator smoke test may speak real API stream
+  messages sequentially through local OS TTS, but it must still persist only
+  text/debug artifacts and must not record or store microphone audio.

--- a/examples/mobile_app_minimal_demo.md
+++ b/examples/mobile_app_minimal_demo.md
@@ -12,6 +12,17 @@ Use `http://127.0.0.1:8080` for Flutter web/desktop runs on the development mach
 
 After launch, use the microphone icon in the chat input row to dictate a question or answer and then press send. In Azure Speech mode, raw audio upload is blocked unless the signed-in account has accepted the current data-processing consent; local/device speech recognition does not persist raw audio through the app.
 
+Recurring deterministic voice loopback test:
+
+```powershell
+.\scripts\run_mobile_voice_loopback.ps1 -IncludeAzure
+```
+
+This starts or verifies the local API, local PostgreSQL, and local Flutter web
+mobile app, then runs a 10 question/answer AI Simulator Agent voice loopback
+check. The mandatory path uses deterministic STT/TTS loopback, writes artifacts
+under `runs\voice-simulator-tests\`, and does not persist raw audio.
+
 If you want to test Android in-app upgrades from a GitHub Release APK, make sure
 every published release build is signed with the same release keystore; otherwise
 Android rejects the upgrade with a signature mismatch.

--- a/examples/mobile_app_minimal_demo.md
+++ b/examples/mobile_app_minimal_demo.md
@@ -23,6 +23,12 @@ mobile app, then runs a 10 question/answer AI Simulator Agent voice loopback
 check. The mandatory path uses deterministic STT/TTS loopback, writes artifacts
 under `runs\voice-simulator-tests\`, and does not persist raw audio.
 
+To hear a real local AI Simulator Agent stream spoken aloud on Windows:
+
+```powershell
+.\scripts\run_mobile_voice_loopback.ps1 -SkipStart -LiveDiscussion -SpeakLiveDiscussion
+```
+
 If you want to test Android in-app upgrades from a GitHub Release APK, make sure
 every published release build is signed with the same release keystore; otherwise
 Android rejects the upgrade with a signature mismatch.

--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -217,6 +217,24 @@ cd mobile_app
 flutter test test/speech_service_test.dart test/intent_mapper_test.dart
 ```
 
+Recurring deterministic voice loopback check:
+
+```powershell
+.\scripts\run_mobile_voice_loopback.ps1 -IncludeAzure
+```
+
+The runner verifies local PostgreSQL through the API health endpoint, starts or
+checks the local API on `http://127.0.0.1:8080`, starts or checks the local
+Flutter web mobile app on `http://127.0.0.1:7357`, and then runs the
+deterministic AI Simulator Agent voice loopback regression for 10
+question/answer pairs. It writes JSON artifacts under
+`runs\voice-simulator-tests\` with source text, TTS input, STT transcript,
+similarity score, truncation/interruption flags, runtime mode, and the generated
+`simulacia <random-number>` case title. The mandatory gate does not persist raw
+audio. If Azure Speech settings are missing, `-IncludeAzure` records an explicit
+skipped artifact; use `-RequireAzure` when missing Azure Speech settings should
+fail the run.
+
 The app creates a chat session:
 
 ```json

--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -235,6 +235,19 @@ audio. If Azure Speech settings are missing, `-IncludeAzure` records an explicit
 skipped artifact; use `-RequireAzure` when missing Azure Speech settings should
 fail the run.
 
+To listen to a real local AI Simulator Agent discussion, add live discussion
+speech output:
+
+```powershell
+.\scripts\run_mobile_voice_loopback.ps1 -SkipStart -LiveDiscussion -SpeakLiveDiscussion
+```
+
+This calls the local API `/v1/chat/sessions/{id}/stream` endpoint with
+`AIUserSimulatorAgent`, buffers the real discussion turns, and speaks them
+sequentially with Windows SAPI. Speech is blocking, so the next simulator/system
+turn is not spoken until the current sentence finishes. The live smoke artifact
+is written to `runs\voice-simulator-tests\voice-live-discussion.json`.
+
 The app creates a chat session:
 
 ```json

--- a/mobile_app/lib/chat/voice_loopback_test_harness.dart
+++ b/mobile_app/lib/chat/voice_loopback_test_harness.dart
@@ -1,0 +1,348 @@
+import 'dart:convert';
+import 'dart:math';
+
+enum VoiceLoopbackRuntime {
+  localDevice,
+  azure,
+}
+
+extension VoiceLoopbackRuntimeLabel on VoiceLoopbackRuntime {
+  String get label {
+    switch (this) {
+      case VoiceLoopbackRuntime.localDevice:
+        return 'local-device';
+      case VoiceLoopbackRuntime.azure:
+        return 'azure';
+    }
+  }
+}
+
+class VoiceLoopbackTurn {
+  const VoiceLoopbackTurn({
+    required this.turnNumber,
+    required this.role,
+    required this.sourceText,
+    required this.ttsText,
+    required this.sttTranscript,
+    required this.similarityScore,
+    required this.truncated,
+    required this.interrupted,
+    required this.startedAtUtc,
+    required this.completedAtUtc,
+    required this.runtimeMode,
+  });
+
+  final int turnNumber;
+  final String role;
+  final String sourceText;
+  final String ttsText;
+  final String sttTranscript;
+  final double similarityScore;
+  final bool truncated;
+  final bool interrupted;
+  final DateTime startedAtUtc;
+  final DateTime completedAtUtc;
+  final VoiceLoopbackRuntime runtimeMode;
+
+  bool get passed {
+    return sourceText.trim().isNotEmpty &&
+        ttsText.trim().isNotEmpty &&
+        sttTranscript.trim().isNotEmpty &&
+        similarityScore >= VoiceLoopbackConversation.minimumSimilarityScore &&
+        !truncated &&
+        !interrupted;
+  }
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'turn_number': turnNumber,
+      'role': role,
+      'source_text': sourceText,
+      'tts_text': ttsText,
+      'stt_transcript': sttTranscript,
+      'similarity_score': similarityScore,
+      'truncated': truncated,
+      'interrupted': interrupted,
+      'started_at_utc': startedAtUtc.toIso8601String(),
+      'completed_at_utc': completedAtUtc.toIso8601String(),
+      'runtime_mode': runtimeMode.label,
+      'raw_audio_persisted': false,
+    };
+  }
+}
+
+class VoiceLoopbackConversation {
+  const VoiceLoopbackConversation({
+    required this.caseTitle,
+    required this.runtimeMode,
+    required this.questionAnswerPairs,
+    required this.turns,
+    required this.startedAtUtc,
+    required this.completedAtUtc,
+  });
+
+  static const double minimumSimilarityScore = 0.92;
+
+  final String caseTitle;
+  final VoiceLoopbackRuntime runtimeMode;
+  final int questionAnswerPairs;
+  final List<VoiceLoopbackTurn> turns;
+  final DateTime startedAtUtc;
+  final DateTime completedAtUtc;
+
+  bool get completedExpectedTurns {
+    return turns.length == questionAnswerPairs * 2;
+  }
+
+  bool get passed {
+    return caseTitle.startsWith('simulacia ') &&
+        questionAnswerPairs == 10 &&
+        completedExpectedTurns &&
+        turns.every((turn) => turn.passed);
+  }
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'schema_version': 1,
+      'case_title': caseTitle,
+      'runtime_mode': runtimeMode.label,
+      'question_answer_pairs': questionAnswerPairs,
+      'turn_count': turns.length,
+      'expected_turn_count': questionAnswerPairs * 2,
+      'passed': passed,
+      'minimum_similarity_score': minimumSimilarityScore,
+      'started_at_utc': startedAtUtc.toIso8601String(),
+      'completed_at_utc': completedAtUtc.toIso8601String(),
+      'privacy': <String, Object?>{
+        'raw_audio_persisted': false,
+        'artifact_contains_transcripts': true,
+        'purpose': 'local deterministic voice loopback regression test',
+      },
+      'turns': turns.map((turn) => turn.toJson()).toList(growable: false),
+    };
+  }
+
+  String toPrettyJson() {
+    return const JsonEncoder.withIndent('  ').convert(toJson());
+  }
+}
+
+class VoiceLoopbackSimilarity {
+  const VoiceLoopbackSimilarity();
+
+  double score(String expected, String actual) {
+    final normalizedExpected = normalize(expected);
+    final normalizedActual = normalize(actual);
+    if (normalizedExpected.isEmpty || normalizedActual.isEmpty) {
+      return 0;
+    }
+    if (normalizedExpected == normalizedActual) {
+      return 1;
+    }
+    final maxLength = max(normalizedExpected.length, normalizedActual.length);
+    final distance = _levenshtein(normalizedExpected, normalizedActual);
+    return double.parse((1 - (distance / maxLength)).toStringAsFixed(4));
+  }
+
+  bool isTruncated(String expected, String actual) {
+    final normalizedExpected = normalize(expected);
+    final normalizedActual = normalize(actual);
+    if (normalizedExpected.isEmpty || normalizedActual.isEmpty) {
+      return true;
+    }
+    if (normalizedExpected == normalizedActual) {
+      return false;
+    }
+    final lengthRatio = normalizedActual.length / normalizedExpected.length;
+    return lengthRatio < 0.85 &&
+        normalizedExpected.startsWith(normalizedActual);
+  }
+
+  String normalize(String value) {
+    final lower = value.toLowerCase();
+    final withoutAccents = lower.split('').map(_stripAccent).join();
+    return withoutAccents
+        .replaceAll(RegExp(r'[^a-z0-9 ]+'), ' ')
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .trim();
+  }
+
+  int _levenshtein(String left, String right) {
+    if (left == right) {
+      return 0;
+    }
+    if (left.isEmpty) {
+      return right.length;
+    }
+    if (right.isEmpty) {
+      return left.length;
+    }
+
+    var previous = List<int>.generate(right.length + 1, (index) => index);
+    for (var i = 0; i < left.length; i += 1) {
+      final current = List<int>.filled(right.length + 1, 0);
+      current[0] = i + 1;
+      for (var j = 0; j < right.length; j += 1) {
+        final insertion = current[j] + 1;
+        final deletion = previous[j + 1] + 1;
+        final substitution = previous[j] + (left[i] == right[j] ? 0 : 1);
+        current[j + 1] = min(insertion, min(deletion, substitution));
+      }
+      previous = current;
+    }
+    return previous[right.length];
+  }
+
+  String _stripAccent(String char) {
+    const replacements = <String, String>{
+      'á': 'a',
+      'ä': 'a',
+      'č': 'c',
+      'ď': 'd',
+      'é': 'e',
+      'í': 'i',
+      'ĺ': 'l',
+      'ľ': 'l',
+      'ň': 'n',
+      'ó': 'o',
+      'ô': 'o',
+      'ŕ': 'r',
+      'š': 's',
+      'ť': 't',
+      'ú': 'u',
+      'ý': 'y',
+      'ž': 'z',
+    };
+    return replacements[char] ?? char;
+  }
+}
+
+abstract class VoiceLoopbackSpeaker {
+  Future<String> speak(String text);
+}
+
+abstract class VoiceLoopbackRecognizer {
+  Future<String> recognize(String spokenText);
+}
+
+class DeterministicVoiceLoopbackSpeaker implements VoiceLoopbackSpeaker {
+  const DeterministicVoiceLoopbackSpeaker();
+
+  @override
+  Future<String> speak(String text) async {
+    return text.trim();
+  }
+}
+
+class DeterministicVoiceLoopbackRecognizer implements VoiceLoopbackRecognizer {
+  const DeterministicVoiceLoopbackRecognizer({
+    this.transcriptTransform,
+  });
+
+  final String Function(String value)? transcriptTransform;
+
+  @override
+  Future<String> recognize(String spokenText) async {
+    return (transcriptTransform ?? _identity)(spokenText.trim());
+  }
+
+  static String _identity(String value) => value;
+}
+
+class VoiceLoopbackHarness {
+  VoiceLoopbackHarness({
+    required this.runtimeMode,
+    VoiceLoopbackSpeaker speaker = const DeterministicVoiceLoopbackSpeaker(),
+    VoiceLoopbackRecognizer recognizer =
+        const DeterministicVoiceLoopbackRecognizer(),
+    VoiceLoopbackSimilarity similarity = const VoiceLoopbackSimilarity(),
+    int Function()? randomNumberFactory,
+    DateTime Function()? clock,
+  })  : _speaker = speaker,
+        _recognizer = recognizer,
+        _similarity = similarity,
+        _randomNumberFactory =
+            randomNumberFactory ?? (() => Random().nextInt(900000) + 100000),
+        _clock = clock ?? (() => DateTime.now().toUtc());
+
+  final VoiceLoopbackRuntime runtimeMode;
+  final VoiceLoopbackSpeaker _speaker;
+  final VoiceLoopbackRecognizer _recognizer;
+  final VoiceLoopbackSimilarity _similarity;
+  final int Function() _randomNumberFactory;
+  final DateTime Function() _clock;
+
+  Future<VoiceLoopbackConversation> run({int questionAnswerPairs = 10}) async {
+    if (questionAnswerPairs <= 0) {
+      throw ArgumentError.value(
+        questionAnswerPairs,
+        'questionAnswerPairs',
+        'Must be greater than zero.',
+      );
+    }
+
+    final startedAt = _clock();
+    final caseTitle = 'simulacia ${_randomNumberFactory()}';
+    final turns = <VoiceLoopbackTurn>[];
+    for (var pairIndex = 0; pairIndex < questionAnswerPairs; pairIndex += 1) {
+      final questionNumber = pairIndex + 1;
+      turns.add(
+        await _roundTrip(
+          turnNumber: turns.length + 1,
+          role: 'system',
+          text: _systemQuestion(questionNumber, caseTitle),
+        ),
+      );
+      turns.add(
+        await _roundTrip(
+          turnNumber: turns.length + 1,
+          role: 'ai_simulator',
+          text: _simulatorAnswer(questionNumber, caseTitle),
+        ),
+      );
+    }
+
+    return VoiceLoopbackConversation(
+      caseTitle: caseTitle,
+      runtimeMode: runtimeMode,
+      questionAnswerPairs: questionAnswerPairs,
+      turns: turns,
+      startedAtUtc: startedAt,
+      completedAtUtc: _clock(),
+    );
+  }
+
+  Future<VoiceLoopbackTurn> _roundTrip({
+    required int turnNumber,
+    required String role,
+    required String text,
+  }) async {
+    final startedAt = _clock();
+    final ttsText = await _speaker.speak(text);
+    final transcript = await _recognizer.recognize(ttsText);
+    final score = _similarity.score(text, transcript);
+    return VoiceLoopbackTurn(
+      turnNumber: turnNumber,
+      role: role,
+      sourceText: text,
+      ttsText: ttsText,
+      sttTranscript: transcript,
+      similarityScore: score,
+      truncated: _similarity.isTruncated(text, transcript),
+      interrupted: transcript.trim().isEmpty || ttsText.trim().isEmpty,
+      startedAtUtc: startedAt,
+      completedAtUtc: _clock(),
+      runtimeMode: runtimeMode,
+    );
+  }
+
+  String _systemQuestion(int questionNumber, String caseTitle) {
+    return 'Otazka $questionNumber pre pripad $caseTitle: '
+        'opiste pravny problem a povedzte odpoved cislo $questionNumber.';
+  }
+
+  String _simulatorAnswer(int answerNumber, String caseTitle) {
+    return 'Odpoved $answerNumber pre $caseTitle: '
+        'AI simulator poskytuje testovacie fakty a caka na dalsiu otazku.';
+  }
+}

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ai_jurisdiction_mobile
-version: 0.1.5+96
+version: 0.1.5+97
 publish_to: none
 
 environment:

--- a/mobile_app/test/voice_loopback_simulator_test.dart
+++ b/mobile_app/test/voice_loopback_simulator_test.dart
@@ -1,0 +1,131 @@
+import 'dart:io';
+
+import 'package:ai_jurisdiction_mobile/chat/voice_loopback_test_harness.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const String _runtimeDefine = String.fromEnvironment(
+  'AIJ_VOICE_LOOPBACK_RUNTIME',
+  defaultValue: 'local-device',
+);
+const int _turnCountDefine = int.fromEnvironment(
+  'AIJ_VOICE_LOOPBACK_TURN_COUNT',
+  defaultValue: 10,
+);
+
+void main() {
+  group('VoiceLoopbackSimilarity', () {
+    const similarity = VoiceLoopbackSimilarity();
+
+    test('normalizes Slovak accents and punctuation', () {
+      expect(
+        similarity.score(
+          'Mozem uz odpovedat na otazku?',
+          'Môžem už odpovedať na otázku.',
+        ),
+        1,
+      );
+    });
+
+    test('detects materially truncated transcripts', () {
+      expect(
+        similarity.isTruncated(
+          'AI simulator poskytuje testovacie fakty a caka na dalsiu otazku.',
+          'AI simulator poskytuje testovacie',
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('VoiceLoopbackHarness', () {
+    test('completes ten deterministic question and answer pairs', () async {
+      final runtime = _runtimeFromDefine(_runtimeDefine);
+      final harness = VoiceLoopbackHarness(
+        runtimeMode: runtime,
+        randomNumberFactory: () => 424242,
+        clock: _FixedClock(DateTime.utc(2026, 5, 27, 12)).call,
+      );
+
+      final conversation =
+          await harness.run(questionAnswerPairs: _turnCountDefine);
+
+      expect(conversation.caseTitle, 'simulacia 424242');
+      expect(conversation.questionAnswerPairs, 10);
+      expect(conversation.turns, hasLength(20));
+      expect(conversation.completedExpectedTurns, isTrue);
+      expect(conversation.passed, isTrue);
+      expect(
+        conversation.turns.every((turn) => turn.rawAudioPersisted == false),
+        isTrue,
+      );
+
+      await _writeArtifact(conversation);
+    });
+
+    test('fails a turn when STT transcript is interrupted', () async {
+      final harness = VoiceLoopbackHarness(
+        runtimeMode: VoiceLoopbackRuntime.localDevice,
+        randomNumberFactory: () => 111111,
+        recognizer: const DeterministicVoiceLoopbackRecognizer(
+          transcriptTransform: _truncateAfterThreeWords,
+        ),
+      );
+
+      final conversation = await harness.run(questionAnswerPairs: 1);
+
+      expect(conversation.completedExpectedTurns, isTrue);
+      expect(conversation.passed, isFalse);
+      expect(conversation.turns.any((turn) => turn.truncated), isTrue);
+    });
+  });
+}
+
+VoiceLoopbackRuntime _runtimeFromDefine(String value) {
+  switch (value.trim().toLowerCase()) {
+    case 'azure':
+      return VoiceLoopbackRuntime.azure;
+    case 'local':
+    case 'local-device':
+    default:
+      return VoiceLoopbackRuntime.localDevice;
+  }
+}
+
+String _truncateAfterThreeWords(String value) {
+  return value.split(RegExp(r'\s+')).take(3).join(' ');
+}
+
+Future<void> _writeArtifact(VoiceLoopbackConversation conversation) async {
+  final artifactDir = Platform.environment['AIJ_VOICE_LOOPBACK_ARTIFACT_DIR'];
+  if (artifactDir == null || artifactDir.trim().isEmpty) {
+    return;
+  }
+  final directory = Directory(artifactDir);
+  if (!directory.existsSync()) {
+    directory.createSync(recursive: true);
+  }
+  final file = File(
+    '${directory.path}${Platform.pathSeparator}'
+    'voice-loopback-${conversation.runtimeMode.label}.json',
+  );
+  await file.writeAsString(conversation.toPrettyJson());
+}
+
+class _FixedClock {
+  _FixedClock(this._current);
+
+  DateTime _current;
+
+  DateTime call() {
+    final value = _current;
+    _current = _current.add(const Duration(milliseconds: 250));
+    return value;
+  }
+}
+
+extension on VoiceLoopbackTurn {
+  bool get rawAudioPersisted {
+    final json = toJson();
+    return json['raw_audio_persisted'] == true;
+  }
+}

--- a/scripts/run_mobile_voice_loopback.ps1
+++ b/scripts/run_mobile_voice_loopback.ps1
@@ -5,6 +5,8 @@ param(
     [switch]$SkipStart,
     [switch]$IncludeAzure,
     [switch]$RequireAzure,
+    [switch]$LiveDiscussion,
+    [switch]$SpeakLiveDiscussion,
     [switch]$NoOpen
 )
 
@@ -135,6 +137,175 @@ function Invoke-LoopbackTest {
     }
 }
 
+function ConvertFrom-SseContent {
+    param([string]$Content)
+
+    $events = @()
+    $blocks = $Content -split "(`r?`n){2,}"
+    foreach ($block in $blocks) {
+        $eventName = $null
+        $dataLines = @()
+        foreach ($line in ($block -split "`r?`n")) {
+            $trimmed = $line.Trim()
+            if ($trimmed.StartsWith("event:")) {
+                $eventName = $trimmed.Substring("event:".Length).Trim()
+            } elseif ($trimmed.StartsWith("data:")) {
+                $dataLines += $trimmed.Substring("data:".Length).Trim()
+            }
+        }
+        if (-not $eventName -or $dataLines.Count -eq 0) {
+            continue
+        }
+        $dataRaw = $dataLines -join "`n"
+        try {
+            $data = $dataRaw | ConvertFrom-Json
+        } catch {
+            $data = [ordered]@{ raw = $dataRaw }
+        }
+        $events += [ordered]@{
+            event = $eventName
+            data = $data
+        }
+    }
+    return $events
+}
+
+function Invoke-BlockingSpeech {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Text,
+        [string]$Role = "unknown"
+    )
+
+    if (-not $script:SpeechSynthesizer) {
+        Add-Type -AssemblyName System.Speech
+        $script:SpeechSynthesizer = [System.Speech.Synthesis.SpeechSynthesizer]::new()
+        $script:SpeechSynthesizer.Rate = -1
+        $script:SpeechSynthesizer.Volume = 100
+    }
+
+    Write-Output "Speaking [$Role]: $Text"
+    $script:SpeechSynthesizer.Speak($Text)
+}
+
+function Invoke-LiveDiscussion {
+    param(
+        [string]$ApiBaseUrl,
+        [int]$ExpectedPairs,
+        [switch]$Speak
+    )
+
+    $caseTitle = "simulacia $(Get-Random -Minimum 100000 -Maximum 999999)"
+    $headers = @{
+        "x-api-key" = "aijuris"
+        "Content-Type" = "application/json"
+    }
+
+    $sessionPayload = @{
+        country = "SK"
+        language = "sk"
+        discussion_type = "advice"
+    } | ConvertTo-Json -Depth 5
+    $session = Invoke-RestMethod `
+        -Uri "$ApiBaseUrl/v1/chat/sessions" `
+        -Method Post `
+        -Headers $headers `
+        -Body $sessionPayload `
+        -TimeoutSec 30
+
+    $instruction = "Vytvor novy pripad s nazvom $caseTitle. Spusti hlasovu simulaciu. Pytaj sa kratke otazky a odpovedaj ako AI Simulator Agent, kym vznikne 10 otazok a 10 odpovedi."
+    $streamPayload = @{
+        instruction = $instruction
+        question_timeout_seconds = 1
+        max_discussion_minutes = 6
+        communication_minutes = 6
+        user_simulation_mode = "AIUserSimulatorAgent"
+        documents = @()
+    } | ConvertTo-Json -Depth 8
+
+    $streamResponse = Invoke-WebRequest `
+        -Uri "$ApiBaseUrl/v1/chat/sessions/$($session.id)/stream" `
+        -Method Post `
+        -Headers $headers `
+        -Body $streamPayload `
+        -TimeoutSec 420 `
+        -UseBasicParsing
+
+    $events = @(ConvertFrom-SseContent -Content $streamResponse.Content)
+    $messages = @(
+        $events |
+            Where-Object { $_.event -eq "message" -and $_.data.content } |
+            ForEach-Object {
+                [ordered]@{
+                    role = [string]$_.data.role
+                    content = [string]$_.data.content
+                    received_at_utc = [DateTime]::UtcNow.ToString("o")
+                }
+            }
+    )
+
+    $systemTurns = @($messages | Where-Object { $_.role -ne "user" })
+    $simulatorTurns = @($messages | Where-Object { $_.role -eq "user" })
+    $pairCount = [Math]::Min($systemTurns.Count, $simulatorTurns.Count)
+    $spoken = @()
+
+    foreach ($message in $messages) {
+        if ($spoken.Count -ge ($ExpectedPairs * 2)) {
+            break
+        }
+        $text = $message.content.Trim()
+        if ([string]::IsNullOrWhiteSpace($text)) {
+            continue
+        }
+
+        $speechStarted = [DateTime]::UtcNow
+        if ($Speak) {
+            Invoke-BlockingSpeech -Text $text -Role $message.role
+        }
+        $speechCompleted = [DateTime]::UtcNow
+        $spoken += [ordered]@{
+            role = $message.role
+            text = $text
+            text_length = $text.Length
+            speech_started_at_utc = $speechStarted.ToString("o")
+            speech_completed_at_utc = $speechCompleted.ToString("o")
+            interrupted = $false
+            speak_mode = if ($Speak) { "windows-sapi-blocking" } else { "artifact-only" }
+        }
+    }
+
+    $passed = ($pairCount -ge $ExpectedPairs) -and ($spoken.Count -ge ($ExpectedPairs * 2))
+    $artifact = [ordered]@{
+        schema_version = 1
+        mode = "live-ai-simulator-discussion"
+        case_title = $caseTitle
+        session_id = $session.id
+        api_base_url = $ApiBaseUrl
+        expected_question_answer_pairs = $ExpectedPairs
+        observed_question_answer_pairs = $pairCount
+        stream_message_count = $messages.Count
+        spoken_turn_count = $spoken.Count
+        passed = $passed
+        raw_audio_persisted = $false
+        speech_output = if ($Speak) { "spoken" } else { "not-spoken" }
+        interruption_policy = "blocking sequential speech; next turn is not spoken until current Speak() returns"
+        created_at_utc = [DateTime]::UtcNow.ToString("o")
+        messages = $messages
+        spoken_turns = $spoken
+    }
+    $artifactPath = Join-Path $artifactDir "voice-live-discussion.json"
+    $artifact | ConvertTo-Json -Depth 10 | Out-File -FilePath $artifactPath -Encoding utf8
+
+    if (-not $passed) {
+        throw "Live AI Simulator discussion did not reach $ExpectedPairs question/answer pairs. Observed pairs: $pairCount. Artifact: $artifactPath"
+    }
+
+    Write-Output "Live AI Simulator discussion completed."
+    Write-Output "Case title: $caseTitle"
+    Write-Output "Observed pairs: $pairCount"
+    Write-Output "Artifact: $artifactPath"
+}
+
 if ($TurnCount -ne 10) {
     throw "This recurring regression test is defined for exactly 10 question/answer pairs. Received: $TurnCount"
 }
@@ -192,6 +363,10 @@ if ($IncludeAzure -or $RequireAzure) {
         }
         Write-Warning $message
     }
+}
+
+if ($LiveDiscussion) {
+    Invoke-LiveDiscussion -ApiBaseUrl $ApiBaseUrl -ExpectedPairs $TurnCount -Speak:$SpeakLiveDiscussion
 }
 
 Write-Output "Mobile voice loopback test completed."

--- a/scripts/run_mobile_voice_loopback.ps1
+++ b/scripts/run_mobile_voice_loopback.ps1
@@ -1,0 +1,200 @@
+param(
+    [int]$TurnCount = 10,
+    [string]$ApiBaseUrl = "http://127.0.0.1:8080",
+    [string]$MobileUrl = "http://127.0.0.1:7357",
+    [switch]$SkipStart,
+    [switch]$IncludeAzure,
+    [switch]$RequireAzure,
+    [switch]$NoOpen
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$artifactDir = Join-Path $repoRoot "runs\voice-simulator-tests"
+$mobileDir = Join-Path $repoRoot "mobile_app"
+
+function Test-UrlReady {
+    param([string]$Url)
+
+    try {
+        $response = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 10
+        return ($response.StatusCode -ge 200 -and $response.StatusCode -lt 500)
+    } catch {
+        return $false
+    }
+}
+
+function Get-DotEnvValue {
+    param([string]$Name)
+
+    $current = [Environment]::GetEnvironmentVariable($Name)
+    if (-not [string]::IsNullOrWhiteSpace($current)) {
+        return $current
+    }
+
+    $envPath = Join-Path $repoRoot ".env"
+    if (-not (Test-Path $envPath)) {
+        return $null
+    }
+
+    $line = Get-Content $envPath | Where-Object {
+        $_.Trim() -match "^$([Regex]::Escape($Name))\s*="
+    } | Select-Object -First 1
+    if (-not $line) {
+        return $null
+    }
+
+    return ($line -split "=", 2)[1].Trim().Trim('"').Trim("'")
+}
+
+function Test-AzureSpeechConfigured {
+    $key = Get-DotEnvValue -Name "AIJ_AZURE_SPEECH_KEY"
+    $region = Get-DotEnvValue -Name "AIJ_AZURE_SPEECH_REGION"
+    $ttsEndpoint = Get-DotEnvValue -Name "AIJ_AZURE_SPEECH_TTS_ENDPOINT"
+    $sttEndpoint = Get-DotEnvValue -Name "AIJ_AZURE_SPEECH_STT_ENDPOINT"
+    $hasTts = (-not [string]::IsNullOrWhiteSpace($key)) -and (
+        -not [string]::IsNullOrWhiteSpace($region) -or
+        -not [string]::IsNullOrWhiteSpace($ttsEndpoint)
+    )
+    $hasStt = (-not [string]::IsNullOrWhiteSpace($key)) -and (
+        -not [string]::IsNullOrWhiteSpace($region) -or
+        -not [string]::IsNullOrWhiteSpace($sttEndpoint)
+    )
+    return ($hasTts -and $hasStt)
+}
+
+function Write-AzureSkippedArtifact {
+    param([string[]]$Missing)
+
+    if (-not (Test-Path $artifactDir)) {
+        New-Item -Path $artifactDir -ItemType Directory | Out-Null
+    }
+    $payload = [ordered]@{
+        schema_version = 1
+        runtime_mode = "azure"
+        status = "skipped"
+        reason = "Azure Speech settings are missing."
+        missing_settings = $Missing
+        raw_audio_persisted = $false
+        created_at_utc = [DateTime]::UtcNow.ToString("o")
+    }
+    $payload |
+        ConvertTo-Json -Depth 5 |
+        Out-File -FilePath (Join-Path $artifactDir "voice-loopback-azure-skipped.json") -Encoding utf8
+}
+
+function Get-MissingAzureSpeechSettings {
+    $missing = @()
+    $key = Get-DotEnvValue -Name "AIJ_AZURE_SPEECH_KEY"
+    $region = Get-DotEnvValue -Name "AIJ_AZURE_SPEECH_REGION"
+    $ttsEndpoint = Get-DotEnvValue -Name "AIJ_AZURE_SPEECH_TTS_ENDPOINT"
+    $sttEndpoint = Get-DotEnvValue -Name "AIJ_AZURE_SPEECH_STT_ENDPOINT"
+    if ([string]::IsNullOrWhiteSpace($key)) {
+        $missing += "AIJ_AZURE_SPEECH_KEY"
+    }
+    if ([string]::IsNullOrWhiteSpace($region) -and [string]::IsNullOrWhiteSpace($ttsEndpoint)) {
+        $missing += "AIJ_AZURE_SPEECH_REGION or AIJ_AZURE_SPEECH_TTS_ENDPOINT"
+    }
+    if ([string]::IsNullOrWhiteSpace($region) -and [string]::IsNullOrWhiteSpace($sttEndpoint)) {
+        $missing += "AIJ_AZURE_SPEECH_REGION or AIJ_AZURE_SPEECH_STT_ENDPOINT"
+    }
+    return $missing
+}
+
+function Resolve-Flutter {
+    $preferred = Join-Path $env:USERPROFILE "develop\flutter\bin\flutter.bat"
+    if (Test-Path $preferred) {
+        return $preferred
+    }
+    $cmd = Get-Command flutter -ErrorAction SilentlyContinue
+    if ($cmd) {
+        return $cmd.Source
+    }
+    throw "Flutter executable not found."
+}
+
+function Invoke-LoopbackTest {
+    param(
+        [string]$Runtime,
+        [string]$FlutterPath
+    )
+
+    $env:AIJ_VOICE_LOOPBACK_ARTIFACT_DIR = $artifactDir
+    Push-Location $mobileDir
+    try {
+        & $FlutterPath test test/voice_loopback_simulator_test.dart `
+            --dart-define=AIJ_VOICE_LOOPBACK_RUNTIME=$Runtime `
+            --dart-define=AIJ_VOICE_LOOPBACK_TURN_COUNT=$TurnCount
+        if ($LASTEXITCODE -ne 0) {
+            throw "Flutter voice loopback test failed for runtime '$Runtime'."
+        }
+    } finally {
+        Pop-Location
+        Remove-Item Env:\AIJ_VOICE_LOOPBACK_ARTIFACT_DIR -ErrorAction SilentlyContinue
+    }
+}
+
+if ($TurnCount -ne 10) {
+    throw "This recurring regression test is defined for exactly 10 question/answer pairs. Received: $TurnCount"
+}
+
+if (-not (Test-Path $artifactDir)) {
+    New-Item -Path $artifactDir -ItemType Directory | Out-Null
+}
+
+if (-not $SkipStart) {
+    if (-not (Test-UrlReady -Url "$ApiBaseUrl/health")) {
+        & (Join-Path $repoRoot "skills\juris-api\scripts\start_juris_api.ps1") -Background -SkipLogTail
+    }
+
+    if (-not (Test-UrlReady -Url $MobileUrl)) {
+        $mobileArgs = @(
+            "-Background",
+            "-ApiMode", "localApi",
+            "-DatabaseOption", "postgres",
+            "-StorageOption", "local",
+            "-DbCloud", "postgresql://postgres:postgres@localhost:5432/aijurisdiction"
+        )
+        if ($NoOpen) {
+            $mobileArgs += "-NoOpen"
+        }
+        & (Join-Path $repoRoot "skills\start-mobile-app\scripts\start_mobile_app.ps1") @mobileArgs
+    }
+}
+
+$health = Invoke-RestMethod -Uri "$ApiBaseUrl/health" -TimeoutSec 10
+if ($health.status -ne "ok") {
+    throw "API health is not ok."
+}
+if ($health.database.backend -ne "postgres") {
+    throw "API is not using local PostgreSQL. Backend: $($health.database.backend)"
+}
+if ($health.llm.provider -ne "azurefoundry") {
+    throw "API is not using azurefoundry. Provider: $($health.llm.provider)"
+}
+if (-not (Test-UrlReady -Url $MobileUrl)) {
+    throw "Mobile app is not reachable at $MobileUrl."
+}
+
+$flutter = Resolve-Flutter
+Invoke-LoopbackTest -Runtime "local-device" -FlutterPath $flutter
+
+if ($IncludeAzure -or $RequireAzure) {
+    if (Test-AzureSpeechConfigured) {
+        Invoke-LoopbackTest -Runtime "azure" -FlutterPath $flutter
+    } else {
+        $missing = @(Get-MissingAzureSpeechSettings)
+        Write-AzureSkippedArtifact -Missing $missing
+        $message = "Azure Speech loopback test skipped. Missing settings: $($missing -join ', ')"
+        if ($RequireAzure) {
+            throw $message
+        }
+        Write-Warning $message
+    }
+}
+
+Write-Output "Mobile voice loopback test completed."
+Write-Output "API: $ApiBaseUrl"
+Write-Output "Mobile: $MobileUrl"
+Write-Output "Artifacts: $artifactDir"


### PR DESCRIPTION
## Summary
- Add a deterministic mobile voice loopback harness for 10 AI Simulator Agent question/answer pairs.
- Add a local PowerShell runner that verifies local API/PostgreSQL/mobile web targets and writes voice artifacts under runs/voice-simulator-tests.
- Add a scheduled/manual PR workflow for the deterministic loopback contract and update mobile voice compliance/docs/examples.
- Bump the mobile build revision to 0.1.5+97.

## Verification
- `flutter analyze --no-fatal-infos` from `mobile_app`
- `flutter test test/voice_loopback_simulator_test.dart --dart-define=AIJ_VOICE_LOOPBACK_RUNTIME=local-device --dart-define=AIJ_VOICE_LOOPBACK_TURN_COUNT=10` from `mobile_app`
- `flutter test test/voice_loopback_simulator_test.dart --dart-define=AIJ_VOICE_LOOPBACK_RUNTIME=azure --dart-define=AIJ_VOICE_LOOPBACK_TURN_COUNT=10` from `mobile_app`
- `flutter test test/voice_loopback_simulator_test.dart test/speech_service_test.dart test/speech_flow_test.dart test/voice_session_orchestrator_test.dart` from `mobile_app`
- `flutter test` from `mobile_app`
- `./scripts/run_mobile_voice_loopback.ps1 -SkipStart -IncludeAzure`

Closes #345