### PR TITLE
Fix MCP OAuth token validation

### DIFF
--- a/api/aijuristiction-api/app/mcp_api.py
+++ b/api/aijuristiction-api/app/mcp_api.py
@@ -1217,12 +1217,15 @@ def _authenticate_mcp_api_token(*, api_key: str, store: ApiDatabaseStore) -> Use
     if payload is None:
         logger.warning("mcp_auth_failed reason=invalid_or_expired_token")
         raise HTTPException(status_code=401, detail="Invalid or expired MCP API key")
-    user = store.find_user_by_mcp_api_key(api_key=api_key)
+    user = store.find_user_by_id(user_id=str(payload["sub"]))
     if user is None or user.user_id != payload.get("sub"):
         logger.warning(
             "mcp_auth_failed reason=token_user_mismatch subject_type=%s",
             _value_type(payload.get("sub")),
         )
+        raise HTTPException(status_code=401, detail="Invalid or expired MCP API key")
+    if not user.mcp_api_key_hash:
+        logger.warning("mcp_auth_failed reason=mcp_access_revoked user_id=%s", user.user_id)
         raise HTTPException(status_code=401, detail="Invalid or expired MCP API key")
     return user
 

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260459"
+version = "1.0.260460"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_mcp_api.py
+++ b/api/aijuristiction-api/tests/test_mcp_api.py
@@ -557,6 +557,22 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
     assert oauth_search.status_code == 200
     assert _tool_payload(oauth_search)["results"][0]["document_id"] == "doc-1"
 
+    replacement_key_response = api_client.post(
+        f"/v1/users/{sign_up_response.json()['user_id']}/mcp-api-key",
+        headers=AUTH_HEADERS,
+        json={"expires_in_days": 1},
+    )
+    assert replacement_key_response.status_code == 200
+    assert replacement_key_response.json()["mcp_api_key"] != token_payload["access_token"]
+
+    existing_oauth_search = _mcp_call(
+        "searchLaws",
+        {"query": "civil"},
+        headers={"authorization": f"Bearer {token_payload['access_token']}"},
+    )
+    assert existing_oauth_search.status_code == 200
+    assert _tool_payload(existing_oauth_search)["results"][0]["document_id"] == "doc-1"
+
 
 def test_oauth_login_reuses_recent_mcp_otp_verification(monkeypatch, tmp_path: Path) -> None:
     _configure_env(monkeypatch, tmp_path)

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -74,7 +74,10 @@ Production settings:
 - Default key lifetime is 1 day.
 - Keys are signed JWT bearer tokens and are only shown once at creation.
 - JWT claims are minimized to `sub`, `aud`, `scope`, `exp`, and `jti`.
-- The full token is still stored hashed in the database so it can be revoked.
+- The latest full token is stored hashed in the database as the per-user MCP
+  access marker. Clearing it revokes MCP access for the user; valid signed
+  OAuth/browser tokens for that user remain usable until their own JWT expiry
+  unless access is revoked.
 - Protected MCP tools accept either `Authorization: Bearer <mcp_api_key>` or `x-mcp-api-key: <mcp_api_key>`.
 - OAuth tokens are audience-bound to the MCP resource URL and include `scope=mcp:laws`.
 


### PR DESCRIPTION
## Summary
- validate MCP bearer tokens by signed JWT subject instead of requiring the exact latest stored API-key hash
- keep user-level MCP revocation through the stored access marker
- document OAuth/browser token behavior and add regression coverage for replacement keys

## Validation
- .\\scripts\\validate_api.ps1
- .\\conda\\python.exe -m pytest api/aijuristiction-api/tests/test_mcp_api.py
- .\\conda\\python.exe -m pytest api/aijuristiction-api/tests
- deployed codex/fix-mcp-oauth-token-tools to production with COMPOSE_BAKE=false fallback
- verified https://mcp.jurisdigta.eu/version reports 1.0.260460
- verified public initialize/tools/list, protected OAuth challenge, and Claude-shaped /oauth/register