### PR TITLE
Support MCP OAuth refresh tokens

### DIFF
--- a/api/aijuristiction-api/app/mcp_api.py
+++ b/api/aijuristiction-api/app/mcp_api.py
@@ -19,7 +19,15 @@ from fastapi import APIRouter, Body, Depends, Form, Header, HTTPException, Reque
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 
 from app.laws_api import _laws_db_config, _read_laws_statistics
-from app.mcp_tokens import MCP_TOKEN_SCOPE, create_mcp_api_token, default_mcp_resource_url, validate_mcp_api_token
+from app.mcp_tokens import (
+    MCP_REFRESH_TOKEN_SCOPE,
+    MCP_TOKEN_SCOPE,
+    create_mcp_api_token,
+    create_mcp_refresh_token,
+    default_mcp_resource_url,
+    validate_mcp_api_token,
+    validate_mcp_refresh_token,
+)
 from app.services.email_scheduler import EmailScheduler
 from app.users.api import get_email_scheduler, get_user_store
 from app.users.notifications import queue_registration_email
@@ -287,10 +295,10 @@ def oauth_authorization_server_metadata(request: Request) -> dict[str, Any]:
         "token_endpoint": f"{base_url}/oauth/token",
         "registration_endpoint": f"{base_url}/oauth/register",
         "response_types_supported": ["code"],
-        "grant_types_supported": ["authorization_code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
         "code_challenge_methods_supported": ["S256"],
         "token_endpoint_auth_methods_supported": ["none"],
-        "scopes_supported": [MCP_TOKEN_SCOPE],
+        "scopes_supported": [MCP_TOKEN_SCOPE, MCP_REFRESH_TOKEN_SCOPE],
     }
 
 
@@ -340,10 +348,10 @@ def oauth_dynamic_client_registration(
         "client_id_issued_at": int(time.time()),
         "client_name": str(metadata.get("client_name") or "MCP client").strip()[:100],
         "redirect_uris": redirect_uris,
-        "grant_types": ["authorization_code"],
+        "grant_types": ["authorization_code", "refresh_token"],
         "response_types": ["code"],
         "token_endpoint_auth_method": "none",
-        "scope": MCP_TOKEN_SCOPE,
+        "scope": f"{MCP_TOKEN_SCOPE} {MCP_REFRESH_TOKEN_SCOPE}",
     }
 
 
