### PR TITLE
Implement unlimited access email allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,9 @@ STORAGE_OPTION=local
 # Local auth test helper. Keep disabled outside local development.
 # The local API launcher enables this automatically for 127.0.0.1/localhost starts.
 LOCAL_AUTH_ACCEPT_ANY_CODE=0
+# Comma- or semicolon-separated account emails with internal unlimited access.
+# Use only for controlled test/operator accounts; matching is case-insensitive.
+JURISDIGTA_UNLIMITED_ACCESS_EMAILS=mmaideveloper@gmail.com
 # Secret used to sign MCP JWT bearer tokens. Set a long random value in deployed environments.
 # MCP_API_JWT_SECRET=change-this-long-random-secret
 # Hours to skip a repeat email OTP after the same MCP user successfully verifies one.

--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -422,6 +422,13 @@ same `x-api-key` guard as the chat endpoints.
   - monthly plans start a 30-day window when status changes to `paid`
   - queues an email for every subscription status change (including payment failure)
 
+Privileged test/operator accounts can bypass subscription case count, document upload,
+and free-plan case TTL restrictions through `JURISDIGTA_UNLIMITED_ACCESS_EMAILS`.
+The value is a comma- or semicolon-separated email allowlist, matched
+case-insensitively, and defaults to `mmaideveloper@gmail.com`. Treat this as
+privileged access configuration: keep the list small, review it during deployments,
+and do not use it for normal customer entitlements.
+
 Generated chat documents can also be sent by email through
 `POST /v1/chat/sessions/{session_id}/documents/send-email`. Omit `recipient` to use the
 signed-in user's profile email. The first call with `confirmed=false` returns the email address

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260467"
+version = "1.0.260468"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_case_documents_processing.py
+++ b/api/aijuristiction-api/tests/test_case_documents_processing.py
@@ -226,14 +226,15 @@ def test_case_document_upload_processes_immediately_by_default(monkeypatch, tmp_
     assert upload.json()["unprocessed_document_count"] == 0
 
 
-def test_whitelisted_phone_gets_extended_free_document_limit(monkeypatch, tmp_path) -> None:
+def test_unlimited_access_email_bypasses_free_document_limit(monkeypatch, tmp_path) -> None:
     _configure(monkeypatch, tmp_path)
+    monkeypatch.setenv("JURISDIGTA_UNLIMITED_ACCESS_EMAILS", "test-email@example.com")
     client = TestClient(app)
-    user_id = _create_user(client, "+421944400166", "test-phone@example.com")
+    user_id = _create_user(client, "+421944400166", "test-email@example.com")
     case_id = client.post(
         "/v1/cases",
         headers=_headers(),
-        json={"user_id": user_id, "title": "Premium by phone"},
+        json={"user_id": user_id, "title": "Unlimited by email"},
     ).json()["case_id"]
 
     files = [("files", (f"doc-{index}.txt", f"evidence-{index}".encode(), "text/plain")) for index in range(3)]
@@ -247,7 +248,7 @@ def test_whitelisted_phone_gets_extended_free_document_limit(monkeypatch, tmp_pa
 
     store = ApiDatabaseStore.from_env()
     store.initialize()
-    assert store.get_document_upload_limit(user_id=user_id) == 50
+    assert store.get_document_upload_limit(user_id=user_id) > 1_000_000
 
 
 def test_chunk_retrieval_adds_relevant_document_excerpt_to_prompt_context(monkeypatch, tmp_path) -> None:

--- a/api/aijuristiction-api/tests/test_cases.py
+++ b/api/aijuristiction-api/tests/test_cases.py
@@ -75,6 +75,39 @@ def test_case_lifecycle_and_limit(monkeypatch, tmp_path) -> None:
     assert listing.json() == []
 
 
+def test_unlimited_access_email_bypasses_case_limit(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("DB_OPTION", "local")
+    monkeypatch.setenv("STORAGE_OPTION", "local")
+    monkeypatch.setenv("DB_LOCAL", str(tmp_path / "api.sqlite3"))
+    monkeypatch.setenv("STORE_LOCAL", str(tmp_path / "storage"))
+    monkeypatch.setenv("JURISDIGTA_UNLIMITED_ACCESS_EMAILS", "mmaideveloper@gmail.com")
+
+    client = TestClient(app)
+    response = client.post(
+        "/v1/users/sign-up",
+        headers=_headers(),
+        json={
+            "phone_number": "+421900000370",
+            "email": "mmaideveloper@gmail.com",
+            "password": "secret",
+        },
+    )
+    assert response.status_code == 201
+    user_id = response.json()["user_id"]
+
+    for index in range(3):
+        created = client.post(
+            "/v1/cases",
+            headers=_headers(),
+            json={"user_id": user_id, "title": f"Unlimited case {index}"},
+        )
+        assert created.status_code == 201
+
+    listing = client.get(f"/v1/cases?user_id={user_id}", headers=_headers())
+    assert listing.status_code == 200
+    assert len(listing.json()) == 3
+
+
 def test_free_case_becomes_readonly_after_one_day(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("DB_OPTION", "local")
     monkeypatch.setenv("STORAGE_OPTION", "local")

--- a/docs/API_DATABASE_LAYER.md
+++ b/docs/API_DATABASE_LAYER.md
@@ -146,13 +146,20 @@ DB_OPTION=postgres DB_CLOUD=postgresql://postgres:postgres@localhost:5432/aijuri
 
 The API database now seeds four subscription plans and tracks user subscription lifecycle:
 
-- `free` (`none`): assigned on sign-up, max 5 cases, 1 day case TTL.
+- `free` (`none`): assigned on sign-up, max 1 case, 1 day case TTL.
 - `case` (`perCase`): €10, max 1 case, unlimited case time, assigned to user/case usage.
 - `basic` (`monthly`): €30/month, max 10 cases.
 - `premium` (`monthly`): €100/month, max 100 cases.
 
 Status model: `pending`, `paying`, `paid`, `canceled`, `expired`.
 For monthly plans, `starts_at` and `ends_at` are set when status switches to `paid`.
+
+`JURISDIGTA_UNLIMITED_ACCESS_EMAILS` defines a comma- or semicolon-separated
+case-insensitive allowlist for controlled test/operator accounts. Allowlisted users
+receive an internal synthetic `unlimited` plan at runtime so case-count limits,
+document-upload limits, and free-plan write TTL restrictions do not apply. The
+setting defaults to `mmaideveloper@gmail.com` and should stay limited to explicitly
+approved accounts for GDPR/EU AI Act traceability and human-oversight controls.
 
 Minimal runnable example:
 

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -111,6 +111,7 @@ These are used by infrastructure deployment and API deployment workflows:
 | `AZURE_OPENAI_DEPLOYMENT` | Azure OpenAI chat deployment name used by the API |
 | `AZURE_OPENAI_EMBEDDINGS_MODEL` | Azure OpenAI embedding deployment name used for document chunk embeddings, recommended `text-embedding-3-large` |
 | `AZURE_OPENAI_API_VERSION` | Azure OpenAI API version, keep aligned with `.env.example` unless you intentionally upgrade |
+| `JURISDIGTA_UNLIMITED_ACCESS_EMAILS` | Privileged comma- or semicolon-separated email allowlist for controlled test/operator accounts with unlimited case/document access; default `mmaideveloper@gmail.com` |
 | `AZURE_POSTGRES_SERVER_NAME` | Azure PostgreSQL Flexible Server name |
 | `AZURE_POSTGRES_DATABASE_NAME` | API database name |
 | `AZURE_POSTGRES_ADMIN_USERNAME` | PostgreSQL admin login |
@@ -389,6 +390,7 @@ Server-local `jurisdigta.env` must include at least:
 - `INTERNAL_MCP_BASE_URL=http://jurisdigta-mcp:8070` is injected by the self-managed deploy script for the API container; it normally does not need to be stored in the GitHub Environment.
 - `MCP_OAUTH_ALLOWED_REDIRECT_HOSTS=chatgpt.com,chat.openai.com,claude.ai`
 - `MCP_OTP_REUSE_WINDOW_HOURS=24`
+- `JURISDIGTA_UNLIMITED_ACCESS_EMAILS=mmaideveloper@gmail.com`
 - `DOCUMENT_PROCESSOR_OPTION=azure`
 - `DOCUMENT_PROCESSOR_MAX_RUNNING_TIME=15` or another bounded runtime in minutes
 - email/Turnstile settings when those production features are enabled

--- a/docs/manual_infrastucture_setup.md
+++ b/docs/manual_infrastucture_setup.md
@@ -307,6 +307,7 @@ If the repository is not cloned yet, run the same script from a temporary copy o
 - Required Azure Foundry values when `LLM_PROVIDER=azurefoundry`: `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT`, `AZURE_OPENAI_EMBEDDINGS_MODEL`, `AZURE_OPENAI_API_VERSION`, and `AZURE_OPENAI_API_KEY`.
 - PostgreSQL usernames, passwords, and connection strings must remain server-local or in a secret manager.
 - Required MCP OAuth values in `/srv/jurisdigta/secrets/jurisdigta.env`: `MCP_API_JWT_SECRET`, `MCP_PUBLIC_BASE_URL=https://mcp.jurisdigta.eu`, `MCP_OAUTH_ALLOWED_REDIRECT_HOSTS=chatgpt.com,chat.openai.com,claude.ai`, and `MCP_OTP_REUSE_WINDOW_HOURS=24`.
+- Required privileged test-account value in `/srv/jurisdigta/secrets/jurisdigta.env`: `JURISDIGTA_UNLIMITED_ACCESS_EMAILS=mmaideveloper@gmail.com`. Keep this allowlist restricted to approved test/operator accounts, validate it before deploy, and roll back by removing the email from the server-local env file and redeploying/restarting the API.
 - The self-managed deploy script injects `INTERNAL_MCP_BASE_URL=http://jurisdigta-mcp:8070` into the API container so internal assistant law lookups call the dedicated MCP service over the Docker network.
 - Public DNS/TLS values may include `jurisdigta.eu`, `www.jurisdigta.eu`, `api.jurisdigta.eu`, `web.jurisdigta.eu`, `agent.jurisdigta.eu`, `services.jurisdigta.eu`, and `admin.jurisdigta.eu`.
 - Server-local laws collector cron wrapper path: `/srv/jurisdigta/ops/run_laws_collector_daily.sh`.

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -1,4 +1,5 @@
 from aijurisdictionagents.agents.audio_action_tools import AIAudioToolRecognizerAgent
+from aijurisdictionagents.api_db import ApiDatabaseStore
 
 agent = AIAudioToolRecognizerAgent()
 print("speechtype default => message (review STT transcript before send)")
@@ -21,4 +22,8 @@ print(
 print(
     "mcp_wire_logging => MCP HTTP middleware logs redacted request/response envelopes; "
     "set MCP_WIRE_LOGGING_ENABLED=false to disable or MCP_WIRE_LOG_MAX_BYTES to adjust preview size."
+)
+print(
+    "unlimited_access_emails => "
+    f"{sorted(ApiDatabaseStore.unlimited_access_email_allowlist())}"
 )

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260388"
+__version__ = "1.0.260389"

--- a/src/aijurisdictionagents/api_db/store.py
+++ b/src/aijurisdictionagents/api_db/store.py
@@ -22,6 +22,9 @@ except ImportError:  # pragma: no cover - optional dependency
 
 from .config import ApiDataConfig
 
+DEFAULT_UNLIMITED_ACCESS_EMAILS = ("mmaideveloper@gmail.com",)
+UNLIMITED_ACCESS_LIMIT = 2_147_483_647
+
 
 @dataclass(frozen=True)
 class User:
@@ -1577,6 +1580,28 @@ class ApiDatabaseStore:
             )
         return int(row[0]) if row else 0
 
+    @staticmethod
+    def unlimited_access_email_allowlist() -> set[str]:
+        raw_value = os.getenv("JURISDIGTA_UNLIMITED_ACCESS_EMAILS")
+        if raw_value is None:
+            return set(DEFAULT_UNLIMITED_ACCESS_EMAILS)
+        normalized = raw_value.strip()
+        if normalized.lower() == "unknown-variable":
+            return set(DEFAULT_UNLIMITED_ACCESS_EMAILS)
+        if not normalized:
+            return set()
+        return {
+            chunk.strip().lower()
+            for chunk in normalized.replace(";", ",").split(",")
+            if chunk.strip()
+        }
+
+    def has_unlimited_access(self, *, user_id: str) -> bool:
+        user = self.find_user_by_id(user_id=user_id)
+        if user is None:
+            return False
+        return user.email.strip().lower() in self.unlimited_access_email_allowlist()
+
     def get_case_limit(self, *, user_id: str) -> int:
         return self.get_effective_subscription_plan(user_id=user_id).max_cases
 
@@ -1903,6 +1928,16 @@ class ApiDatabaseStore:
         return int(row[0]) if row else 0
 
     def get_effective_subscription_plan(self, *, user_id: str) -> SubscriptionPlan:
+        if self.has_unlimited_access(user_id=user_id):
+            return SubscriptionPlan(
+                "unlimited",
+                "Unlimited Access",
+                "internal",
+                0,
+                UNLIMITED_ACCESS_LIMIT,
+                UNLIMITED_ACCESS_LIMIT,
+                None,
+            )
         with self._connect() as conn:
             row = self._fetchone(
                 conn,
@@ -1922,9 +1957,6 @@ class ApiDatabaseStore:
         return _row_to_subscription_plan(row)
 
     def get_document_upload_limit(self, *, user_id: str) -> int:
-        user = self.find_user_by_id(user_id=user_id)
-        if user and (user.phone_number or '').strip() == '+421944400166':
-            return 50
         return self.get_effective_subscription_plan(user_id=user_id).max_documents_per_case
 
     def list_unprocessed_case_documents(self, *, limit: int = 20) -> list[CaseDocument]:

--- a/tests/test_api_database_layer.py
+++ b/tests/test_api_database_layer.py
@@ -238,6 +238,32 @@ def test_postgres_store_init_does_not_create_local_dirs(tmp_path: Path) -> None:
     assert not blob_root.exists()
 
 
+def test_default_unlimited_access_email_gets_internal_unlimited_plan(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("JURISDIGTA_UNLIMITED_ACCESS_EMAILS", raising=False)
+    db_path = tmp_path / "api.sqlite3"
+    store = ApiDatabaseStore(
+        db_path=db_path,
+        blob_root=tmp_path / "blob",
+    )
+    store.initialize()
+    user = store.create_user(
+        phone_number="+421900370370",
+        email="MMAIDEVELOPER@GMAIL.COM",
+        password="secret",
+    )
+
+    plan = store.get_effective_subscription_plan(user_id=user.user_id)
+
+    assert plan.plan_code == "unlimited"
+    assert plan.max_cases > 1_000_000
+    assert plan.max_documents_per_case > 1_000_000
+    assert plan.case_ttl_days is None
+    case = store.create_case(user_id=user.user_id, company_id=None, title="Unlimited access")
+    assert store.get_case_write_block_reason(case_id=case.case_id, user_id=user.user_id) is None
+
+
 def test_list_unprocessed_case_documents_includes_chat_attachments(tmp_path: Path) -> None:
     store = ApiDatabaseStore(
         db_path=tmp_path / "api.sqlite3",


### PR DESCRIPTION
## Summary
- add env-driven unlimited access email allowlist with mmaideveloper@gmail.com as the default
- apply the allowlist through the API subscription plan layer so case limits, document limits, and free-plan TTL restrictions are bypassed for listed accounts
- document local/test/prod/self-managed configuration and update the minimal demo

## Compliance
- keeps the privileged exception data-minimized to normalized email addresses from configuration
- documents that the allowlist is only for controlled test/operator accounts and should remain restricted for GDPR/EU AI Act traceability and human oversight

## Validation
- ruff check app tests
- mypy app
- .\\scripts\\validate_api.ps1
- python -m pytest api\\aijuristiction-api\\tests\\test_cases.py api\\aijuristiction-api\\tests\\test_case_documents_processing.py tests\\test_api_database_layer.py
- python examples\\minimal_demo.py

Note: the full API suite timed out locally after 304s in this worktree; the modified test files passed, and the required API lint/type validation passed.