### PR TITLE
Add task worktree conda bootstrap helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ API validation rule:
 
 Ask for implementation of task. Create for each task separate branch.
 For every separate task, bug, or product change, create a separate Git branch and a separate Git worktree before editing files. Do not reuse one checkout or shared working directory for multiple independent tasks.
+When creating a new task worktree, use `.\scripts\new_task_worktree.ps1` from an existing repo checkout instead of raw `git worktree add` whenever possible. The helper creates the branch/worktree and bootstraps the local `.\conda` environment from `environment.yml`, so API validation scripts can run inside the new worktree.
 Do not implement multiple tasks, bugs, experiments, or unrelated product changes in the same branch or worktree.
 Before starting work, check the current branch and `git status`; if the branch or worktree already contains changes for another task, stop and create a new branch and worktree from the correct base branch instead of continuing there.
 If a change grows into a second independent task, stop, leave the first task isolated, and move the second task into its own branch and worktree.

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -12,6 +12,31 @@ conda env create -f environment.yml -p ./.conda
 conda activate ./.conda
 ```
 
+## Create a task worktree with a local environment
+
+When starting a new Codex task, create the branch and worktree through the helper
+so the new checkout also contains its own ignored `conda/` environment:
+
+```powershell
+.\scripts\new_task_worktree.ps1 `
+  -Branch codex/issue-123-short-name `
+  -WorktreePath C:\Users\maton\.codex\worktrees\issue-123-short-name\aijurisdictionagents
+```
+
+The helper runs `git worktree add`, then creates `conda/` from `environment.yml`.
+After it finishes, run API validation from inside the new worktree:
+
+```powershell
+cd C:\Users\maton\.codex\worktrees\issue-123-short-name\aijurisdictionagents
+.\scripts\validate_api.ps1
+.\conda\python.exe -m pytest api\aijuristiction-api\tests
+```
+
+If `conda` is not on `PATH`, pass `-CondaExecutable` with the full path to
+`conda.exe`. Use `-CloneEnvFrom` only when you intentionally want to clone an
+existing conda prefix; the helper refreshes editable installs afterward so they
+point at the new worktree.
+
 ## Open the workspace
 
 Open the workspace file (recommended):

--- a/scripts/new_task_worktree.ps1
+++ b/scripts/new_task_worktree.ps1
@@ -1,0 +1,136 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Branch,
+
+    [string]$WorktreePath,
+
+    [string]$Base = "origin/main",
+
+    [ValidateSet("conda", ".conda")]
+    [string]$EnvDirectoryName = "conda",
+
+    [string]$CondaExecutable,
+
+    [string]$CloneEnvFrom,
+
+    [switch]$SkipEnvCreate
+)
+
+$ErrorActionPreference = "Stop"
+
+function Find-CondaExecutable {
+    param([string]$ExplicitPath)
+
+    if ($ExplicitPath) {
+        if (-not (Test-Path $ExplicitPath)) {
+            throw "Conda executable was not found at '$ExplicitPath'."
+        }
+        return (Resolve-Path $ExplicitPath).Path
+    }
+
+    $command = Get-Command conda -ErrorAction SilentlyContinue
+    if ($command) {
+        return $command.Source
+    }
+
+    $candidates = @(
+        "$env:USERPROFILE\miniconda3\Scripts\conda.exe",
+        "$env:USERPROFILE\anaconda3\Scripts\conda.exe",
+        "$env:ProgramData\miniconda3\Scripts\conda.exe",
+        "$env:ProgramData\anaconda3\Scripts\conda.exe"
+    )
+    foreach ($candidate in $candidates) {
+        if (Test-Path $candidate) {
+            return (Resolve-Path $candidate).Path
+        }
+    }
+
+    throw "Conda was not found. Install Miniconda/Anaconda or pass -CondaExecutable."
+}
+
+function Resolve-DefaultWorktreePath {
+    param([string]$RepoRoot, [string]$BranchName)
+
+    $slug = $BranchName -replace "^codex/", ""
+    $slug = $slug -replace "[^A-Za-z0-9._-]+", "-"
+    $slug = $slug.Trim("-")
+    if (-not $slug) {
+        $slug = "task-worktree"
+    }
+
+    $repoName = Split-Path -Leaf $RepoRoot
+    $parent = Split-Path -Parent $RepoRoot
+    if ((Split-Path -Leaf $parent) -eq "worktrees") {
+        return Join-Path $parent $slug
+    }
+    return Join-Path (Join-Path $env:USERPROFILE ".codex\worktrees\$slug") $repoName
+}
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+if (-not $WorktreePath) {
+    $WorktreePath = Resolve-DefaultWorktreePath -RepoRoot $RepoRoot -BranchName $Branch
+}
+$WorktreePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($WorktreePath)
+
+Push-Location $RepoRoot
+try {
+    git fetch origin main
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    git worktree add -b $Branch $WorktreePath $Base
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+}
+finally {
+    Pop-Location
+}
+
+if ($SkipEnvCreate) {
+    Write-Host "Created worktree at $WorktreePath. Skipped conda environment creation."
+    exit 0
+}
+
+$EnvironmentFile = Join-Path $WorktreePath "environment.yml"
+if (-not (Test-Path $EnvironmentFile)) {
+    throw "Cannot create conda environment because environment.yml was not found in $WorktreePath."
+}
+
+$Conda = Find-CondaExecutable -ExplicitPath $CondaExecutable
+$EnvPath = Join-Path $WorktreePath $EnvDirectoryName
+$PythonPath = Join-Path $EnvPath "python.exe"
+
+if (Test-Path $PythonPath) {
+    Write-Host "Conda environment already exists at $EnvPath."
+}
+elseif ($CloneEnvFrom) {
+    $ResolvedCloneSource = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($CloneEnvFrom)
+    if (-not (Test-Path (Join-Path $ResolvedCloneSource "python.exe"))) {
+        throw "Clone source '$ResolvedCloneSource' does not look like a conda prefix with python.exe."
+    }
+    & $Conda create --prefix $EnvPath --clone $ResolvedCloneSource -y
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+    & $PythonPath -m pip install -e "$WorktreePath[dev]" -e (Join-Path $WorktreePath "api\aijuristiction-api[dev]")
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+}
+else {
+    & $Conda env create --prefix $EnvPath --file $EnvironmentFile
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+}
+
+if (-not (Test-Path $PythonPath)) {
+    throw "Conda environment creation finished, but python.exe was not found at $PythonPath."
+}
+
+Write-Host "Created worktree at $WorktreePath."
+Write-Host "Conda environment ready at $EnvPath."
+Write-Host "Python: $PythonPath"
+Write-Host "Validate API with: .\scripts\validate_api.ps1"


### PR DESCRIPTION
## Summary
- Add `scripts/new_task_worktree.ps1` to create a task branch/worktree and bootstrap a local ignored `conda/` environment from `environment.yml`.
- Document the helper in `AGENTS.md` so future task worktrees use it instead of raw `git worktree add`.
- Add workspace setup docs with examples and the post-create API validation commands.

## Validation
- PowerShell parser syntax check for `scripts/new_task_worktree.ps1`: passed.
- `git diff --check`: passed.

Note: I did not run the helper end-to-end because that would create another worktree and install a full conda environment during this tooling change.
