### PR TITLE
Improve mobile voice dictation resilience

### DIFF
--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -18,8 +18,9 @@ The current mobile build is kept compatible with Flutter analyzer changes in the
 - Confirmation parsing also accepts common corrupted STT/encoding forms such as `�no` and `Ã¡no`, so a spoken Slovak yes clears the pending prompt instead of leaving the app waiting and asking again later.
 - While waiting for that confirmation, the prompt is not repeated automatically; the app waits for `yes`/`áno` or `no`/`nie` so assistant TTS cannot loop on its own echo.
 - Tapping the microphone while listening or waiting for confirmation is treated as an explicit user stop: speech input is disabled and will not auto-restart until the user enables it again.
-- On Android, when the speech recognizer auto-stops unexpectedly while speech input remains enabled, the app now shows a short polite status message and re-starts listening automatically.
+- On Android, when the speech recognizer auto-stops unexpectedly while speech input remains enabled, the app now shows a short polite status message and re-starts listening automatically without discarding the current draft.
 - Enabling the microphone now opens/expands the input box immediately (same visual behavior as tapping the input), keeps partial dictated transcript, and appends recognized speech to existing typed text.
+- In the default message flow, Android STT restarts append the next recognized segment to the visible draft. A standalone spoken `Posli`/`Pošli` sends the previous draft instead of replacing it with the command word.
 - While microphone mode is enabled, the expanded input stays open until the user disables microphone, sends the message, or taps outside the input area.
 - During assistant speech, STT fragments are not used for automatic barge-in. The assistant finishes unless the user explicitly taps the microphone button.
 - Voice session handling now runs through `VoiceSessionOrchestrator`, which tracks listening, processing, and confirmation states, applies idempotency keys to STT transcripts, and dispatches `RuleEngineAction` values through an action queue.
@@ -218,7 +219,7 @@ Android note:
 
 ### Speech input
 
-Use the `Speech input` button in the top control area to enable audio. In the default `AIJ_SPEECHTYPE=message` flow, Jurisdicta says the welcome/instruction text, then waits for the composer microphone. The microphone fills the input draft and remains active until the user taps send, taps the microphone again, or says `Send`, `send message`, `I am done`, `this is end`, `Posli`, `to je vsetko`, or `cakam na odpoved`. The transcript stays visible for review before ordinary messages are sent. In `AIJ_SPEECHTYPE=conversation`, the older continuous flow is preserved: if no more speech is detected for 5 seconds after a dictated draft, Jurisdicta asks whether it may answer and waits for `ano/yes` or `nie/no`; answering `ano/yes` runs the pending action immediately, while `nie/no` preserves the current draft and keeps listening for more speech. Say `clean message`, `clean last message`, or `zrus vsetko` to clear it. In Azure mode, the app records microphone audio and sends it to Azure Speech STT only when the signed-in user has data-processing consent.
+Use the `Speech input` button in the top control area to enable audio. In the default `AIJ_SPEECHTYPE=message` flow, Jurisdicta says the welcome/instruction text, then waits for the composer microphone. The microphone fills the input draft and remains active until the user taps send, taps the microphone again, or says `Send`, `send message`, `I am done`, `this is end`, `Posli`, `Pošli`, `to je vsetko`, or `cakam na odpoved`. The transcript stays visible for review before ordinary messages are sent. If Android briefly stops local STT while the microphone is still enabled, the app restarts listening and appends the next recognized segment to the same draft. A standalone send command sends the existing draft; trailing send words are stripped from the message text. In `AIJ_SPEECHTYPE=conversation`, the older continuous flow is preserved: if no more speech is detected for 5 seconds after a dictated draft, Jurisdicta asks whether it may answer and waits for `ano/yes` or `nie/no`; answering `ano/yes` runs the pending action immediately, while `nie/no` preserves the current draft and keeps listening for more speech. Say `clean message`, `clean last message`, or `zrus vsetko` to clear it. In Azure mode, the app records microphone audio and sends it to Azure Speech STT only when the signed-in user has data-processing consent.
 
 Some Android devices do not expose usable local STT, or their platform recognizer may depend on Google/cloud services outside the app's direct control. The app treats local/device STT as the privacy-first default where available, shows a typed-input fallback when unavailable, and keeps Azure/server STT behind explicit consent instead of silently uploading raw audio.
 
@@ -244,6 +245,14 @@ Voice compliance regression checks:
 ```bash
 cd mobile_app
 flutter test test/speech_service_test.dart test/intent_mapper_test.dart
+```
+
+Deterministic message-mode STT draft/send check:
+
+```bash
+cd mobile_app
+dart run examples/voice_message_dictation_demo.dart
+flutter test test/speech_flow_test.dart test/voice_session_orchestrator_test.dart
 ```
 
 Recurring deterministic voice loopback check:

--- a/mobile_app/examples/voice_message_dictation_demo.dart
+++ b/mobile_app/examples/voice_message_dictation_demo.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+
+import 'package:ai_jurisdiction_mobile/chat/rule_engine.dart';
+import 'package:ai_jurisdiction_mobile/chat/speech_flow.dart';
+
+void main() {
+  var draft = mergeRecognizedSpeechDraft(
+    existingDraft: '',
+    recognizedText: 'Potrebujem poradit so zmluvou',
+  );
+  draft = mergeRecognizedSpeechDraft(
+    existingDraft: draft,
+    recognizedText: 'a este s vypovednou lehotou',
+    previousRecognizedSegment: draft,
+  );
+
+  final finalTranscript = '$draft posli';
+  final message = stripTrailingSpokenSendCommand(finalTranscript) ?? draft;
+
+  stdout.writeln('Draft: $draft');
+  stdout.writeln(
+    'Spoken send recognized: ${hasTrailingSpokenSendCommand(finalTranscript)}',
+  );
+  stdout.writeln('Message to send: $message');
+}

--- a/mobile_app/lib/chat/speech_flow.dart
+++ b/mobile_app/lib/chat/speech_flow.dart
@@ -124,3 +124,43 @@ String speechMessageModeReadyMessage(String languageCode, {String? firstName}) {
   final namePart = resolvedFirstName.isEmpty ? '' : ', $resolvedFirstName';
   return template.replaceAll('{{name_part}}', namePart);
 }
+
+String mergeRecognizedSpeechDraft({
+  required String existingDraft,
+  required String recognizedText,
+  String? previousRecognizedSegment,
+}) {
+  final existing = existingDraft.trim();
+  final recognized = recognizedText.trim();
+  if (recognized.isEmpty) {
+    return existing;
+  }
+  if (existing.isEmpty) {
+    return recognized;
+  }
+
+  final normalizedExisting = _normalizeDraftForMerge(existing);
+  final normalizedRecognized = _normalizeDraftForMerge(recognized);
+  if (normalizedExisting == normalizedRecognized ||
+      normalizedExisting.endsWith(normalizedRecognized)) {
+    return existing;
+  }
+  if (normalizedRecognized.startsWith(normalizedExisting)) {
+    return recognized;
+  }
+
+  final previous = (previousRecognizedSegment ?? '').trim();
+  final normalizedPrevious = _normalizeDraftForMerge(previous);
+  if (normalizedPrevious.isNotEmpty &&
+      normalizedExisting.endsWith(normalizedPrevious) &&
+      normalizedRecognized.startsWith(normalizedPrevious)) {
+    final prefix = existing.substring(0, existing.length - previous.length);
+    return '$prefix$recognized'.trim();
+  }
+
+  return '$existing $recognized'.trim();
+}
+
+String _normalizeDraftForMerge(String value) {
+  return value.trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
+}

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -6549,21 +6549,38 @@ class _ChatHomePageState extends State<ChatHomePage>
       return;
     }
     _speechDraftStartedAt ??= DateTime.now();
+    final existingDraft = _inputController.text.trim();
+    final exactSendCommand = isSpokenSendCommand(recognizedText);
+    final clearDraftCommand = isSpokenClearDraftCommand(recognizedText);
+    final trailingSendCommand = hasTrailingSpokenSendCommand(recognizedText);
+    final recognizedMessage =
+        stripTrailingSpokenSendCommand(recognizedText) ?? recognizedText;
     if (_shouldStopAssistantSpeechForTranscript(recognizedText)) {
       _stopAssistantSpeechForUserSpeech('recognized_speech');
     }
