### PR TITLE
Harden MCP OAuth authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,10 @@ STORAGE_OPTION=local
 LOCAL_AUTH_ACCEPT_ANY_CODE=0
 # Secret used to sign MCP JWT bearer tokens. Set a long random value in deployed environments.
 # MCP_API_JWT_SECRET=change-this-long-random-secret
+# Public MCP origin used in OAuth metadata and JWT audience validation.
+# MCP_PUBLIC_BASE_URL=https://mcp.jurisdigta.eu
+# Comma-separated OAuth redirect hosts allowed for browser authorization callbacks.
+# MCP_OAUTH_ALLOWED_REDIRECT_HOSTS=chatgpt.com,chat.openai.com
 # Dedicated local MCP server port and optional browser origins.
 # MCP_PORT=8070
 # MCP_CORS_ALLOW_ORIGINS=https://mcp.jurisdigta.eu

--- a/.github/workflows/api_build_deploy.yml
+++ b/.github/workflows/api_build_deploy.yml
@@ -620,8 +620,8 @@ jobs:
           echo "runner_ip=$runner_ip" >> "$GITHUB_OUTPUT"
           az postgres flexible-server firewall-rule create \
             --resource-group "$AZURE_RESOURCE_GROUP" \
-            --name "$AZURE_POSTGRES_SERVER_NAME" \
-            --rule-name "github-runner-${GITHUB_RUN_ID}" \
+            --server-name "$AZURE_POSTGRES_SERVER_NAME" \
+            --name "github-runner-${GITHUB_RUN_ID}" \
             --start-ip-address "$runner_ip" \
             --end-ip-address "$runner_ip" \
             --only-show-errors \
@@ -676,8 +676,8 @@ jobs:
         run: |
           az postgres flexible-server firewall-rule delete \
             --resource-group "$AZURE_RESOURCE_GROUP" \
-            --name "$AZURE_POSTGRES_SERVER_NAME" \
-            --rule-name "github-runner-${GITHUB_RUN_ID}" \
+            --server-name "$AZURE_POSTGRES_SERVER_NAME" \
+            --name "github-runner-${GITHUB_RUN_ID}" \
             --yes \
             --only-show-errors \
             --output none || true

--- a/.github/workflows/database_schema_upgrade.yml
+++ b/.github/workflows/database_schema_upgrade.yml
@@ -62,8 +62,8 @@ jobs:
           echo "RUNNER_IP=$runner_ip" >> "$GITHUB_ENV"
           az postgres flexible-server firewall-rule create \
             --resource-group "$AZURE_RESOURCE_GROUP" \
-            --name "$AZURE_POSTGRES_SERVER_NAME" \
-            --rule-name "github-runner-${GITHUB_RUN_ID}" \
+            --server-name "$AZURE_POSTGRES_SERVER_NAME" \
+            --name "github-runner-${GITHUB_RUN_ID}" \
             --start-ip-address "$runner_ip" \
             --end-ip-address "$runner_ip" \
             --only-show-errors \
@@ -100,8 +100,8 @@ jobs:
         run: |
           az postgres flexible-server firewall-rule delete \
             --resource-group "$AZURE_RESOURCE_GROUP" \
-            --name "$AZURE_POSTGRES_SERVER_NAME" \
-            --rule-name "github-runner-${GITHUB_RUN_ID}" \
+            --server-name "$AZURE_POSTGRES_SERVER_NAME" \
+            --name "github-runner-${GITHUB_RUN_ID}" \
             --yes \
             --only-show-errors \
             --output none || true

--- a/.github/workflows/email_build_deploy.yml
+++ b/.github/workflows/email_build_deploy.yml
@@ -168,8 +168,8 @@ jobs:
           $runnerIp = (Invoke-RestMethod -Uri "https://api.ipify.org").Trim()
           az postgres flexible-server firewall-rule create `
             --resource-group $env:AZURE_RESOURCE_GROUP `
-            --name $env:AZURE_POSTGRES_SERVER_NAME `
-            --rule-name "github-runner-${{ github.run_id }}" `
+            --server-name $env:AZURE_POSTGRES_SERVER_NAME `
+            --name "github-runner-${{ github.run_id }}" `
             --start-ip-address $runnerIp `
             --end-ip-address $runnerIp `
             --only-show-errors `
@@ -221,8 +221,8 @@ jobs:
         run: |
           az postgres flexible-server firewall-rule delete `
             --resource-group $env:AZURE_RESOURCE_GROUP `
-            --name $env:AZURE_POSTGRES_SERVER_NAME `
-            --rule-name "github-runner-${{ github.run_id }}" `
+            --server-name $env:AZURE_POSTGRES_SERVER_NAME `
+            --name "github-runner-${{ github.run_id }}" `
             --yes `
             --only-show-errors `
             --output none

--- a/.github/workflows/laws_collector_build_deploy.yml
+++ b/.github/workflows/laws_collector_build_deploy.yml
@@ -169,8 +169,8 @@ jobs:
           $runnerIp = (Invoke-RestMethod -Uri "https://api.ipify.org").Trim()
           az postgres flexible-server firewall-rule create `
             --resource-group $env:AZURE_RESOURCE_GROUP `
-            --name $env:AZURE_POSTGRES_SERVER_NAME `
-            --rule-name "github-runner-${{ github.run_id }}" `
+            --server-name $env:AZURE_POSTGRES_SERVER_NAME `
+            --name "github-runner-${{ github.run_id }}" `
             --start-ip-address $runnerIp `
             --end-ip-address $runnerIp `
             --only-show-errors `
