### PR TITLE
Run self-managed prod deploy on dedicated runner

### DIFF
--- a/.github/workflows/self_managed_prod_deploy.yml
+++ b/.github/workflows/self_managed_prod_deploy.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, jurisdigta-prod]
     environment: prod
     permissions:
       contents: read

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -324,6 +324,8 @@ the selected GitHub Environment contains stale or mismatched signing secrets.
 
 These are used by `.github/workflows/self_managed_prod_deploy.yml` to deploy API, MCP, frontend web, the document processor, laws collector, and system status monitoring to the Ubuntu `jurisdigta-server`.
 
+The workflow must run on a repository self-hosted runner with labels `self-hosted`, `Linux`, `X64`, and `jurisdigta-prod`. Keep this runner on the trusted server or trusted private network that can reach `jurisdigta-server` over SSH. Do not run the production deployment from a GitHub-hosted runner when `JURISDIGTA_SSH_HOST` is a private LAN address such as `192.168.1.50`.
+
 The workflow does not store application runtime secrets in GitHub. Keep Azure OpenAI, PostgreSQL, SMTP, MCP JWT, and API secrets in the server-local file:
 
 ```text
@@ -338,7 +340,7 @@ Required `prod` GitHub Environment variable:
 
 | Variable | Purpose |
 | --- | --- |
-| `JURISDIGTA_SSH_HOST` | SSH host or DNS name for `jurisdigta-server`; use a public/tunnel-reachable hostname for GitHub-hosted runners |
+| `JURISDIGTA_SSH_HOST` | SSH host or DNS name for `jurisdigta-server`; `192.168.1.50` is valid only when the self-hosted `jurisdigta-prod` runner can reach that private LAN address |
 
 Optional `prod` GitHub Environment variables:
 

--- a/docs/manual_infrastucture_setup.md
+++ b/docs/manual_infrastucture_setup.md
@@ -293,7 +293,8 @@ If the repository is not cloned yet, run the same script from a temporary copy o
 20. Use nginx/Certbot only as a future static-IP fallback; for the current no-static-IP production server, Cloudflare Tunnel is the public HTTPS path.
 21. Add systemd units or timers only after the exact smoke deployment commands are validated.
 22. Configure the GitHub `prod` Environment values documented in `docs/GITHUB_ENVIRONMENTS.md`.
-23. Run `Self-Managed Prod Deploy` from GitHub Actions after the server-local environment file is complete.
+23. Register a repository self-hosted GitHub Actions runner on the trusted server or private network with labels `self-hosted`, `Linux`, `X64`, and `jurisdigta-prod`.
+24. Run `Self-Managed Prod Deploy` from GitHub Actions after the server-local environment file is complete.
 
 ### Secrets And Environment Values
 
@@ -332,6 +333,7 @@ If the repository is not cloned yet, run the same script from a temporary copy o
 - GitHub `prod` Environment variable `JURISDIGTA_SSH_HOST`.
 - GitHub `prod` Environment secret `JURISDIGTA_SSH_PRIVATE_KEY`, preferably a deploy-only key.
 - Optional GitHub `prod` Environment variables: `JURISDIGTA_SSH_PORT`, `JURISDIGTA_SSH_USER`, `JURISDIGTA_DEPLOY_ROOT`, `JURISDIGTA_ENV_FILE`, `JURISDIGTA_WEB_API_BASE_URL`, `JURISDIGTA_API_PORT`, `JURISDIGTA_MCP_PORT`, and `JURISDIGTA_WEB_PORT`.
+- Repository self-hosted GitHub Actions runner labels: `self-hosted`, `Linux`, `X64`, `jurisdigta-prod`.
 
 ### Validation Steps
 


### PR DESCRIPTION
## Summary
- run the self-managed production deploy workflow on the `jurisdigta-prod` self-hosted runner instead of `ubuntu-latest`
- document the private-network runner requirement for the `prod` environment
- update manual infrastructure setup with the runner label requirement

## Validation
- Registered `jurisdigta-server` self-hosted runner with labels `self-hosted`, `Linux`, `X64`, `jurisdigta-prod`
- `Self-Managed Prod Deploy` run `27672629585` succeeded from branch `codex/self-managed-prod-runner`
- Verified server-local API, MCP, and web health endpoints
- Verified public `https://api.jurisdigta.eu/health` and `https://web.jurisdigta.eu/privacy`

## Compliance
- Keeps application runtime secrets server-local under `/srv/jurisdigta/secrets/jurisdigta.env`
- Does not expose private service ports publicly; deployment uses the trusted self-hosted runner path for the private LAN host