### PR TITLE
Allow agent web origin for API CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -189,7 +189,7 @@ STORE_LOCAL=./runs/storage/api/files
 # STORE_CLOUD=https://<storage-account>.blob.core.windows.net/<container-name>
 # Set this only for deployed browser clients (for example Flutter web hosted outside ACA).
 # Native Android/iOS builds do not need CORS_ALLOW_ORIGINS.
-# CORS_ALLOW_ORIGINS=https://mobile-web-dev.example.com,https://web-juris-dev.<region>.azurecontainerapps.io
+# CORS_ALLOW_ORIGINS=https://mobile-web-dev.example.com,https://web-juris-dev.<region>.azurecontainerapps.io,https://web.jurisdigta.eu,https://agent.jurisdigta.eu
 
 # Laws collector
 # Selects the country-specific collector implementation. Only SK is implemented today.

--- a/Deployment/server/deploy_jurisdigta_prod.sh
+++ b/Deployment/server/deploy_jurisdigta_prod.sh
@@ -54,6 +54,28 @@ load_env() {
   set +a
 }
 
+append_csv_value() {
+  local existing="$1"
+  local required="$2"
+  if [ -z "$existing" ]; then
+    printf '%s' "$required"
+    return
+  fi
+  case ",$existing," in
+    *",$required,"*) printf '%s' "$existing" ;;
+    *) printf '%s,%s' "$existing" "$required" ;;
+  esac
+}
+
+production_api_cors_origins() {
+  local origins="${CORS_ALLOW_ORIGINS:-}"
+  origins="$(append_csv_value "$origins" "https://jurisdigta.eu")"
+  origins="$(append_csv_value "$origins" "https://www.jurisdigta.eu")"
+  origins="$(append_csv_value "$origins" "https://web.jurisdigta.eu")"
+  origins="$(append_csv_value "$origins" "https://agent.jurisdigta.eu")"
+  printf '%s' "$origins"
+}
+
 require_azurefoundry_settings() {
   local provider="${LLM_PROVIDER:-azurefoundry}"
   if [ "$provider" != "azurefoundry" ]; then
@@ -164,8 +186,10 @@ start_api_and_mcp() {
   compose_env
   local api_db_cloud
   local laws_db_cloud
+  local api_cors_allow_origins
   api_db_cloud="$(postgres_url "postgres" "${LOCAL_POSTGRES_DB:-aijurisdiction}")"
   laws_db_cloud="$(postgres_url "postgres" "${AZURE_LAWS_POSTGRES_DATABASE_NAME_SK:-laws_sk}")"
+  api_cors_allow_origins="$(production_api_cors_origins)"
   docker rm -f jurisdigta-api jurisdigta-mcp jurisdigta-email-scheduler >/dev/null 2>&1 || true
   docker run -d \
     --name jurisdigta-api \
@@ -176,6 +200,7 @@ start_api_and_mcp() {
     -e DB_OPTION=postgres \
     -e DB_CLOUD="$api_db_cloud" \
     -e DB_LOCAL=/workspace/runs/storage/api/sqlite/api.sqlite3 \
+    -e CORS_ALLOW_ORIGINS="$api_cors_allow_origins" \
     -e EMAIL_DB_OPTION=postgres \
     -e EMAIL_DB_CLOUD="$api_db_cloud" \
     -e EMAIL_DB_LOCAL=/workspace/runs/storage/api/sqlite/email.sqlite3 \

--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -658,7 +658,7 @@ curl -X POST "http://localhost:8080/v1/chat/sessions" \
   - `http://127.x.x.x:<any-port>` for loopback IPv4 addresses
   - `http://[::1]:<any-port>` for IPv6 loopback
   - `Origin: null` for static `file://` previews, including the corporate web contact form during local checks
-- Deployed browser clients are blocked until you set `CORS_ALLOW_ORIGINS` explicitly.
+- Deployed browser clients are blocked until `CORS_ALLOW_ORIGINS` includes their exact origins. The self-managed production deploy always adds `https://web.jurisdigta.eu` and `https://agent.jurisdigta.eu` for the API container.
 - Native Android/iOS builds do not require `CORS_ALLOW_ORIGINS`.
 - Override allowed origins with `CORS_ALLOW_ORIGINS` (comma-separated), for example:
 
@@ -669,7 +669,7 @@ CORS_ALLOW_ORIGINS=http://localhost:8090,http://127.0.0.1:8090,http://localhost:
 Example for a deployed browser build:
 
 ```bash
-CORS_ALLOW_ORIGINS=https://mobile-web-dev.example.com,https://web-juris-dev.<region>.azurecontainerapps.io uvicorn app.main:app --reload --port 8080
+CORS_ALLOW_ORIGINS=https://mobile-web-dev.example.com,https://web-juris-dev.<region>.azurecontainerapps.io,https://web.jurisdigta.eu,https://agent.jurisdigta.eu uvicorn app.main:app --reload --port 8080
 
 ## Local source precedence
 

--- a/api/aijuristiction-api/app/main.py
+++ b/api/aijuristiction-api/app/main.py
@@ -70,9 +70,11 @@ _DEFAULT_CORPORATE_WEB_ORIGINS: tuple[str, ...] = (
     "https://jurisdigta.eu",
     "https://www.jurisdigta.eu",
     "https://web.jurisdigta.eu",
+    "https://agent.jurisdigta.eu",
     "https://juridigta.eu",
     "https://www.juridigta.eu",
     "https://web.juridigta.eu",
+    "https://agent.juridigta.eu",
 )
 
 

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260462"
+version = "1.0.260463"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_health.py
+++ b/api/aijuristiction-api/tests/test_health.py
@@ -233,6 +233,22 @@ def test_cors_preflight_allows_local_chat_simulator() -> None:
     assert response.headers["access-control-allow-origin"] == "http://localhost:8090"
 
 
+def test_cors_preflight_allows_production_agent_web() -> None:
+    response = client.options(
+        "/v1/users/sign-in",
+        headers={
+            "Origin": "https://agent.jurisdigta.eu",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "x-api-key,content-type",
+        },
+    )
+    assert response.status_code == 200
+    assert (
+        response.headers["access-control-allow-origin"]
+        == "https://agent.jurisdigta.eu"
+    )
+
+
 def test_cors_preflight_allows_flutter_web_localhost() -> None:
     response = client.options(
         "/v1/chat/sessions",

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -142,7 +142,7 @@ These are used by infrastructure deployment and API deployment workflows:
 | `AZURE_POSTGRES_SKU_TIER` | Optional infra sizing value |
 | `AZURE_POSTGRES_VERSION` | Optional PostgreSQL version |
 | `AZURE_POSTGRES_STORAGE_SIZE_GB` | Optional PostgreSQL storage size |
-| `CORS_ALLOW_ORIGINS` | Optional browser origins allowed to call the API |
+| `CORS_ALLOW_ORIGINS` | Optional browser origins allowed to call the API. Include browser-hosted frontend origins such as `https://web.jurisdigta.eu` and `https://agent.jurisdigta.eu`; self-managed prod deploy appends those two origins when starting the API container |
 | `MCP_CORS_ALLOW_ORIGINS` | Optional browser origins allowed to call the dedicated MCP service; default production value should include `https://mcp.jurisdigta.eu` |
 | `MCP_PORT` | Local/self-managed MCP service port when using Docker Compose, default `8070` |
 | `CONTACT_CAPTCHA_REQUIRED` | Set `true` in public environments to require Cloudflare Turnstile verification for `POST /v1/contact` |


### PR DESCRIPTION
## Summary
- allow agent.jurisdigta.eu in API CORS defaults
- make self-managed prod deploy append web and agent API origins
- document prod CORS requirements and add a regression preflight test

## Validation
- .\\scripts\\validate_api.ps1
- C:\\Users\\maton\\Projects\\aijurisdictionagents\\conda\\python.exe -m pytest api\\aijuristiction-api\\tests\\test_health.py

Full API suite was attempted with the synced local .env temporarily isolated, but it exceeded the interactive timeout; the targeted CORS/API gate passed.