@@ -247,8 +247,8 @@ jobs:
         run: |
           az postgres flexible-server firewall-rule delete `
             --resource-group $env:AZURE_RESOURCE_GROUP `
-            --name $env:AZURE_POSTGRES_SERVER_NAME `
-            --rule-name "github-runner-${{ github.run_id }}" `
+            --server-name $env:AZURE_POSTGRES_SERVER_NAME `
+            --name "github-runner-${{ github.run_id }}" `
             --yes `
             --only-show-errors `
             --output none

--- a/api/aijuristiction-api/app/mcp_api.py
+++ b/api/aijuristiction-api/app/mcp_api.py
@@ -12,13 +12,14 @@ import secrets
 import time
 from typing import Any, Callable, Sequence, cast
 from datetime import datetime, timedelta, timezone
+from urllib.parse import urlparse
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, Form, Header, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
 from app.laws_api import _laws_db_config, _read_laws_statistics
-from app.mcp_tokens import create_mcp_api_token, validate_mcp_api_token
+from app.mcp_tokens import MCP_TOKEN_SCOPE, create_mcp_api_token, default_mcp_resource_url, validate_mcp_api_token
 from app.services.email_scheduler import EmailScheduler
 from app.users.api import get_email_scheduler, get_user_store
 from app.users.notifications import queue_registration_email
@@ -35,6 +36,7 @@ router = APIRouter(prefix="/MCP", tags=["mcp"])
 oauth_router = APIRouter(tags=["mcp-oauth"])
 MCP_PROTOCOL_VERSION = "2025-03-26"
 _PUBLIC_TOOLS = {"getVersion", "getStatistics"}
+_DEFAULT_ALLOWED_REDIRECT_HOSTS = ("chatgpt.com", "chat.openai.com")
 logger = logging.getLogger("aijuristiction-api.mcp")
 
 
@@ -94,6 +96,16 @@ async def mcp_json_rpc(
         _payload_message_count(payload),
         ",".join(_payload_methods(payload)),
     )
+    if _payload_requires_auth(payload) and not _extract_mcp_api_key(
+        authorization=authorization,
+        x_mcp_api_key=x_mcp_api_key,
+    ):
+        logger.warning("mcp_json_rpc_auth_challenge reason=missing_bearer_token")
+        return JSONResponse(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            content=_json_rpc_error(_first_payload_id(payload), 401, "Tool requires OAuth authorization"),
+            headers={"WWW-Authenticate": _www_authenticate_header(request)},
+        )
     response = _handle_json_rpc(
         payload=payload,
         authorization=authorization,
@@ -124,10 +136,12 @@ def mcp_sign_up_page() -> HTMLResponse:
 @oauth_router.get("/.well-known/oauth-protected-resource")
 def oauth_protected_resource_metadata(request: Request) -> dict[str, Any]:
     base_url = _base_url(request)
+    resource = _resource_url(request)
     return {
-        "resource": f"{base_url}/MCP",
+        "resource": resource,
         "authorization_servers": [base_url],
         "bearer_methods_supported": ["header"],
+        "scopes_supported": [MCP_TOKEN_SCOPE],
         "resource_documentation": f"{base_url}/MCP/login",
     }
 
@@ -148,24 +162,30 @@ def oauth_authorization_server_metadata(request: Request) -> dict[str, Any]:
         "grant_types_supported": ["authorization_code"],
         "code_challenge_methods_supported": ["S256"],
         "token_endpoint_auth_methods_supported": ["none"],
+        "scopes_supported": [MCP_TOKEN_SCOPE],
     }
 
 
 @oauth_router.get("/oauth/authorize", response_class=HTMLResponse)
 def oauth_authorize_page(
+    request: Request,
     response_type: str,
     client_id: str,
     redirect_uri: str,
     code_challenge: str,
     code_challenge_method: str,
     state: str = "",
+    resource: str = "",
 ) -> HTMLResponse:
+    resolved_resource = _resolve_oauth_resource(request=request, resource=resource)
     _validate_oauth_authorize_request(
         response_type=response_type,
         client_id=client_id,
         redirect_uri=redirect_uri,
         code_challenge=code_challenge,
         code_challenge_method=code_challenge_method,
+        resource=resolved_resource,
+        expected_resource=_resource_url(request),
     )
     return HTMLResponse(
         _oauth_login_form_html(
@@ -175,29 +195,35 @@ def oauth_authorize_page(
             code_challenge=code_challenge,
             code_challenge_method=code_challenge_method,
             state=state,
+            resource=resolved_resource,
         )
     )
 
 
 @oauth_router.post("/oauth/authorize/login", response_class=HTMLResponse)
 def oauth_authorize_login(
+    request: Request,
     response_type: str = Form(...),
     client_id: str = Form(...),
     redirect_uri: str = Form(...),
     code_challenge: str = Form(...),
     code_challenge_method: str = Form(...),
+    resource: str = Form(""),
     state: str = Form(""),
     email: str = Form(...),
     password: str = Form(...),
     store: ApiDatabaseStore = Depends(get_user_store),
     scheduler: EmailScheduler = Depends(get_email_scheduler),
 ) -> HTMLResponse:
+    resolved_resource = _resolve_oauth_resource(request=request, resource=resource)
     _validate_oauth_authorize_request(
         response_type=response_type,
         client_id=client_id,
         redirect_uri=redirect_uri,
         code_challenge=code_challenge,
         code_challenge_method=code_challenge_method,
+        resource=resolved_resource,
+        expected_resource=_resource_url(request),
     )
     user = store.authenticate_user(email=email, password=password)
     if user is None:
@@ -223,28 +249,34 @@ def oauth_authorize_login(
             code_challenge=code_challenge,
             code_challenge_method=code_challenge_method,
             state=state,
+            resource=resolved_resource,
         )
     )
 
 
 @oauth_router.post("/oauth/authorize/verify")
 def oauth_authorize_verify(
+    request: Request,
     response_type: str = Form(...),
     client_id: str = Form(...),
     redirect_uri: str = Form(...),
     code_challenge: str = Form(...),
     code_challenge_method: str = Form(...),
+    resource: str = Form(""),
     email: str = Form(...),
     verification_code: str = Form(...),
     state: str = Form(""),
     store: ApiDatabaseStore = Depends(get_user_store),
 ) -> RedirectResponse:
