### PR TITLE
Fix MCP OAuth OTP reuse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,9 @@ STORAGE_OPTION=local
 LOCAL_AUTH_ACCEPT_ANY_CODE=0
 # Secret used to sign MCP JWT bearer tokens. Set a long random value in deployed environments.
 # MCP_API_JWT_SECRET=change-this-long-random-secret
+# Hours to skip a repeat email OTP after the same MCP user successfully verifies one.
+# Set to 0 to require OTP on every MCP login/OAuth authorization.
+MCP_OTP_REUSE_WINDOW_HOURS=24
 # Dedicated local MCP server port and optional browser origins.
 # MCP_PORT=8070
 # MCP_CORS_ALLOW_ORIGINS=https://mcp.jurisdigta.eu

--- a/api/aijuristiction-api/app/mcp_api.py
+++ b/api/aijuristiction-api/app/mcp_api.py
@@ -37,6 +37,7 @@ oauth_router = APIRouter(tags=["mcp-oauth"])
 MCP_PROTOCOL_VERSION = "2025-03-26"
 _PUBLIC_TOOLS = {"getVersion", "getStatistics"}
 _DEFAULT_ALLOWED_REDIRECT_HOSTS = ("chatgpt.com", "chat.openai.com", "claude.ai")
+_MCP_OTP_VERIFICATION_PURPOSE = "mcp_access"
 logger = logging.getLogger("aijuristiction-api.mcp")
 _MCP_SUPPORTED_LOCALES = {"en", "sk"}
 _MCP_TEXT: dict[str, dict[str, str]] = {
@@ -376,7 +377,7 @@ def oauth_authorize_login(
     password: str = Form(...),
     store: ApiDatabaseStore = Depends(get_user_store),
     scheduler: EmailScheduler = Depends(get_email_scheduler),
-) -> HTMLResponse:
+) -> Response:
     resolved_resource = _resolve_oauth_resource(request=request, resource=resource)
     _validate_oauth_authorize_request(
         response_type=response_type,
@@ -390,6 +391,17 @@ def oauth_authorize_login(
     user = store.authenticate_user(email=email, password=password)
     if user is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid email or password")
+    if _has_recent_mcp_otp_verification(store=store, user=user):
+        logger.info("mcp_oauth_otp_reuse user_id=%s client_id=%s", user.user_id, client_id)
+        return _redirect_with_oauth_authorization_code(
+            store=store,
+            user=user,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            code_challenge=code_challenge,
+            resource=resolved_resource,
+            state=state,
+        )
     code = generate_one_time_code()
     store.save_registration_code(email=_oauth_login_code_key(email=user.email), code=code)
     scheduler.enqueue(
@@ -464,19 +476,16 @@ def oauth_authorize_verify(
     user = store.find_user_by_email(email=email)
     if user is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
-    authorization_code = secrets.token_urlsafe(32)
-    store.save_mcp_oauth_authorization_code(
-        code=authorization_code,
-        user_id=user.user_id,
+    _save_mcp_otp_verification(store=store, user=user)
+    return _redirect_with_oauth_authorization_code(
+        store=store,
+        user=user,
         client_id=client_id,
         redirect_uri=redirect_uri,
         code_challenge=code_challenge,
         resource=resolved_resource,
+        state=state,
     )
-    query = {"code": authorization_code}
-    if state:
-        query["state"] = state
-    return RedirectResponse(url=f"{redirect_uri}?{urlencode(query)}", status_code=status.HTTP_303_SEE_OTHER)
 
 
 @oauth_router.post("/oauth/token")
@@ -519,6 +528,31 @@ def oauth_token(
     }
 
 
+def _redirect_with_oauth_authorization_code(
+    *,
+    store: ApiDatabaseStore,
+    user: User,
+    client_id: str,
+    redirect_uri: str,
+    code_challenge: str,
+    resource: str,
+    state: str,
+) -> RedirectResponse:
+    authorization_code = secrets.token_urlsafe(32)
+    store.save_mcp_oauth_authorization_code(
+        code=authorization_code,
+        user_id=user.user_id,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        code_challenge=code_challenge,
+        resource=resource,
+    )
+    query = {"code": authorization_code}
+    if state:
+        query["state"] = state
+    return RedirectResponse(url=f"{redirect_uri}?{urlencode(query)}", status_code=status.HTTP_303_SEE_OTHER)
+
+
 @router.post("/login", response_class=HTMLResponse)
 def mcp_login_submit(
     request: Request,
@@ -533,6 +567,12 @@ def mcp_login_submit(
     user = store.authenticate_user(email=email, password=password)
     if user is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid email or password")
+    if _has_recent_mcp_otp_verification(store=store, user=user):
+        raw_key, expires_at = _issue_mcp_api_key(store=store, user=user, expires_in_days=expires_in_days)
+        logger.info("mcp_login_otp_reuse user_id=%s", user.user_id)
+        return HTMLResponse(
+            _key_created_html(locale=_mcp_locale(request), api_key=raw_key, expires_at=expires_at)
+        )
     code = generate_one_time_code()
     code_key = _mcp_login_code_key(email=user.email)
     store.save_registration_code(email=code_key, code=code)
@@ -1153,6 +1193,38 @@ def _accepts_any_local_auth_code() -> bool:
         "yes",
         "on",
     }
+
+
+def _mcp_otp_reuse_window_hours() -> int:
+    raw_value = os.getenv("MCP_OTP_REUSE_WINDOW_HOURS", "24").strip()
+    try:
+        value = int(raw_value)
+    except ValueError:
+        logger.warning("mcp_otp_reuse_window_invalid value_type=str")
+        return 24
+    return _bounded_int(value, default=24, minimum=0, maximum=168)
+
+
+def _has_recent_mcp_otp_verification(*, store: ApiDatabaseStore, user: User) -> bool:
+    if _mcp_otp_reuse_window_hours() < 1:
+        return False
+    return bool(
+        store.has_valid_mcp_otp_verification(
+            user_id=user.user_id,
+            purpose=_MCP_OTP_VERIFICATION_PURPOSE,
+        )
+    )
+
+
+def _save_mcp_otp_verification(*, store: ApiDatabaseStore, user: User) -> None:
+    reuse_window_hours = _mcp_otp_reuse_window_hours()
+    if reuse_window_hours < 1:
+        return
+    store.save_mcp_otp_verification(
+        user_id=user.user_id,
+        purpose=_MCP_OTP_VERIFICATION_PURPOSE,
+        expires_in_hours=reuse_window_hours,
+    )
 
 
 def _require_sign_up_consent(accepted: bool) -> None:

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260456"
+version = "1.0.260457"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_mcp_api.py
+++ b/api/aijuristiction-api/tests/test_mcp_api.py
@@ -452,6 +452,112 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
     assert _tool_payload(oauth_search)["results"][0]["document_id"] == "doc-1"
 
 
+def test_oauth_login_reuses_recent_mcp_otp_verification(monkeypatch, tmp_path: Path) -> None:
+    _configure_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("LOCAL_AUTH_ACCEPT_ANY_CODE", "true")
+    monkeypatch.setenv("MCP_OTP_REUSE_WINDOW_HOURS", "24")
+    sign_up_response = api_client.post(
+        "/v1/users/sign-up",
+        headers=AUTH_HEADERS,
+        json={
+            "phone_number": "+421 900 111 233",
+            "email": "mcp-oauth-reuse@example.com",
+            "password": "secret-pass",
+        },
+    )
+    assert sign_up_response.status_code == 201
+
+    code_verifier = "test-code-verifier-reuse-1234567890"
+    code_challenge = _pkce_challenge(code_verifier)
+    resource = "https://mcp.jurisdigta.eu/MCP"
+    authorize_data = {
+        "response_type": "code",
+        "client_id": "claude",
+        "redirect_uri": "https://claude.ai/api/mcp/auth_callback",
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": "claude-state",
+        "resource": resource,
+        "email": "mcp-oauth-reuse@example.com",
+        "password": "secret-pass",
+    }
+
+    first_login_response = mcp_client.post("/oauth/authorize/login", data=authorize_data)
+    assert first_login_response.status_code == 200
+    assert "Verify MCP OAuth login" in first_login_response.text
+
+    verify_response = mcp_client.post(
+        "/oauth/authorize/verify",
+        data={
+            **{key: value for key, value in authorize_data.items() if key != "password"},
+            "verification_code": "123456",
+        },
+        follow_redirects=False,
+    )
+    assert verify_response.status_code == 303
+
+    reuse_response = mcp_client.post(
+        "/oauth/authorize/login",
+        data=authorize_data,
+        follow_redirects=False,
+    )
+
+    assert reuse_response.status_code == 303
+    assert reuse_response.headers["location"].startswith("https://claude.ai/api/mcp/auth_callback?")
+    assert "state=claude-state" in reuse_response.headers["location"]
+    with sqlite3.connect(tmp_path / "email.sqlite3") as conn:
+        rows = conn.execute(
+            "SELECT subject FROM email_outbox WHERE recipient = ? AND subject = ?",
+            ("mcp-oauth-reuse@example.com", "Your MCP OAuth login code"),
+        ).fetchall()
+    assert rows == [("Your MCP OAuth login code",)]
+
+
+def test_mcp_otp_reuse_can_be_disabled(monkeypatch, tmp_path: Path) -> None:
+    _configure_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("LOCAL_AUTH_ACCEPT_ANY_CODE", "true")
+    monkeypatch.setenv("MCP_OTP_REUSE_WINDOW_HOURS", "0")
+    sign_up_response = api_client.post(
+        "/v1/users/sign-up",
+        headers=AUTH_HEADERS,
+        json={
+            "phone_number": "+421 900 111 234",
+            "email": "mcp-oauth-no-reuse@example.com",
+            "password": "secret-pass",
+        },
+    )
+    assert sign_up_response.status_code == 201
+
+    code_challenge = _pkce_challenge("test-code-verifier-no-reuse-1234567890")
+    authorize_data = {
+        "response_type": "code",
+        "client_id": "claude",
+        "redirect_uri": "https://claude.ai/api/mcp/auth_callback",
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": "claude-state",
+        "resource": "https://mcp.jurisdigta.eu/MCP",
+        "email": "mcp-oauth-no-reuse@example.com",
+        "password": "secret-pass",
+    }
+
+    first_login_response = mcp_client.post("/oauth/authorize/login", data=authorize_data)
+    assert first_login_response.status_code == 200
+    verify_response = mcp_client.post(
+        "/oauth/authorize/verify",
+        data={
+            **{key: value for key, value in authorize_data.items() if key != "password"},
+            "verification_code": "123456",
+        },
+        follow_redirects=False,
+    )
+    assert verify_response.status_code == 303
+
+    second_login_response = mcp_client.post("/oauth/authorize/login", data=authorize_data)
+    assert second_login_response.status_code == 200
+    assert "Verify MCP OAuth login" in second_login_response.text
+
+
 def test_oauth_discovery_uses_public_base_url(monkeypatch, tmp_path: Path) -> None:
     _configure_env(monkeypatch, tmp_path)
     monkeypatch.setenv("MCP_PUBLIC_BASE_URL", "https://mcp.jurisdigta.eu")

--- a/databases/api/migrations/0006_mcp_otp_verifications.sql
+++ b/databases/api/migrations/0006_mcp_otp_verifications.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS mcp_otp_verifications (
+    user_id TEXT NOT NULL,
+    purpose TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    verified_at TEXT NOT NULL,
+    PRIMARY KEY(user_id, purpose),
+    FOREIGN KEY(user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -383,6 +383,9 @@ Server-local `jurisdigta.env` must include at least:
 - `LOCAL_POSTGRES_PASSWORD`
 - `AZURE_LAWS_POSTGRES_DATABASE_NAME_SK=laws_sk`
 - `MCP_API_JWT_SECRET`
+- `MCP_PUBLIC_BASE_URL=https://mcp.jurisdigta.eu`
+- `MCP_OAUTH_ALLOWED_REDIRECT_HOSTS=chatgpt.com,chat.openai.com,claude.ai`
+- `MCP_OTP_REUSE_WINDOW_HOURS=24`
 - `DOCUMENT_PROCESSOR_OPTION=azure`
 - `DOCUMENT_PROCESSOR_MAX_RUNNING_TIME=15` or another bounded runtime in minutes
 - email/Turnstile settings when those production features are enabled
@@ -457,6 +460,9 @@ At minimum, you should expect these values to differ between `test` and `prod`:
 - `CORS_ALLOW_ORIGINS`
 - `MCP_CORS_ALLOW_ORIGINS=https://mcp.jurisdigta.eu`
 - `MCP_PORT=8070` for self-managed Docker Compose deployments
+- `MCP_PUBLIC_BASE_URL=https://mcp.jurisdigta.eu` for self-managed MCP OAuth metadata and token audience binding
+- `MCP_OAUTH_ALLOWED_REDIRECT_HOSTS=chatgpt.com,chat.openai.com,claude.ai` for remote connector OAuth callbacks
+- `MCP_OTP_REUSE_WINDOW_HOURS=24` for bounded repeat OTP suppression after successful MCP OTP verification
 - `CONTACT_CAPTCHA_REQUIRED=true`
 - `CONTACT_RATE_LIMIT_MAX_REQUESTS=5`
 - `CONTACT_RATE_LIMIT_WINDOW_SECONDS=600`

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -60,6 +60,7 @@ Production settings:
 - `MCP_PUBLIC_BASE_URL=https://mcp.jurisdigta.eu`
 - `MCP_OAUTH_ALLOWED_REDIRECT_HOSTS=chatgpt.com,chat.openai.com,claude.ai`
 - `MCP_API_JWT_SECRET=<long-random-secret>`
+- `MCP_OTP_REUSE_WINDOW_HOURS=24`
 
 ## Authentication
 
@@ -78,6 +79,8 @@ Users can generate a key in either way:
 - API endpoint: `POST /v1/users/{user_id}/mcp-api-key` with optional `{ "expires_in_days": 1 }`.
 
 The browser login, sign-up, OTP, OAuth authorization, and key-created pages share the JurisDigta MCP auth shell in `api/aijuristiction-api/app/mcp_api.py`. Keep the form field names and POST targets stable when changing UX, because external MCP and OAuth clients rely on those routes. Do not add remote tracking images or echo submitted password, ID-card, or profile values back into the OTP pages.
+
+After a successful MCP OTP verification, the server records a per-user MCP verification marker and skips repeat OTP prompts for subsequent MCP login or OAuth authorization attempts during `MCP_OTP_REUSE_WINDOW_HOURS` hours. The default is 24 hours; set it to `0` to require OTP every time. The user password is still required before a reused verification can authorize a client or create an MCP API key.
 
 Keys can be revoked with:
 
@@ -153,4 +156,4 @@ Debugging fields are intentionally minimized:
 
 For production troubleshooting, filter application logs by `mcp_` event names and correlate them with the `x-request-id` or `x-correlation-id` response headers.
 
-Security/GDPR/EU AI Act notes: the current MCP surface exposes public-law data and per-user access credentials. JWT tokens are signed, audience-bound, hashed in storage, expire by default after 1 day, and can be revoked. Public tools avoid user-specific data. Protected legal-data tools remain read-only and are logged with request correlation IDs by the MCP middleware for traceability. Pending MCP sign-up data is stored server-side with a short expiry and is not echoed into hidden browser fields. OAuth and MCP tool responses do not return raw API keys to ChatGPT or Claude. Dynamic client registration only issues a public OAuth client identifier for PKCE flows; it does not issue user tokens, secrets, or data access without the existing user login and email OTP authorization. Set `MCP_API_JWT_SECRET` to a long random value in deployed environments, set `MCP_PUBLIC_BASE_URL=https://mcp.jurisdigta.eu`, keep OAuth redirect hosts restricted, protect `mcp.jurisdigta.eu` separately from the public API, and keep assistant/tool audit logs privacy-safe.
+Security/GDPR/EU AI Act notes: the current MCP surface exposes public-law data and per-user access credentials. JWT tokens are signed, audience-bound, hashed in storage, expire by default after 1 day, and can be revoked. Public tools avoid user-specific data. Protected legal-data tools remain read-only and are logged with request correlation IDs by the MCP middleware for traceability. Pending MCP sign-up data is stored server-side with a short expiry and is not echoed into hidden browser fields. OAuth and MCP tool responses do not return raw API keys to ChatGPT or Claude. Dynamic client registration only issues a public OAuth client identifier for PKCE flows; it does not issue user tokens, secrets, or data access without the existing user login and email OTP authorization. OTP reuse stores only user id, purpose, verification time, and expiry; it does not store OTP codes, passwords, OAuth tokens, email addresses, prompts, or law text. Set `MCP_API_JWT_SECRET` to a long random value in deployed environments, set `MCP_PUBLIC_BASE_URL=https://mcp.jurisdigta.eu`, keep OAuth redirect hosts restricted, protect `mcp.jurisdigta.eu` separately from the public API, and keep assistant/tool audit logs privacy-safe.

--- a/docs/manual_infrastucture_setup.md
+++ b/docs/manual_infrastucture_setup.md
@@ -306,6 +306,7 @@ If the repository is not cloned yet, run the same script from a temporary copy o
 - Required production LLM default: `LLM_PROVIDER=azurefoundry`.
 - Required Azure Foundry values when `LLM_PROVIDER=azurefoundry`: `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT`, `AZURE_OPENAI_EMBEDDINGS_MODEL`, `AZURE_OPENAI_API_VERSION`, and `AZURE_OPENAI_API_KEY`.
 - PostgreSQL usernames, passwords, and connection strings must remain server-local or in a secret manager.
+- Required MCP OAuth values in `/srv/jurisdigta/secrets/jurisdigta.env`: `MCP_API_JWT_SECRET`, `MCP_PUBLIC_BASE_URL=https://mcp.jurisdigta.eu`, `MCP_OAUTH_ALLOWED_REDIRECT_HOSTS=chatgpt.com,chat.openai.com,claude.ai`, and `MCP_OTP_REUSE_WINDOW_HOURS=24`.
 - Public DNS/TLS values may include `jurisdigta.eu`, `www.jurisdigta.eu`, `api.jurisdigta.eu`, `web.jurisdigta.eu`, `services.jurisdigta.eu`, and `admin.jurisdigta.eu`.
 - Server-local laws collector cron wrapper path: `/srv/jurisdigta/ops/run_laws_collector_daily.sh`.
 - Server-local laws collector log path: `/srv/jurisdigta/runs/logs/laws-collector-daily-latest.log`.
@@ -345,6 +346,7 @@ If the repository is not cloned yet, run the same script from a temporary copy o
 - PostgreSQL health check succeeds.
 - API health check returns HTTP 200 at `http://127.0.0.1:8080/health`.
 - MCP health check returns HTTP 200 at `http://127.0.0.1:8070/health`.
+- MCP OAuth metadata at `https://mcp.jurisdigta.eu/.well-known/oauth-protected-resource/MCP` advertises `https://mcp.jurisdigta.eu/MCP` as the protected resource.
 - Repository minimal runnable example succeeds: `python examples/minimal_demo.py`.
 - `crontab -l` contains the daily laws collector wrapper entry.
 - `docker ps -a --filter name=jurisdigta-laws-collector-daily` shows no stuck active collector container after deployment validation.

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260387"
+__version__ = "1.0.260388"

--- a/src/aijurisdictionagents/api_db/store.py
+++ b/src/aijurisdictionagents/api_db/store.py
@@ -249,6 +249,15 @@ class ApiDatabaseStore:
                     FOREIGN KEY(user_id) REFERENCES users(user_id) ON DELETE CASCADE
                 );
 
+                CREATE TABLE IF NOT EXISTS mcp_otp_verifications (
+                    user_id TEXT NOT NULL,
+                    purpose TEXT NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    verified_at TEXT NOT NULL,
+                    PRIMARY KEY(user_id, purpose),
+                    FOREIGN KEY(user_id) REFERENCES users(user_id) ON DELETE CASCADE
+                );
+
                 CREATE TABLE IF NOT EXISTS companies (
                     company_id TEXT PRIMARY KEY,
                     legal_name TEXT NOT NULL,
@@ -711,6 +720,66 @@ class ApiDatabaseStore:
             "code_challenge": str(row[3]),
             "resource": str(row[4]),
         }
+
+    def save_mcp_otp_verification(
+        self,
+        *,
+        user_id: str,
+        purpose: str,
+        expires_in_hours: int,
+    ) -> None:
+        normalized_user_id = user_id.strip()
+        normalized_purpose = purpose.strip().lower()
+        if not normalized_user_id or not normalized_purpose:
+            return
+        now = datetime.now(timezone.utc)
+        expires_at = now + timedelta(hours=max(expires_in_hours, 1))
+        with self._connect() as conn:
+            self._execute(
+                conn,
+                """
+                INSERT INTO mcp_otp_verifications(user_id, purpose, expires_at, verified_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(user_id, purpose) DO UPDATE SET
+                    expires_at = excluded.expires_at,
+                    verified_at = excluded.verified_at
+                """,
+                (
+                    normalized_user_id,
+                    normalized_purpose,
+                    expires_at.isoformat(),
+                    now.isoformat(),
+                ),
+            )
+            conn.commit()
+
+    def has_valid_mcp_otp_verification(self, *, user_id: str, purpose: str) -> bool:
+        normalized_user_id = user_id.strip()
+        normalized_purpose = purpose.strip().lower()
+        if not normalized_user_id or not normalized_purpose:
+            return False
+        with self._connect() as conn:
+            row = self._fetchone(
+                conn,
+                """
+                SELECT expires_at
+                FROM mcp_otp_verifications
+                WHERE user_id = ? AND purpose = ?
+                """,
+                (normalized_user_id, normalized_purpose),
+            )
+            if row is None:
+                return False
+            expires_at = str(row[0])
+            if _is_future_iso_datetime(expires_at):
+                return True
+            self._execute(
+                conn,
+                "DELETE FROM mcp_otp_verifications WHERE user_id = ? AND purpose = ?",
+                (normalized_user_id, normalized_purpose),
+            )
+            conn.commit()
+            return False
 
     def issue_device_auth_token(
         self,
@@ -1905,6 +1974,19 @@ class ApiDatabaseStore:
                 conn,
                 "ALTER TABLE mcp_oauth_authorization_codes ADD COLUMN resource TEXT NOT NULL DEFAULT ''",
             )
+        self._execute(
+            conn,
+            """
+            CREATE TABLE IF NOT EXISTS mcp_otp_verifications (
+                user_id TEXT NOT NULL,
+                purpose TEXT NOT NULL,
+                expires_at TEXT NOT NULL,
+                verified_at TEXT NOT NULL,
+                PRIMARY KEY(user_id, purpose),
+                FOREIGN KEY(user_id) REFERENCES users(user_id) ON DELETE CASCADE
+            )
+            """,
+        )
 
     def _ensure_case_document_schema(
         self, conn: sqlite3.Connection | PostgresConnection[Any]


### PR DESCRIPTION
## Summary
- add bounded MCP OTP reuse for OAuth/manual MCP login after successful verification
- persist per-user MCP OTP verification markers with a PostgreSQL migration
- document `MCP_OTP_REUSE_WINDOW_HOURS` and self-managed prod MCP env requirements

## Validation
- `./scripts/validate_api.ps1`
- `./conda/python.exe -m pytest api/aijuristiction-api/tests/test_mcp_api.py`
- `./conda/python.exe -m pytest api/aijuristiction-api/tests`

## Notes
- GDPR/EU AI Act: OTP reuse stores only user id, purpose, verification time, and expiry; it does not store OTP codes, passwords, OAuth tokens, prompts, law text, or email addresses.