-    _lastDictatedSpeechDraft = recognizedText;
-    if (result.finalResult) {
-      _lastFinalSpeechResult = recognizedText;
+    if (!exactSendCommand && !clearDraftCommand) {
+      _lastDictatedSpeechDraft = mergeRecognizedSpeechDraft(
+        existingDraft: existingDraft,
+        recognizedText: recognizedMessage,
+        previousRecognizedSegment: _lastDictatedSpeechDraft,
+      );
+    }
+    if (result.finalResult && !exactSendCommand && !clearDraftCommand) {
+      _lastFinalSpeechResult = recognizedMessage;
     }
     setState(() {
-      _inputController.text = recognizedText;
+      if (!exactSendCommand && !clearDraftCommand) {
+        _inputController.text = _lastDictatedSpeechDraft ?? recognizedMessage;
+      }
       _inputController.selection = TextSelection.fromPosition(
         TextPosition(offset: _inputController.text.length),
       );
     });
     if (result.finalResult &&
-        _shouldProcessFinalSpeechResultImmediately(recognizedText)) {
+        (exactSendCommand ||
+            clearDraftCommand ||
+            trailingSendCommand ||
+            _shouldProcessFinalSpeechResultImmediately(recognizedText))) {
       final action = _ruleEngine.evaluate(
         input: recognizedText,
         context: _buildRuleEngineContext(
@@ -6702,7 +6719,14 @@ class _ChatHomePageState extends State<ChatHomePage>
     });
     _voiceSessionOrchestrator.stopListening();
     if (error.isNoSpeechDetected) {
-      _showSnackbar(_strings.t('speech_no_input_detected'));
+      if (_usesMessageSpeechType &&
+          !_stoppingSpeechManually &&
+          _speechInputEnabled) {
+        _showSnackbar(_strings.t('speech_input_auto_stopped'));
+        unawaited(_resumeSpeechListeningAfterAutoStop());
+      } else {
+        _showSnackbar(_strings.t('speech_no_input_detected'));
+      }
       unawaited(
         widget.logger.info(
           'Speech recognition ended without detected speech',

--- a/mobile_app/lib/speech_service.dart
+++ b/mobile_app/lib/speech_service.dart
@@ -260,7 +260,7 @@ abstract class JurisdictaSpeechRecognizer {
     Duration? listenFor,
     Duration? pauseFor,
     bool partialResults = true,
-    bool cancelOnError = true,
+    bool cancelOnError = false,
     ListenMode listenMode = ListenMode.dictation,
   });
 
@@ -400,7 +400,7 @@ class PlatformSpeechRecognizer implements JurisdictaSpeechRecognizer {
     Duration? listenFor,
     Duration? pauseFor,
     bool partialResults = true,
-    bool cancelOnError = true,
+    bool cancelOnError = false,
     ListenMode listenMode = ListenMode.dictation,
   }) {
     return _speechToText.listen(
@@ -521,7 +521,7 @@ class AzureSpeechRecognizer implements JurisdictaSpeechRecognizer {
     Duration? listenFor,
     Duration? pauseFor,
     bool partialResults = true,
-    bool cancelOnError = true,
+    bool cancelOnError = false,
     ListenMode listenMode = ListenMode.dictation,
   }) async {
     _onResult = onResult;

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ai_jurisdiction_mobile
-version: 0.1.5+99
+version: 0.1.5+100
 publish_to: none
 
 environment:

--- a/mobile_app/test/speech_flow_test.dart
+++ b/mobile_app/test/speech_flow_test.dart
@@ -84,6 +84,40 @@ void main() {
     });
   });
 
+  group('mergeRecognizedSpeechDraft', () {
+    test('extends the same partial segment without duplicating words', () {
+      expect(
+        mergeRecognizedSpeechDraft(
+          existingDraft: 'Potrebujem poradit',
+          recognizedText: 'Potrebujem poradit so zmluvou',
+          previousRecognizedSegment: 'Potrebujem poradit',
+        ),
+        'Potrebujem poradit so zmluvou',
+      );
+    });
+
+    test('appends a new Android recognizer segment after an auto restart', () {
+      expect(
+        mergeRecognizedSpeechDraft(
+          existingDraft: 'Potrebujem poradit so zmluvou',
+          recognizedText: 'a este s vypovednou lehotou',
+          previousRecognizedSegment: 'Potrebujem poradit so zmluvou',
+        ),
+        'Potrebujem poradit so zmluvou a este s vypovednou lehotou',
+      );
+    });
+
+    test('keeps typed text and appends dictated speech', () {
+      expect(
+        mergeRecognizedSpeechDraft(
+          existingDraft: 'Dobry den,',
+          recognizedText: 'potrebujem poradit',
+        ),
+        'Dobry den, potrebujem poradit',
+      );
+    });
+  });
+
   group('parseSpokenCaseCreationCommand', () {
     test('matches a polite English command without a spoken title', () {
       final parsed = parseSpokenCaseCreationCommand('Please create a new case');


### PR DESCRIPTION
## Summary
- Keep message-mode STT drafts intact across Android recognizer auto-stops and restarts.
- Treat standalone spoken send commands like `Posli`/`Pošli` as commands that submit the existing draft instead of replacing it.
- Add deterministic voice draft/send tests and a runnable Dart demo.
- Bump the mobile build revision from `0.1.5+99` to `0.1.5+100`.

## Compliance
- Keeps local/device STT as the default and does not introduce new raw-audio storage or upload paths.
- Preserves explicit consent requirements for Azure/server STT.
- Supports transparency through README updates and traceable voice logging already present in the app.

## Validation
- `dart run examples\voice_message_dictation_demo.dart`
- `flutter analyze`
- `flutter test`
- `flutter test test\speech_flow_test.dart test\voice_session_orchestrator_test.dart test\speech_service_test.dart test\voice_loopback_simulator_test.dart`
- `flutter run -d emulator-5554 --debug --no-resident --dart-define=AIJ_SPEECHTYPE=message`

Android note: the app built, installed, and started successfully on Android emulator `emulator-5554` / Android 16 API 36. Real Redmi/Xiaomi microphone behavior still needs hardware validation on the physical device.