+    resolved_resource = _resolve_oauth_resource(request=request, resource=resource)
     _validate_oauth_authorize_request(
         response_type=response_type,
         client_id=client_id,
         redirect_uri=redirect_uri,
         code_challenge=code_challenge,
         code_challenge_method=code_challenge_method,
+        resource=resolved_resource,
+        expected_resource=_resource_url(request),
     )
     if not _accepts_any_local_auth_code() and not store.verify_registration_code(
         email=_oauth_login_code_key(email=email),
@@ -261,6 +293,7 @@ def oauth_authorize_verify(
         client_id=client_id,
         redirect_uri=redirect_uri,
         code_challenge=code_challenge,
+        resource=resolved_resource,
     )
     query = {"code": authorization_code}
     if state:
@@ -270,11 +303,13 @@ def oauth_authorize_verify(
 
 @oauth_router.post("/oauth/token")
 def oauth_token(
+    request: Request,
     grant_type: str = Form(...),
     code: str = Form(...),
     redirect_uri: str = Form(...),
     client_id: str = Form(...),
     code_verifier: str = Form(...),
+    resource: str = Form(""),
     store: ApiDatabaseStore = Depends(get_user_store),
 ) -> dict[str, Any]:
     if grant_type != "authorization_code":
@@ -284,16 +319,25 @@ def oauth_token(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid authorization code")
     if record["client_id"] != client_id or record["redirect_uri"] != redirect_uri:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Authorization code context mismatch")
+    expected_resource = _resource_url(request)
+    resolved_resource = _resolve_oauth_resource(request=request, resource=resource)
+    if record["resource"] != expected_resource or resolved_resource != expected_resource:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="OAuth resource mismatch")
     if _pkce_s256_challenge(code_verifier) != record["code_challenge"]:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid PKCE code verifier")
     user = store.get_user(user_id=record["user_id"])
-    token, expires_at = _issue_mcp_api_key(store=store, user=user, expires_in_days=1)
+    token, expires_at = _issue_mcp_api_key(
+        store=store,
+        user=user,
+        expires_in_days=1,
+        audience=expected_resource,
+    )
     expires_in = max(1, int((datetime.fromisoformat(expires_at) - datetime.now(timezone.utc)).total_seconds()))
     return {
         "access_token": token,
         "token_type": "Bearer",
         "expires_in": expires_in,
-        "scope": "mcp:laws",
+        "scope": MCP_TOKEN_SCOPE,
     }
 
 
@@ -837,9 +881,15 @@ def _mcp_tools() -> list[dict[str, Any]]:
     ]
 
 
-def _issue_mcp_api_key(*, store: ApiDatabaseStore, user: User, expires_in_days: int) -> tuple[str, str]:
+def _issue_mcp_api_key(
+    *,
+    store: ApiDatabaseStore,
+    user: User,
+    expires_in_days: int,
+    audience: str | None = None,
+) -> tuple[str, str]:
     expires_at_dt = (datetime.now(timezone.utc) + timedelta(days=expires_in_days)).replace(microsecond=0)
-    raw_key = create_mcp_api_token(user=user, expires_at=expires_at_dt)
+    raw_key = create_mcp_api_token(user=user, expires_at=expires_at_dt, audience=audience)
     expires_at = expires_at_dt.isoformat()
     store.set_user_mcp_api_key(user_id=user.user_id, api_key=raw_key, expires_at=expires_at)
     return raw_key, expires_at
@@ -868,16 +918,19 @@ def _oauth_login_code_key(*, email: str) -> str:
 
 
 def _authenticate_mcp_api_token(*, api_key: str, store: ApiDatabaseStore) -> User:
-    payload = validate_mcp_api_token(api_key)
+    payload = validate_mcp_api_token(
+        api_key,
+        audience=default_mcp_resource_url(),
+        required_scope=MCP_TOKEN_SCOPE,
+    )
     if payload is None:
         logger.warning("mcp_auth_failed reason=invalid_or_expired_token")
         raise HTTPException(status_code=401, detail="Invalid or expired MCP API key")
     user = store.find_user_by_mcp_api_key(api_key=api_key)
-    if user is None or user.user_id != payload.get("sub") or user.email != payload.get("email"):
+    if user is None or user.user_id != payload.get("sub"):
         logger.warning(
-            "mcp_auth_failed reason=token_user_mismatch subject_type=%s email_claim_present=%s",
+            "mcp_auth_failed reason=token_user_mismatch subject_type=%s",
             _value_type(payload.get("sub")),
-            payload.get("email") is not None,
         )
         raise HTTPException(status_code=401, detail="Invalid or expired MCP API key")
     return user
@@ -923,6 +976,52 @@ def _base_url(request: Request) -> str:
     return str(request.base_url).rstrip("/")
 
 
+def _resource_url(request: Request) -> str:
+    return f"{_base_url(request)}/MCP"
+
+
+def _resolve_oauth_resource(*, request: Request, resource: str) -> str:
+    return resource.strip() or _resource_url(request)
+
+
+def _allowed_oauth_redirect_hosts() -> set[str]:
+    configured = os.getenv("MCP_OAUTH_ALLOWED_REDIRECT_HOSTS", "").strip()
+    if configured:
+        return {host.strip().lower() for host in configured.split(",") if host.strip()}
+    return set(_DEFAULT_ALLOWED_REDIRECT_HOSTS)
+
+
+def _payload_requires_auth(payload: Any) -> bool:
+    messages = payload if isinstance(payload, list) else [payload]
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        if message.get("method") != "tools/call":
+            continue
+        raw_params = message.get("params")
+        params: dict[str, Any] = raw_params if isinstance(raw_params, dict) else {}
+        tool_name = params.get("name")
+        if isinstance(tool_name, str) and tool_name not in _PUBLIC_TOOLS:
+            return True
+    return False
+
+
+def _first_payload_id(payload: Any) -> Any:
+    if isinstance(payload, list):
+        for message in payload:
+            if isinstance(message, dict):
+                return message.get("id")
+        return None
+    if isinstance(payload, dict):
+        return payload.get("id")
+    return None
+
+
+def _www_authenticate_header(request: Request) -> str:
+    metadata_url = f"{_base_url(request)}/.well-known/oauth-protected-resource/MCP"
+    return f'Bearer resource_metadata="{metadata_url}", scope="{MCP_TOKEN_SCOPE}"'
+
+
 def _validate_oauth_authorize_request(
     *,
     response_type: str,
@@ -930,17 +1029,26 @@ def _validate_oauth_authorize_request(
     redirect_uri: str,
     code_challenge: str,
     code_challenge_method: str,
+    resource: str,
+    expected_resource: str,
 ) -> None:
     if response_type != "code":
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Only response_type=code is supported")
     if not client_id.strip():
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="client_id is required")
-    if not redirect_uri.startswith(("http://", "https://", "vscode://", "vscode-insiders://")):
+    parsed_redirect = urlparse(redirect_uri)
+    if parsed_redirect.scheme not in {"http", "https", "vscode", "vscode-insiders"}:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported redirect_uri")
+    if parsed_redirect.scheme in {"http", "https"}:
+        allowed_hosts = _allowed_oauth_redirect_hosts()
+        if parsed_redirect.hostname is None or parsed_redirect.hostname.lower() not in allowed_hosts:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unregistered redirect_uri host")
     if code_challenge_method != "S256":
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Only PKCE S256 is supported")
     if not code_challenge.strip():
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="code_challenge is required")
+    if resource != expected_resource:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="OAuth resource mismatch")
 
 
 def _pkce_s256_challenge(code_verifier: str) -> str:
@@ -1083,6 +1191,7 @@ def _oauth_login_form_html(
     code_challenge: str,
     code_challenge_method: str,
     state: str,
+    resource: str,
 ) -> str:
     hidden = _hidden_inputs(
         {
@@ -1092,6 +1201,7 @@ def _oauth_login_form_html(
             "code_challenge": code_challenge,
             "code_challenge_method": code_challenge_method,
             "state": state,
+            "resource": resource,
         }
     )
     return f"""<!doctype html>
@@ -1121,6 +1231,7 @@ def _oauth_otp_form_html(
     code_challenge: str,
     code_challenge_method: str,
     state: str,
+    resource: str,
 ) -> str:
     hidden = _hidden_inputs(
         {
@@ -1131,6 +1242,7 @@ def _oauth_otp_form_html(
             "code_challenge": code_challenge,
             "code_challenge_method": code_challenge_method,
             "state": state,
+            "resource": resource,
         }
     )
     escaped_email = escape(email, quote=False)

--- a/api/aijuristiction-api/app/mcp_tokens.py
+++ b/api/aijuristiction-api/app/mcp_tokens.py
@@ -11,13 +11,22 @@ from uuid import uuid4
 
 from aijurisdictionagents.api_db import User
 
+MCP_TOKEN_SCOPE = "mcp:laws"
 
-def create_mcp_api_token(*, user: User, expires_at: datetime) -> str:
+
+def create_mcp_api_token(
+    *,
+    user: User,
+    expires_at: datetime,
+    audience: str | None = None,
+    scope: str = MCP_TOKEN_SCOPE,
+) -> str:
     token_id = str(uuid4())
     header = {"alg": "HS256", "typ": "JWT"}
     payload = {
         "sub": user.user_id,
-        "email": user.email,
+        "aud": audience or default_mcp_resource_url(),
+        "scope": scope,
         "exp": int(expires_at.timestamp()),
         "jti": token_id,
     }
@@ -28,7 +37,7 @@ def create_mcp_api_token(*, user: User, expires_at: datetime) -> str:
     return f"{signing_input}.{signature}"
 
 
-def validate_mcp_api_token(token: str) -> dict[str, Any] | None:
+def validate_mcp_api_token(token: str, *, audience: str, required_scope: str) -> dict[str, Any] | None:
     parts = token.split(".")
     if len(parts) != 3:
         return None
@@ -47,11 +56,21 @@ def validate_mcp_api_token(token: str) -> dict[str, Any] | None:
     exp = payload.get("exp")
     if not isinstance(exp, int) or exp <= int(datetime.now(timezone.utc).timestamp()):
         return None
-    if not isinstance(payload.get("sub"), str) or not isinstance(payload.get("email"), str):
+    if not isinstance(payload.get("sub"), str):
+        return None
+    if payload.get("aud") != audience:
+        return None
+    scope = payload.get("scope")
+    if not isinstance(scope, str) or required_scope not in scope.split():
         return None
     if not isinstance(payload.get("jti"), str):
         return None
     return payload
+
+
+def default_mcp_resource_url() -> str:
+    base_url = os.getenv("MCP_PUBLIC_BASE_URL", "https://mcp.jurisdigta.eu").strip().rstrip("/")
+    return f"{base_url}/MCP"
 
 
 def _base64url_json(payload: dict[str, Any]) -> str:

--- a/api/aijuristiction-api/app/telemetry.py
+++ b/api/aijuristiction-api/app/telemetry.py
@@ -88,6 +88,6 @@ def configure_telemetry(service_name: str, service_version: str) -> TelemetryMod
 
 
 def instrument_fastapi(app: FastAPI) -> None:
-    if _TELEMETRY_MODE == "azure-monitor":
+    if _TELEMETRY_MODE in {"azure-monitor", "console"}:
         return
     FastAPIInstrumentor.instrument_app(app)

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "python-dotenv>=1.0",
   "python-multipart>=0.0.9",
   "reportlab>=4.0",
+  "starlette<1.0",
   "truststore>=0.10.0",
   "uvicorn[standard]>=0.35.0",
 ]

--- a/api/aijuristiction-api/tests/test_mcp_api.py
+++ b/api/aijuristiction-api/tests/test_mcp_api.py
@@ -37,7 +37,8 @@ def test_mcp_public_tools_and_authenticated_law_search(monkeypatch, tmp_path: Pa
     assert statistics["last_processed_day"] == "2026-06-01T12:00:00Z"
 
     unauthenticated_search = _mcp_call("searchLaws", {"query": "civil"})
-    assert unauthenticated_search.status_code == 200
+    assert unauthenticated_search.status_code == 401
+    assert "WWW-Authenticate" in unauthenticated_search.headers
     assert unauthenticated_search.json()["error"]["code"] == 401
 
     authenticated_search = _mcp_call(
@@ -118,7 +119,9 @@ def test_user_mcp_api_key_defaults_to_one_day(monkeypatch, tmp_path: Path) -> No
     token = create_key_response.json()["mcp_api_key"]
     claims = _jwt_claims(token)
     assert claims["sub"] == sign_up_response.json()["user_id"]
-    assert claims["email"] == "mcp-default@example.com"
+    assert claims["aud"] == "https://mcp.jurisdigta.eu/MCP"
+    assert claims["scope"] == "mcp:laws"
+    assert "email" not in claims
     assert "first_name" not in claims
     assert "last_name" not in claims
     expires_at = datetime.fromisoformat(create_key_response.json()["mcp_api_key_expires_at"])
@@ -233,6 +236,7 @@ def test_mcp_sign_up_requires_email_otp_and_profile_fields(monkeypatch, tmp_path
 
 def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path) -> None:
     _configure_env(monkeypatch, tmp_path)
+    _create_laws_db(tmp_path / "laws.sqlite3")
     monkeypatch.setenv("LOCAL_AUTH_ACCEPT_ANY_CODE", "true")
     sign_up_response = api_client.post(
         "/v1/users/sign-up",
@@ -248,13 +252,16 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
     protected_metadata = mcp_client.get("/.well-known/oauth-protected-resource/MCP")
     assert protected_metadata.status_code == 200
     assert protected_metadata.json()["resource"].endswith("/MCP")
+    assert protected_metadata.json()["scopes_supported"] == ["mcp:laws"]
 
     authorization_metadata = mcp_client.get("/.well-known/oauth-authorization-server")
     assert authorization_metadata.status_code == 200
     assert authorization_metadata.json()["code_challenge_methods_supported"] == ["S256"]
+    assert authorization_metadata.json()["scopes_supported"] == ["mcp:laws"]
 
     code_verifier = "test-code-verifier-1234567890"
     code_challenge = _pkce_challenge(code_verifier)
+    resource = "https://mcp.jurisdigta.eu/MCP"
     authorize_page = mcp_client.get(
         "/oauth/authorize",
         params={
@@ -264,6 +271,7 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
             "state": "abc",
+            "resource": resource,
         },
     )
     assert authorize_page.status_code == 200
@@ -278,6 +286,7 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
             "state": "abc",
+            "resource": resource,
             "email": "mcp-oauth@example.com",
             "password": "secret-pass",
         },
@@ -294,6 +303,7 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
             "state": "abc",
+            "resource": resource,
             "email": "mcp-oauth@example.com",
             "verification_code": "123456",
         },
@@ -312,13 +322,25 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
             "redirect_uri": "https://client.example/callback",
             "client_id": "chatgpt",
             "code_verifier": code_verifier,
+            "resource": resource,
         },
     )
     assert token_response.status_code == 200
     token_payload = token_response.json()
     assert token_payload["token_type"] == "Bearer"
     claims = _jwt_claims(token_payload["access_token"])
-    assert claims["email"] == "mcp-oauth@example.com"
+    assert claims["sub"] == sign_up_response.json()["user_id"]
+    assert claims["aud"] == resource
+    assert claims["scope"] == "mcp:laws"
+    assert "email" not in claims
+
+    oauth_search = _mcp_call(
+        "searchLaws",
+        {"query": "civil"},
+        headers={"authorization": f"Bearer {token_payload['access_token']}"},
+    )
+    assert oauth_search.status_code == 200
+    assert _tool_payload(oauth_search)["results"][0]["document_id"] == "doc-1"
 
 
 def test_oauth_discovery_uses_public_base_url(monkeypatch, tmp_path: Path) -> None:
@@ -353,6 +375,8 @@ def _configure_env(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("LAWS_DB_BACKEND", "sqlite")
     monkeypatch.setenv("LAWS_DB_LOCAL", str(tmp_path / "laws.sqlite3"))
     monkeypatch.setenv("MCP_API_JWT_SECRET", "test-mcp-secret")
+    monkeypatch.setenv("MCP_PUBLIC_BASE_URL", "https://mcp.jurisdigta.eu")
+    monkeypatch.setenv("MCP_OAUTH_ALLOWED_REDIRECT_HOSTS", "client.example,chatgpt.com")
 
 
 def _create_mcp_key(tmp_path: Path) -> str:

--- a/api/aijuristiction-api/tests/test_telemetry.py
+++ b/api/aijuristiction-api/tests/test_telemetry.py
@@ -120,8 +120,17 @@ def test_instrument_fastapi_skips_manual_instrumentation_for_azure_monitor(monke
     assert "instrumented" not in calls
 
 
-def test_instrument_fastapi_uses_manual_instrumentation_for_non_azure_monitor(monkeypatch) -> None:
+def test_instrument_fastapi_skips_manual_instrumentation_for_console(monkeypatch) -> None:
     calls = _patch_common(monkeypatch, otlp_endpoint=None)
+
+    telemetry.configure_telemetry("svc", "0.1.0")
+    telemetry.instrument_fastapi(FastAPI())
+
+    assert "instrumented" not in calls
+
+
+def test_instrument_fastapi_uses_manual_instrumentation_for_otlp(monkeypatch) -> None:
+    calls = _patch_common(monkeypatch, otlp_endpoint="http://localhost:4318/v1/traces")
 
     app = FastAPI()
     telemetry.configure_telemetry("svc", "0.1.0")

--- a/databases/api/migrations/0005_mcp_oauth_resource.sql
+++ b/databases/api/migrations/0005_mcp_oauth_resource.sql
@@ -1,0 +1,2 @@
+ALTER TABLE mcp_oauth_authorization_codes
+ADD COLUMN IF NOT EXISTS resource TEXT NOT NULL DEFAULT '';

--- a/docs/AZURE_POSTGRES_MIGRATION.md
+++ b/docs/AZURE_POSTGRES_MIGRATION.md
@@ -147,8 +147,8 @@ For a locked-down production network, replace broad public access with approved 
 $MyIp = (Invoke-RestMethod -Uri "https://api.ipify.org").Trim()
 az postgres flexible-server firewall-rule create `
   --resource-group $ResourceGroupName `
-  --name $PostgresServerName `
-  --rule-name "temporary-operator-restore" `
+  --server-name $PostgresServerName `
+  --name "temporary-operator-restore" `
   --start-ip-address $MyIp `
   --end-ip-address $MyIp
 ```
@@ -367,8 +367,8 @@ Remove temporary operator firewall access after restore:
 ```powershell
 az postgres flexible-server firewall-rule delete `
   --resource-group $ResourceGroupName `
-  --name $PostgresServerName `
-  --rule-name "temporary-operator-restore" `
+  --server-name $PostgresServerName `
+  --name "temporary-operator-restore" `
   --yes
 ```
 

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -144,6 +144,8 @@ These are used by infrastructure deployment and API deployment workflows:
 | `AZURE_POSTGRES_STORAGE_SIZE_GB` | Optional PostgreSQL storage size |
 | `CORS_ALLOW_ORIGINS` | Optional browser origins allowed to call the API |
 | `MCP_CORS_ALLOW_ORIGINS` | Optional browser origins allowed to call the dedicated MCP service; default production value should include `https://mcp.jurisdigta.eu` |
+| `MCP_PUBLIC_BASE_URL` | Public MCP origin used in OAuth metadata and JWT audience validation; production value `https://mcp.jurisdigta.eu` |
+| `MCP_OAUTH_ALLOWED_REDIRECT_HOSTS` | Comma-separated OAuth authorization callback hosts; production value `chatgpt.com,chat.openai.com` |
 | `MCP_PORT` | Local/self-managed MCP service port when using Docker Compose, default `8070` |
 | `CONTACT_CAPTCHA_REQUIRED` | Set `true` in public environments to require Cloudflare Turnstile verification for `POST /v1/contact` |
 | `CONTACT_RATE_LIMIT_MAX_REQUESTS` | Optional backend per-IP contact form throttle, default `5` |
@@ -374,6 +376,8 @@ Server-local `jurisdigta.env` must include at least:
 - `LOCAL_POSTGRES_PASSWORD`
 - `AZURE_LAWS_POSTGRES_DATABASE_NAME_SK=laws_sk`
 - `MCP_API_JWT_SECRET`
+- `MCP_PUBLIC_BASE_URL=https://mcp.jurisdigta.eu`
+- `MCP_OAUTH_ALLOWED_REDIRECT_HOSTS=chatgpt.com,chat.openai.com`
 - email/Turnstile settings when those production features are enabled
 
 Minimal workflow validation after setup:
@@ -427,6 +431,8 @@ At minimum, you should expect these values to differ between `test` and `prod`:
 - `API_BASE_URL`
 - `CORS_ALLOW_ORIGINS`
 - `MCP_CORS_ALLOW_ORIGINS=https://mcp.jurisdigta.eu`
+- `MCP_PUBLIC_BASE_URL=https://mcp.jurisdigta.eu`
+- `MCP_OAUTH_ALLOWED_REDIRECT_HOSTS=chatgpt.com,chat.openai.com`
 - `MCP_PORT=8070` for self-managed Docker Compose deployments
 - `CONTACT_CAPTCHA_REQUIRED=true`
 - `CONTACT_RATE_LIMIT_MAX_REQUESTS=5`

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -45,16 +45,23 @@ curl http://127.0.0.1:8070/
 - Authorization endpoint: `GET /oauth/authorize`
 - Token endpoint: `POST /oauth/token`
 
-The OAuth flow uses authorization code with PKCE S256. The browser authorization page validates the user password, sends an email OTP, and only creates a short-lived authorization code after OTP verification. The token endpoint exchanges that code for the same revocable JWT bearer token accepted by `POST /MCP`.
+The OAuth flow uses authorization code with PKCE S256. ChatGPT should pass the protected resource value `https://mcp.jurisdigta.eu/MCP` on the authorization and token requests. The browser authorization page validates the user password, sends an email OTP, and only creates a short-lived authorization code after OTP verification. The token endpoint exchanges that code for the same revocable JWT bearer token accepted by `POST /MCP`.
+
+Production settings:
+
+- `MCP_PUBLIC_BASE_URL=https://mcp.jurisdigta.eu`
+- `MCP_OAUTH_ALLOWED_REDIRECT_HOSTS=chatgpt.com,chat.openai.com`
+- `MCP_API_JWT_SECRET=<long-random-secret>`
 
 ## Authentication
 
 - MCP API keys are per user.
 - Default key lifetime is 1 day.
 - Keys are signed JWT bearer tokens and are only shown once at creation.
-- JWT claims are minimized to `sub`, `email`, `exp`, and `jti`.
+- JWT claims are minimized to `sub`, `aud`, `scope`, `exp`, and `jti`.
 - The full token is still stored hashed in the database so it can be revoked.
 - Protected MCP tools accept either `Authorization: Bearer <mcp_api_key>` or `x-mcp-api-key: <mcp_api_key>`.
+- OAuth tokens are audience-bound to the MCP resource URL and include `scope=mcp:laws`.
 
 Users can generate a key in either way:
 
@@ -66,13 +73,13 @@ Keys can be revoked with:
 
 - `DELETE /v1/users/{user_id}/mcp-api-key`
 
-Manual JWT generation remains useful for local VS Code setups that pass an `Authorization` header directly. Standards-based remote clients should prefer OAuth discovery.
+Manual JWT generation remains useful for local VS Code setups that pass an `Authorization` header directly. Standards-based remote clients should prefer OAuth discovery. Existing tokens issued before the audience/scope claim update must be regenerated.
 
 ## Assistant Setup
 
 Use `https://mcp.jurisdigta.eu/MCP` as the remote MCP server URL in clients that support custom HTTP MCP servers.
 
-- ChatGPT custom connectors: create a remote MCP connector and enter the MCP server URL. Prefer OAuth discovery when the connector supports it.
+- ChatGPT custom connectors: create a remote MCP connector and enter the MCP server URL. Prefer OAuth discovery when the connector supports it. Users may self-register during the browser authorization flow, but ChatGPT only receives the OAuth access token and tool results, not a raw API key.
 - Claude: add a custom connector or remote MCP server and enter the MCP server URL. OAuth-capable Claude clients can discover authorization metadata from `https://mcp.jurisdigta.eu`.
 - VS Code: add an HTTP MCP server in MCP settings. If OAuth is unavailable in the client, include `Authorization: Bearer <mcp_api_key>` after generating a key from `/MCP/login`.
 - Perplexity and other clients: use the MCP server URL where custom remote MCP servers are supported. If a product only exposes its own MCP server and does not support registering external MCP servers, use another MCP-compatible host.
@@ -120,7 +127,7 @@ These tools require an MCP API key:
 }
 ```
 
-For protected tools, send the MCP API key as a Bearer token or `x-mcp-api-key` header.
+For protected tools, send the MCP API key as a Bearer token or `x-mcp-api-key` header. Protected unauthenticated tool calls return `401` with a `WWW-Authenticate` header pointing clients at the protected-resource metadata endpoint.
 
 ## Logging And Debugging
 
@@ -135,4 +142,4 @@ Debugging fields are intentionally minimized:
 
 For production troubleshooting, filter application logs by `mcp_` event names and correlate them with the `x-request-id` or `x-correlation-id` response headers.
 
-Security/GDPR/EU AI Act notes: the current MCP surface exposes public-law data and per-user access credentials. JWT tokens are signed, hashed in storage, expire by default after 1 day, and can be revoked. Public tools avoid user-specific data. Protected legal-data tools remain read-only and are logged with request correlation IDs by the MCP middleware for traceability. Pending MCP sign-up data is stored server-side with a short expiry and is not echoed into hidden browser fields. Set `MCP_API_JWT_SECRET` to a long random value in deployed environments, protect `mcp.jurisdigta.eu` separately from the public API, and keep assistant/tool audit logs privacy-safe.
+Security/GDPR/EU AI Act notes: the current MCP surface exposes public-law data and per-user access credentials. JWT tokens are signed, audience-bound, hashed in storage, expire by default after 1 day, and can be revoked. Public tools avoid user-specific data. Protected legal-data tools remain read-only and are logged with request correlation IDs by the MCP middleware for traceability. Pending MCP sign-up data is stored server-side with a short expiry and is not echoed into hidden browser fields. OAuth and MCP tool responses do not return raw API keys to ChatGPT. Set `MCP_API_JWT_SECRET` to a long random value in deployed environments, set `MCP_PUBLIC_BASE_URL=https://mcp.jurisdigta.eu`, keep OAuth redirect hosts restricted, protect `mcp.jurisdigta.eu` separately from the public API, and keep assistant/tool audit logs privacy-safe.

--- a/docs/manual_infrastucture_setup.md
+++ b/docs/manual_infrastucture_setup.md
@@ -61,6 +61,8 @@ Purpose: migrate the existing local PostgreSQL laws collector database into Azur
 - `AZURE_STORAGE_ACCOUNT_NAME`
 - `AZURE_LAWS_STORAGE_CONTAINER_NAME`
 - `MCP_API_JWT_SECRET` as a long random per-environment secret for remote MCP OAuth/JWT token signing
+- `MCP_PUBLIC_BASE_URL=https://mcp.jurisdigta.eu` for OAuth metadata and JWT audience validation
+- `MCP_OAUTH_ALLOWED_REDIRECT_HOSTS=chatgpt.com,chat.openai.com` for ChatGPT authorization callbacks
 
 ### Validation Steps
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ local-model-builder = "services.local_model_builder.__main__:main"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"
-pythonpath = ["src"]
+pythonpath = [".", "src"]
 
 [tool.ruff]
 line-length = 100

--- a/src/aijurisdictionagents/api_db/store.py
+++ b/src/aijurisdictionagents/api_db/store.py
@@ -243,6 +243,7 @@ class ApiDatabaseStore:
                     client_id TEXT NOT NULL,
                     redirect_uri TEXT NOT NULL,
                     code_challenge TEXT NOT NULL,
+                    resource TEXT NOT NULL DEFAULT '',
                     expires_at TEXT NOT NULL,
                     created_at TEXT NOT NULL,
                     FOREIGN KEY(user_id) REFERENCES users(user_id) ON DELETE CASCADE
@@ -366,6 +367,7 @@ class ApiDatabaseStore:
                 """,
             )
             self._ensure_user_schema(conn)
