### PR TITLE
Implement service health contracts

### DIFF
--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -264,7 +264,15 @@ If you want only the database container or the repository database rules, use `d
 - `POST /v1/users/sign-in/phone`
 - `PATCH /v1/users/{user_id}`
 
-`GET /health` now verifies the configured API database connection before returning healthy.
+`GET /health` verifies the configured API database connection before returning healthy.
+Healthy responses include `status=ok`, `service=aijuristiction-api`,
+`llm.status`, and `database.status`. Database failures return HTTP 503 with
+`error=database_unavailable` and a sanitized message that does not echo
+connection strings, credentials, raw exception text, prompts, documents, email
+addresses, or generated legal output.
+
+See `docs/SERVICE_HEALTHCHECKS.md` for the reusable health-check rule across
+HTTP services and background workers.
 If the database is unreachable or misconfigured, the endpoint returns `503` with
 `error=database_unavailable` and a `message` field that the mobile app can show directly.
 The response also reports the configured LLM provider so callers can distinguish `mock`

--- a/api/aijuristiction-api/app/main.py
+++ b/api/aijuristiction-api/app/main.py
@@ -120,6 +120,19 @@ def _llm_health_payload() -> dict[str, str]:
     return payload
 
 
+def _database_health_error_payload(*, backend: str) -> dict[str, Any]:
+    return {
+        "status": "error",
+        "service": "aijuristiction-api",
+        "error": "database_unavailable",
+        "message": f'Database health check failed for backend "{backend}".',
+        "database": {
+            "status": "error",
+            "backend": backend,
+        },
+    }
+
+
 def _law_snapshot_payload(*, country_code: str | None) -> dict[str, Any]:
     snapshot = get_law_knowledge_snapshot(country_code)
     return {
@@ -342,27 +355,21 @@ def health() -> JSONResponse:
         database_backend = store.db_option
         store.check_connection()
     except Exception as exc:
-        message = (
-            f"Database health check failed for backend "
-            f'"{database_backend}": {exc}'
+        logger.warning(
+            'Database health check failed for backend "%s": %s',
+            database_backend,
+            exc.__class__.__name__,
         )
-        logger.warning(message)
+        payload = _database_health_error_payload(backend=database_backend)
+        payload["llm"] = llm_payload
         return JSONResponse(
             status_code=503,
-            content={
-                "status": "error",
-                "error": "database_unavailable",
-                "message": message,
-                "llm": llm_payload,
-                "database": {
-                    "status": "error",
-                    "backend": database_backend,
-                },
-            },
+            content=payload,
         )
     return JSONResponse(
         {
             "status": "ok",
+            "service": "aijuristiction-api",
             "llm": llm_payload,
             "database": {
                 "status": "ok",

--- a/api/aijuristiction-api/app/mcp_main.py
+++ b/api/aijuristiction-api/app/mcp_main.py
@@ -277,6 +277,19 @@ def _law_snapshot_payload(*, country_code: str | None) -> dict[str, Any]:
     }
 
 
+def _database_health_error_payload(*, backend: str) -> dict[str, Any]:
+    return {
+        "status": "error",
+        "service": "jurisdigta-mcp-server",
+        "error": "database_unavailable",
+        "message": f'Database health check failed for backend "{backend}".',
+        "database": {
+            "status": "error",
+            "backend": backend,
+        },
+    }
+
+
 def _public_base_url(request: fastapi.Request) -> str:
     forwarded_proto = request.headers.get("x-forwarded-proto")
     forwarded_host = request.headers.get("x-forwarded-host") or request.headers.get("host")
@@ -626,19 +639,14 @@ def health() -> JSONResponse:
         database_backend = store.db_option
         store.check_connection()
     except Exception as exc:
-        message = f'Database health check failed for backend "{database_backend}": {exc}'
-        logger.warning(message)
+        logger.warning(
+            'MCP database health check failed for backend "%s": %s',
+            database_backend,
+            exc.__class__.__name__,
+        )
         return JSONResponse(
             status_code=503,
-            content={
-                "status": "error",
-                "error": "database_unavailable",
-                "message": message,
-                "database": {
-                    "status": "error",
-                    "backend": database_backend,
-                },
-            },
+            content=_database_health_error_payload(backend=database_backend),
         )
     return JSONResponse(
         {

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260470"
+version = "1.0.260471"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_health.py
+++ b/api/aijuristiction-api/tests/test_health.py
@@ -20,7 +20,9 @@ class _UnhealthyStore:
     db_option = "azure"
 
     def check_connection(self) -> None:
-        raise RuntimeError("password authentication failed")
+        raise RuntimeError(
+            "password authentication failed for postgresql://user:secret-token@example/db"
+        )
 
 
 def test_health_endpoint(monkeypatch) -> None:
@@ -30,6 +32,7 @@ def test_health_endpoint(monkeypatch) -> None:
     assert response.status_code == 200
     assert response.json() == {
         "status": "ok",
+        "service": "aijuristiction-api",
         "llm": {
             "status": "ok",
             "provider": "mock",
@@ -60,7 +63,11 @@ def test_health_endpoint_reports_database_failure(monkeypatch) -> None:
     payload = response.json()
     assert payload["status"] == "error"
     assert payload["error"] == "database_unavailable"
-    assert "password authentication failed" in payload["message"]
+    assert payload["service"] == "aijuristiction-api"
+    assert payload["message"] == 'Database health check failed for backend "azure".'
+    assert "secret-token" not in response.text
+    assert "postgresql://" not in response.text
+    assert "password authentication failed" not in response.text
     assert payload["llm"] == {
         "status": "ok",
         "provider": "mock",

--- a/api/aijuristiction-api/tests/test_mcp_service.py
+++ b/api/aijuristiction-api/tests/test_mcp_service.py
@@ -19,7 +19,7 @@ class _UnhealthyStore:
     db_option = "postgres"
 
     def check_connection(self) -> None:
-        raise RuntimeError("connection refused")
+        raise RuntimeError("connection refused for postgresql://user:token@example/db")
 
 
 def test_mcp_health_endpoint(monkeypatch) -> None:
@@ -43,7 +43,11 @@ def test_mcp_health_endpoint_reports_database_failure(monkeypatch) -> None:
     payload = response.json()
     assert payload["status"] == "error"
     assert payload["error"] == "database_unavailable"
-    assert "connection refused" in payload["message"]
+    assert payload["service"] == "jurisdigta-mcp-server"
+    assert payload["message"] == 'Database health check failed for backend "postgres".'
+    assert "token" not in response.text
+    assert "postgresql://" not in response.text
+    assert "connection refused" not in response.text
     assert payload["database"] == {
         "status": "error",
         "backend": "postgres",

--- a/docs/SERVICE_HEALTHCHECKS.md
+++ b/docs/SERVICE_HEALTHCHECKS.md
@@ -1,0 +1,59 @@
+# Service Health Checks
+
+JurisDigta services use two health models. The goal is fast operational triage
+without exposing personal data, legal documents, prompts, generated legal
+outputs, credentials, or raw dependency errors.
+
+## Rule For New Services
+
+- New HTTP-serving services must expose `GET /health`.
+- New worker, scheduler, or batch services must expose supervisor health plus
+  freshness, heartbeat, latest run result, and sanitized error status through an
+  internal/protected status path. Do not make a worker public only to add
+  `/health`.
+- Public health payloads must be privacy-minimized. They may include service
+  name, overall status, dependency names, dependency status, and coarse backend
+  names. They must not include exception traces, connection strings, tokens,
+  user identifiers, emails, prompts, document text, or generated legal output.
+- Critical dependency failure should return HTTP 503 for HTTP services. Optional
+  dependency failure should report `degraded` in the protected aggregate status.
+- Legal-risk freshness checks must stay visible to operators so stale laws,
+  failed document processing, or failed email jobs can be reviewed by a human.
+
+## Current Contracts
+
+| Service | Contract | Exposure | Healthy Signal | Failure Signal |
+| --- | --- | --- | --- | --- |
+| API | `GET /health` | Public | HTTP 200, `status=ok`, `service=aijuristiction-api`, `llm.status=ok`, `database.status=ok` | HTTP 503 when the database check fails; unsupported LLM provider reports `llm.status=error` |
+| MCP | `GET /health` | Public | HTTP 200, `status=ok`, `service=jurisdigta-mcp-server`, `database.status=ok` | HTTP 503 when the database check fails |
+| Web frontend | `GET /health` | Public | HTTP 200 with body `ok` | Non-2xx or missing body |
+| Chat simulator | `GET /health` | Local/dev | HTTP 200 health before simulator flows | Non-2xx startup failure |
+| Document engine API | `GET /health` | Loopback/private network only | HTTP 200, `service=document-engine-service`, `database.status=ok` | HTTP 503 when the database check fails |
+| Document engine worker | Supervisor/container state and lifecycle tests | Internal only | Worker process running and request lifecycle tests pass | Container not running, failed lifecycle tests, or protected status error |
+| Laws collector | Protected `/v1/system/status`, `/version` freshness fields, logs, and metrics | Protected/internal | Recent successful run, latest processed law, next law, up-to-date terminal log | Stale run, import error, error count, or freshness SLA breach |
+| Document processor | Protected `/v1/system/status`, logs, and metrics | Protected/internal | Recent scheduled run, processed/failed counts, sanitized summary | Stale run, repeated failure, or failed-document count breach |
+| Email scheduler | Protected `/v1/system/status`, logs, and metrics | Protected/internal | Enabled/disabled state, recent run result, processed count | Stale run, SMTP/API failure, or sanitized error count |
+
+## Minimal Verification
+
+Run the local API health contract:
+
+```bash
+python examples/minimal_demo.py
+```
+
+Run targeted tests after health contract changes:
+
+```bash
+cd api/aijuristiction-api
+ruff check app tests
+mypy app
+cd ../..
+./conda/python.exe -m pytest api/aijuristiction-api/tests/test_health.py api/aijuristiction-api/tests/test_mcp_service.py
+cd services/document-engine-service
+python -m pytest tests/test_api_health.py tests/test_lifecycle.py
+```
+
+For production, keep public checks limited to externally reachable services and
+verify worker health through `/v1/system/status`, Prometheus metrics, container
+state, and sanitized logs.

--- a/docs/SYSTEM_STATUS_MONITORING.md
+++ b/docs/SYSTEM_STATUS_MONITORING.md
@@ -48,6 +48,15 @@ credentials. If the token is unset, the endpoint falls back to the normal
 - Logs can support traceability and human oversight, but monitoring payloads should stay minimal and redacted.
 - The laws collector freshness status is an operational safeguard because stale legal corpus data can affect legal-risk outputs.
 
+## Service Health Model
+
+HTTP-serving services provide `GET /health` for lightweight readiness and
+dependency checks. Worker and scheduler services use supervisor/container state,
+freshness timestamps, latest run result, error counts, and sanitized logs through
+this protected status model instead of public worker health endpoints. See
+`docs/SERVICE_HEALTHCHECKS.md` for the reusable rule and the current service
+contracts.
+
 ## Server Status Writer
 
 On `jurisdigta-server`, write host/container status every minute:

--- a/docs/manual_infrastucture_setup.md
+++ b/docs/manual_infrastucture_setup.md
@@ -320,6 +320,11 @@ If the repository is not cloned yet, run the same script from a temporary copy o
 - Production API document processing mode: `DOCUMENT_PROCESSOR_OPTION=azure`.
 - Server-local status file path: `/srv/jurisdigta/runs/status/system-status.json`.
 - API status endpoint: `GET /v1/system/status?minutes=60`, protected by `x-api-key`.
+- Service health rule: HTTP-serving services expose privacy-minimized
+  `GET /health`; worker and scheduled services report supervisor state,
+  freshness, latest run result, and sanitized errors through protected status
+  and monitoring paths. Do not publish worker-only services just to expose
+  health checks.
 - Optional Prometheus exporter path: `/srv/jurisdigta/app/scripts/server/export_system_status_metrics.py`.
 - Optional Prometheus exporter port: `127.0.0.1:9108`.
 - Optional monitoring stack path: `/srv/jurisdigta/app/Deployment/monitoring`.

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -31,3 +31,8 @@ print(
     "unlimited_access_emails => "
     f"{sorted(ApiDatabaseStore.unlimited_access_email_allowlist())}"
 )
+print(
+    "service_healthchecks => HTTP services expose privacy-minimized /health; "
+    "worker services report supervisor state, freshness, latest run result, "
+    "and sanitized errors through protected operational status."
+)

--- a/services/document-engine-service/README.md
+++ b/services/document-engine-service/README.md
@@ -119,11 +119,33 @@ The self-managed production API is intentionally bound to loopback only:
 http://127.0.0.1:8060/health
 ```
 