@@ -511,15 +519,25 @@ def oauth_authorize_verify(
 def oauth_token(
     request: Request,
     grant_type: str = Form(...),
-    code: str = Form(...),
-    redirect_uri: str = Form(...),
+    code: str = Form(""),
+    redirect_uri: str = Form(""),
     client_id: str = Form(...),
-    code_verifier: str = Form(...),
+    code_verifier: str = Form(""),
     resource: str = Form(""),
+    refresh_token: str = Form(""),
     store: ApiDatabaseStore = Depends(get_user_store),
 ) -> dict[str, Any]:
+    if grant_type == "refresh_token":
+        return _oauth_refresh_token_response(
+            request=request,
+            refresh_token=refresh_token,
+            resource=resource,
+            store=store,
+        )
     if grant_type != "authorization_code":
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported grant_type")
+    if not code or not redirect_uri or not code_verifier:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing authorization code parameters")
     record = store.consume_mcp_oauth_authorization_code(code=code)
     if record is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid authorization code")
@@ -538,9 +556,47 @@ def oauth_token(
         expires_in_days=1,
         audience=expected_resource,
     )
+    refresh_token_value, _ = _issue_mcp_refresh_token(user=user, audience=expected_resource)
     expires_in = max(1, int((datetime.fromisoformat(expires_at) - datetime.now(timezone.utc)).total_seconds()))
     return {
         "access_token": token,
+        "refresh_token": refresh_token_value,
+        "token_type": "Bearer",
+        "expires_in": expires_in,
+        "scope": MCP_TOKEN_SCOPE,
+    }
+
+
+def _oauth_refresh_token_response(
+    *,
+    request: Request,
+    refresh_token: str,
+    resource: str,
+    store: ApiDatabaseStore,
+) -> dict[str, Any]:
+    if not refresh_token:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing refresh_token")
+    expected_resource = _resource_url(request)
+    resolved_resource = _resolve_oauth_resource(request=request, resource=resource)
+    if resolved_resource != expected_resource:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="OAuth resource mismatch")
+    payload = validate_mcp_refresh_token(refresh_token, audience=expected_resource)
+    if payload is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid refresh_token")
+    user = store.find_user_by_id(user_id=str(payload["sub"]))
+    if user is None or not user.mcp_api_key_hash:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="MCP access revoked")
+    token, expires_at = _issue_mcp_api_key(
+        store=store,
+        user=user,
+        expires_in_days=1,
+        audience=expected_resource,
+    )
+    refresh_token_value, _ = _issue_mcp_refresh_token(user=user, audience=expected_resource)
+    expires_in = max(1, int((datetime.fromisoformat(expires_at) - datetime.now(timezone.utc)).total_seconds()))
+    return {
+        "access_token": token,
+        "refresh_token": refresh_token_value,
         "token_type": "Bearer",
         "expires_in": expires_in,
         "scope": MCP_TOKEN_SCOPE,
@@ -1184,6 +1240,12 @@ def _issue_mcp_api_key(
     expires_at = expires_at_dt.isoformat()
     store.set_user_mcp_api_key(user_id=user.user_id, api_key=raw_key, expires_at=expires_at)
     return raw_key, expires_at
+
+
+def _issue_mcp_refresh_token(*, user: User, audience: str) -> tuple[str, str]:
+    expires_at_dt = (datetime.now(timezone.utc) + timedelta(days=30)).replace(microsecond=0)
+    raw_key = create_mcp_refresh_token(user=user, expires_at=expires_at_dt, audience=audience)
+    return raw_key, expires_at_dt.isoformat()
 
 
 def _extract_mcp_api_key(*, authorization: str | None, x_mcp_api_key: str | None) -> str | None:

--- a/api/aijuristiction-api/app/mcp_tokens.py
+++ b/api/aijuristiction-api/app/mcp_tokens.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 from aijurisdictionagents.api_db import User
 
 MCP_TOKEN_SCOPE = "mcp:laws"
+MCP_REFRESH_TOKEN_SCOPE = "offline_access"
 
 
 def create_mcp_api_token(
@@ -37,7 +38,53 @@ def create_mcp_api_token(
     return f"{signing_input}.{signature}"
 
 
+def create_mcp_refresh_token(
+    *,
+    user: User,
+    expires_at: datetime,
+    audience: str | None = None,
+) -> str:
+    token_id = str(uuid4())
+    header = {"alg": "HS256", "typ": "JWT"}
+    payload = {
+        "sub": user.user_id,
+        "aud": audience or default_mcp_resource_url(),
+        "scope": MCP_REFRESH_TOKEN_SCOPE,
+        "exp": int(expires_at.timestamp()),
+        "jti": token_id,
+        "token_use": "refresh",
+    }
+    encoded_header = _base64url_json(header)
+    encoded_payload = _base64url_json(payload)
+    signing_input = f"{encoded_header}.{encoded_payload}"
+    signature = _sign(signing_input)
+    return f"{signing_input}.{signature}"
+
+
 def validate_mcp_api_token(token: str, *, audience: str, required_scope: str) -> dict[str, Any] | None:
+    payload = _validate_mcp_token(token=token, audience=audience)
+    if payload is None:
+        return None
+    if payload.get("token_use") not in {None, "access"}:
+        return None
+    scope = payload.get("scope")
+    if not isinstance(scope, str) or required_scope not in scope.split():
+        return None
+    return payload
+
+
+def validate_mcp_refresh_token(token: str, *, audience: str) -> dict[str, Any] | None:
+    payload = _validate_mcp_token(token=token, audience=audience)
+    if payload is None:
+        return None
+    if payload.get("token_use") != "refresh":
+        return None
+    if payload.get("scope") != MCP_REFRESH_TOKEN_SCOPE:
+        return None
+    return payload
+
+
+def _validate_mcp_token(token: str, *, audience: str) -> dict[str, Any] | None:
     parts = token.split(".")
     if len(parts) != 3:
         return None
@@ -59,9 +106,6 @@ def validate_mcp_api_token(token: str, *, audience: str, required_scope: str) ->
     if not isinstance(payload.get("sub"), str):
         return None
     if payload.get("aud") != audience:
-        return None
-    scope = payload.get("scope")
-    if not isinstance(scope, str) or required_scope not in scope.split():
         return None
     if not isinstance(payload.get("jti"), str):
         return None

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260460"
+version = "1.0.260461"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_mcp_api.py
+++ b/api/aijuristiction-api/tests/test_mcp_api.py
@@ -436,7 +436,8 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
     authorization_metadata = mcp_client.get("/.well-known/oauth-authorization-server")
     assert authorization_metadata.status_code == 200
     assert authorization_metadata.json()["code_challenge_methods_supported"] == ["S256"]
-    assert authorization_metadata.json()["scopes_supported"] == ["mcp:laws"]
+    assert authorization_metadata.json()["grant_types_supported"] == ["authorization_code", "refresh_token"]
+    assert authorization_metadata.json()["scopes_supported"] == ["mcp:laws", "offline_access"]
     assert authorization_metadata.json()["registration_endpoint"].endswith("/oauth/register")
 
     registration_response = mcp_client.post(
@@ -470,9 +471,9 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
     assert claude_variant_registration.status_code == 201
     claude_variant_payload = claude_variant_registration.json()
     assert claude_variant_payload["client_id"].startswith("jurisdigta-")
-    assert claude_variant_payload["grant_types"] == ["authorization_code"]
+    assert claude_variant_payload["grant_types"] == ["authorization_code", "refresh_token"]
     assert claude_variant_payload["token_endpoint_auth_method"] == "none"
-    assert claude_variant_payload["scope"] == "mcp:laws"
+    assert claude_variant_payload["scope"] == "mcp:laws offline_access"
 
     code_verifier = "test-code-verifier-1234567890"
     code_challenge = _pkce_challenge(code_verifier)
@@ -543,11 +544,18 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
     assert token_response.status_code == 200
     token_payload = token_response.json()
     assert token_payload["token_type"] == "Bearer"
+    assert token_payload["refresh_token"]
     claims = _jwt_claims(token_payload["access_token"])
     assert claims["sub"] == sign_up_response.json()["user_id"]
     assert claims["aud"] == resource
     assert claims["scope"] == "mcp:laws"
     assert "email" not in claims
+    refresh_claims = _jwt_claims(token_payload["refresh_token"])
+    assert refresh_claims["sub"] == sign_up_response.json()["user_id"]
+    assert refresh_claims["aud"] == resource
+    assert refresh_claims["scope"] == "offline_access"
+    assert refresh_claims["token_use"] == "refresh"
+    assert "email" not in refresh_claims
 
     oauth_search = _mcp_call(
         "searchLaws",
@@ -556,6 +564,34 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
     )
     assert oauth_search.status_code == 200
     assert _tool_payload(oauth_search)["results"][0]["document_id"] == "doc-1"
+
+    refresh_as_access_search = _mcp_call(
+        "searchLaws",
+        {"query": "civil"},
+        headers={"authorization": f"Bearer {token_payload['refresh_token']}"},
+    )
+    assert refresh_as_access_search.status_code == 200
+    assert refresh_as_access_search.json()["error"]["code"] == 401
+
+    refresh_response = mcp_client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": token_payload["refresh_token"],
+            "client_id": "chatgpt",
+            "resource": resource,
+        },
+    )
+    assert refresh_response.status_code == 200
+    refreshed_payload = refresh_response.json()
+    assert refreshed_payload["token_type"] == "Bearer"
+    assert refreshed_payload["scope"] == "mcp:laws"
+    assert refreshed_payload["access_token"] != token_payload["access_token"]
+    assert refreshed_payload["refresh_token"] != token_payload["refresh_token"]
+    refreshed_claims = _jwt_claims(refreshed_payload["access_token"])
+    assert refreshed_claims["sub"] == sign_up_response.json()["user_id"]
+    assert refreshed_claims["aud"] == resource
+    assert refreshed_claims["scope"] == "mcp:laws"
 
     replacement_key_response = api_client.post(
         f"/v1/users/{sign_up_response.json()['user_id']}/mcp-api-key",

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -52,14 +52,15 @@ curl http://127.0.0.1:8070/
 - Authorization endpoint: `GET /oauth/authorize`
 - Token endpoint: `POST /oauth/token`
 
-The OAuth flow uses authorization code with PKCE S256. Remote clients can either
-use dynamic client registration at `/oauth/register` or provide a preconfigured
+The OAuth flow uses authorization code with PKCE S256, plus refresh tokens for
+remote clients that request `offline_access`. Remote clients can either use
+dynamic client registration at `/oauth/register` or provide a preconfigured
 public OAuth Client ID. ChatGPT and Claude should pass the protected resource
-value `https://mcp.jurisdigta.eu/MCP` on the authorization and token requests.
-The browser authorization page validates the user password, sends an email OTP,
-and only creates a short-lived authorization code after OTP verification. The
-token endpoint exchanges that code for the same revocable JWT bearer token
-accepted by `POST /MCP`.
+value `https://mcp.jurisdigta.eu/MCP` on the authorization, token, and refresh
+requests. The browser authorization page validates the user password, sends an
+email OTP, and only creates a short-lived authorization code after OTP
+verification. The token endpoint exchanges that code for the same revocable JWT
+bearer token accepted by `POST /MCP` and a separate audience-bound refresh token.
 
 Production settings:
 
@@ -73,13 +74,17 @@ Production settings:
 - MCP API keys are per user.
 - Default key lifetime is 1 day.
 - Keys are signed JWT bearer tokens and are only shown once at creation.
-- JWT claims are minimized to `sub`, `aud`, `scope`, `exp`, and `jti`.
+- JWT claims are minimized to `sub`, `aud`, `scope`, `exp`, `jti`, and
+  `token_use` for refresh tokens.
 - The latest full token is stored hashed in the database as the per-user MCP
   access marker. Clearing it revokes MCP access for the user; valid signed
   OAuth/browser tokens for that user remain usable until their own JWT expiry
   unless access is revoked.
 - Protected MCP tools accept either `Authorization: Bearer <mcp_api_key>` or `x-mcp-api-key: <mcp_api_key>`.
 - OAuth tokens are audience-bound to the MCP resource URL and include `scope=mcp:laws`.
+- OAuth refresh tokens are audience-bound, use `scope=offline_access`, are not
+  accepted as MCP bearer tokens, and can be exchanged at `/oauth/token` with
+  `grant_type=refresh_token`.
 
 Users can generate a key in either way:
 


### PR DESCRIPTION
## Summary
- advertise refresh-token support and offline access in MCP OAuth metadata
- return separate audience-bound refresh tokens from the authorization-code exchange
- support refresh_token grant exchanges while rejecting refresh tokens as MCP bearer credentials
- document the OAuth refresh-token behavior

## Validation
- .\\scripts\\validate_api.ps1
- .\\conda\\python.exe -m pytest api/aijuristiction-api/tests/test_mcp_api.py
- .\\conda\\python.exe -m pytest api/aijuristiction-api/tests