+            self._ensure_mcp_oauth_schema(conn)
             self._ensure_case_document_schema(conn)
             self._ensure_subscription_schema(conn)
             self._ensure_permanent_memory_schema(conn)
@@ -656,6 +658,7 @@ class ApiDatabaseStore:
         client_id: str,
         redirect_uri: str,
         code_challenge: str,
+        resource: str,
         expires_in_minutes: int = 10,
     ) -> None:
         now = datetime.now(timezone.utc)
@@ -664,9 +667,9 @@ class ApiDatabaseStore:
                 conn,
                 """
                 INSERT INTO mcp_oauth_authorization_codes(
-                    code, user_id, client_id, redirect_uri, code_challenge, expires_at, created_at
+                    code, user_id, client_id, redirect_uri, code_challenge, resource, expires_at, created_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     code.strip(),
@@ -674,6 +677,7 @@ class ApiDatabaseStore:
                     client_id.strip(),
                     redirect_uri.strip(),
                     code_challenge.strip(),
+                    resource.strip(),
                     (now + timedelta(minutes=max(expires_in_minutes, 1))).isoformat(),
                     now.isoformat(),
                 ),
@@ -688,7 +692,7 @@ class ApiDatabaseStore:
             row = self._fetchone(
                 conn,
                 """
-                SELECT user_id, client_id, redirect_uri, code_challenge, expires_at
+                SELECT user_id, client_id, redirect_uri, code_challenge, resource, expires_at
                 FROM mcp_oauth_authorization_codes
                 WHERE code = ?
                 """,
@@ -698,13 +702,14 @@ class ApiDatabaseStore:
                 return None
             self._execute(conn, "DELETE FROM mcp_oauth_authorization_codes WHERE code = ?", (normalized_code,))
             conn.commit()
-        if not _is_future_iso_datetime(str(row[4])):
+        if not _is_future_iso_datetime(str(row[5])):
             return None
         return {
             "user_id": str(row[0]),
             "client_id": str(row[1]),
             "redirect_uri": str(row[2]),
             "code_challenge": str(row[3]),
+            "resource": str(row[4]),
         }
 
     def issue_device_auth_token(
@@ -1871,6 +1876,35 @@ class ApiDatabaseStore:
             WHERE full_name IS NULL OR TRIM(full_name) = ''
             """,
         )