+The health response checks database connectivity and returns only
+privacy-minimized operational fields:
+
+```json
+{
+  "status": "ok",
+  "service": "document-engine-service",
+  "database": {
+    "status": "ok",
+    "backend": "postgresql"
+  }
+}
+```
+
+If the database is unavailable, `/health` returns HTTP 503 with
+`error=database_unavailable` and a sanitized message. It does not echo
+connection strings, credentials, document payloads, or raw exception text.
+
 Do not publish the document engine directly to a public hostname in the current
 phase. It has no standalone end-user authentication, rate limiting, or public
 audit boundary. Public document workflows should go through the main JurisDigta
 API, which can enforce user auth, authorization, request validation, audit
 events, and retention policy before delegating to this private service.
+
+The document-engine worker does not expose a public HTTP health endpoint. Monitor
+it through container/supervisor state, worker lifecycle tests, request status
+counts, and the protected aggregate JurisDigta system status.
 
 ## Recommendations
 

--- a/services/document-engine-service/src/document_engine/api.py
+++ b/services/document-engine-service/src/document_engine/api.py
@@ -1,7 +1,12 @@
+import logging
+
 from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from document_engine.db import get_session, init_db
+from document_engine.config import settings
+from document_engine.db import engine, get_session, init_db
 from document_engine.repository import create_request, get_request
 from document_engine.schemas import (
     CreateDocumentRequest,
@@ -11,6 +16,11 @@ from document_engine.schemas import (
 
 
 app = FastAPI(title="Document Engine Service", version="0.1.0")
+logger = logging.getLogger("document-engine-service.http")
+
+
+def _database_backend() -> str:
+    return settings.database_url.split(":", 1)[0] or "unknown"
 
 
 @app.on_event("startup")
@@ -19,8 +29,38 @@ def startup() -> None:
 
 
 @app.get("/health", response_model=HealthResponse)
-def health() -> HealthResponse:
-    return HealthResponse(status="ok")
+def health() -> HealthResponse | JSONResponse:
+    database_backend = _database_backend()
+    try:
+        with engine.connect() as connection:
+            connection.execute(text("SELECT 1"))
+    except Exception as exc:
+        logger.warning(
+            'Document engine database health check failed for backend "%s": %s',
+            database_backend,
+            exc.__class__.__name__,
+        )
+        return JSONResponse(
+            status_code=503,
+            content={
+                "status": "error",
+                "service": "document-engine-service",
+                "error": "database_unavailable",
+                "message": f'Database health check failed for backend "{database_backend}".',
+                "database": {
+                    "status": "error",
+                    "backend": database_backend,
+                },
+            },
+        )
+    return HealthResponse(
+        status="ok",
+        service="document-engine-service",
+        database={
+            "status": "ok",
+            "backend": database_backend,
+        },
+    )
 
 
 @app.post(

--- a/services/document-engine-service/src/document_engine/schemas.py
+++ b/services/document-engine-service/src/document_engine/schemas.py
@@ -30,3 +30,5 @@ class DocumentRequestResponse(BaseModel):
 
 class HealthResponse(BaseModel):
     status: str
+    service: str
+    database: dict[str, str]

--- a/services/document-engine-service/tests/test_api_health.py
+++ b/services/document-engine-service/tests/test_api_health.py
@@ -1,0 +1,46 @@
+from fastapi.testclient import TestClient
+
+from document_engine.api import app
+
+
+client = TestClient(app)
+
+
+class _BrokenEngine:
+    def connect(self) -> "_BrokenEngine":
+        raise RuntimeError("database password leaked in postgresql://user:secret@example/db")
+
+
+def test_health_reports_database_status() -> None:
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "service": "document-engine-service",
+        "database": {
+            "status": "ok",
+            "backend": "sqlite",
+        },
+    }
+
+
+def test_health_sanitizes_database_failure(monkeypatch) -> None:
+    monkeypatch.setattr("document_engine.api.engine", _BrokenEngine())
+
+    response = client.get("/health")
+
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload == {
+        "status": "error",
+        "service": "document-engine-service",
+        "error": "database_unavailable",
+        "message": 'Database health check failed for backend "sqlite".',
+        "database": {
+            "status": "error",
+            "backend": "sqlite",
+        },
+    }
+    assert "secret" not in response.text
+    assert "postgresql://" not in response.text


### PR DESCRIPTION
## Summary
- sanitize API and MCP public health failure payloads so dependency errors do not echo credentials, connection strings, or raw exception text
- add database-aware document-engine API `/health` with 503 failure behavior and tests
- document the reusable HTTP-service vs worker-health rule and update the minimal demo

## Validation
- `scripts\validate_api.ps1` with `C:\Users\maton\Projects\aijurisdictionagents\conda` prepended to PATH
- `python -m pytest tests\test_health.py tests\test_mcp_service.py` from `api/aijuristiction-api`
- `python -m pytest tests --ignore=tests\test_chat.py` from `api/aijuristiction-api` (`146 passed`)
- `python -m pytest tests/test_api_health.py tests/test_lifecycle.py` from `services/document-engine-service`
- `python -m pytest tests\test_server_monitoring.py tests\test_self_managed_deploy_script.py`
- `python examples\minimal_demo.py`
- `git diff --check`

## Notes
- Full `api/aijuristiction-api/tests/test_chat.py` was run separately and timed out after 5 minutes without useful output. This branch does not touch chat behavior.

Closes #372