+
+    def _ensure_mcp_oauth_schema(
+        self, conn: sqlite3.Connection | PostgresConnection[Any]
+    ) -> None:
+        if self.uses_postgres:
+            columns = {
+                row[0]
+                for row in self._execute(
+                    conn,
+                    """
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_name = 'mcp_oauth_authorization_codes'
+                    """,
+                ).fetchall()
+            }
+        else:
+            columns = {
+                row[1]
+                for row in self._execute(
+                    conn,
+                    "PRAGMA table_info(mcp_oauth_authorization_codes)",
+                ).fetchall()
+            }
+        if "resource" not in columns:
+            self._execute(
+                conn,
+                "ALTER TABLE mcp_oauth_authorization_codes ADD COLUMN resource TEXT NOT NULL DEFAULT ''",
+            )
 
     def _ensure_case_document_schema(
         self, conn: sqlite3.Connection | PostgresConnection[Any]


### PR DESCRIPTION
## Summary
- bind MCP OAuth authorization codes and bearer tokens to the `/MCP` resource audience
- remove email from newly issued MCP JWT claims and require `mcp:laws` scope
- return `401` plus `WWW-Authenticate` metadata challenge for unauthenticated protected MCP tool calls
- restrict OAuth redirect hosts by configuration and document production MCP settings
- add PostgreSQL migration for stored OAuth resource values

## Validation
- `./scripts/validate_api.ps1`
- `./conda/python.exe -m pytest api/aijuristiction-api/tests`