### PR TITLE
Add weekly production readiness review automation

### DIFF
--- a/.codex/automations/jurisdigta-weekly-prod-readiness-review/automation.toml
+++ b/.codex/automations/jurisdigta-weekly-prod-readiness-review/automation.toml
@@ -1,0 +1,29 @@
+version = 1
+id = "jurisdigta-weekly-prod-readiness-review"
+kind = "cron"
+name = "JurisDigta Weekly Prod Readiness Review"
+prompt = """
+Act as the JurisDigta weekly production-readiness reviewer.
+
+Goal: inform the owner what still must be done before JurisDigta can go to production and paid public launch. Split the report into exactly these sections: Technical, Business, Legal.
+
+Required review steps:
+1. Inspect current repo docs first, especially AGENTS.md, docs/GDPR_AI_ACT_COMPLIANCE_REVIEW.md, docs/GITHUB_ENVIRONMENTS.md, docs/manual_infrastucture_setup.md, docs/SYSTEM_STATUS_MONITORING.md, API docs, deployment docs, and docs/PROD_READINESS_WEEKLY_REVIEW.md.
+2. Inspect GitHub issues and Project 5/6 status for production blockers. Include at least these known issue groups if still open: payment #363/#362, invoicing #364, user data encryption #384/#182, audit trail #206, disaster recovery #385, AI/model validation #297/#298/#301/#303, admin web #378, model-routing production validation #387, test/pre-prod environment #388, consent/DSAR/retention/transparency #389, commercial launch package #390, and Slovak legal-service positioning #391.
+3. Check whether main contains the model-router work and whether prod/test deployment evidence exists.
+4. For Business and Legal items whose requirements may have changed, use official/current sources where possible and cite links in the report.
+5. Group all findings into Technical, Business, Legal. For each blocker include status, linked issue, owner action needed, and next concrete step.
+6. If a missing production blocker has no equivalent open issue, create one GitHub issue in mmaideveloper/aijurisdictionagents, add it to Project 5 with status Ready when possible, and include it in the report. Do not create duplicates; search open and closed issues first by title and topic.
+7. Keep GDPR and EU AI Act baseline explicit: privacy by design, data minimization, consent, retention/deletion, transparency, traceable logging, and human oversight for legal-risk outputs.
+8. Keep the report concise and implementation-oriented. End with a prioritized Top 5 next actions for the week.
+
+If GitHub Project V2 access is blocked, report the exact missing scope/command needed, for example `gh auth refresh -s read:project -s project`, and still produce the readiness report from accessible repo and issue data.
+"""
+status = "ACTIVE"
+rrule = "RRULE:FREQ=WEEKLY;BYDAY=MO;BYHOUR=8;BYMINUTE=0"
+model = "gpt-5.4"
+reasoning_effort = "medium"
+execution_environment = "worktree"
+cwds = ["__REPO_ROOT__"]
+created_at = 1782453600000
+updated_at = 1782453600000

--- a/docs/CODEX_AUTOMATIONS.md
+++ b/docs/CODEX_AUTOMATIONS.md
@@ -112,6 +112,7 @@ To install into another profile or test location:
 ## Existing Automation Tasks
 
 - `implementation-agent`: active implementation worker for Project 5 ready tasks. It must first prove that `gh` can read Project V2 metadata, then select exactly one issue whose Project V2 Status is `Ready` and whose readiness section contains `Status: Ready for implementation.`. If Project V2 cannot be read, including missing `read:project` or `project` scopes, it stops instead of selecting work from issue text alone. It rechecks status before claiming, moves the task to In progress, implements the requested change, fixes required test/lint/type-check failures before review, opens a PR, comments `Implemented by Codex`, and moves successful work to In review.
+- `jurisdigta-weekly-prod-readiness-review`: active Monday morning review that reports remaining production blockers under Technical, Business, and Legal, checks GitHub issues/projects, and creates non-duplicate ready tasks for missing blockers.
 - `deployment-agent`: paused monitor that checks recent build and deployment workflow failures, deduplicates unresolved failure patterns, and creates ready GitHub tasks in the correct project.
 - `merge-agent`: paused closer that reviews open PRs, skips anything with unresolved reviews or failed/missing checks, merges safe PRs into `main`, comments on linked issues, deletes branches, and moves completed tasks to Done.
 

--- a/docs/PROD_READINESS_WEEKLY_REVIEW.md
+++ b/docs/PROD_READINESS_WEEKLY_REVIEW.md
@@ -1,0 +1,77 @@
+# JurisDigta Weekly Production Readiness Review
+
+This runbook defines the weekly production-readiness review that reports what
+still blocks JurisDigta from production and paid public launch.
+
+## Automation
+
+- Automation id: `jurisdigta-weekly-prod-readiness-review`
+- Schedule: every Monday morning at 08:00 in the local Codex runtime timezone
+- Runtime: Codex cron automation in an isolated worktree
+- Report sections: Technical, Business, Legal
+
+The automation must inspect repository documentation, GitHub issues, and Project
+5/6 status before reporting. For business or legal requirements that can change,
+it should verify official/current sources where possible.
+
+## Current Production Blocker List
+
+### Technical
+
+| Area | Issue | Required outcome |
+| --- | --- | --- |
+| AI model routing production validation | #387 | Model-router foundation is merged to `main`, tested end to end, and proven for free local-only routing, paid external routing, budget fallback, EU data-zone checks, and usage ledger metrics. |
+| Payment system | #363 / #362 | Production payment provider, webhook verification, subscription lifecycle, failed payment, cancellation, refund, VAT/tax, and checkout security are implemented and tested. |
+| Invoicing | #364 | Canonical invoice domain, UBL XML, PDF output, credit notes/corrective invoices, email transport, audit events, and future Peppol-ready boundaries are implemented. |
+| User data encryption | #384 / #182 | Encryption in transit and at rest is designed and implemented with key management that fits AI processing and user-controlled confidentiality requirements. |
+| Audit trail and correlation id | #206 / #303 | User, case, mobile, API, system, model, source, tool-call, and document-generation steps are traceable per request without leaking sensitive content. |
+| Disaster recovery | #385 | Encrypted backups, retention, restore script, restore rehearsal, RTO/RPO evidence, and monitoring status are complete. |
+| Dedicated test/pre-prod environment | #388 | A non-production environment exists with isolated data, secrets, deployment workflows, monitoring, and end-to-end validation. |
+| AI output validation | #297 / #298 / #301 | Hallucination checks, source validation, fairness/quality reports, confidence scoring, and output guardrails are implemented for legal-risk outputs. |
+| Admin web | #378 | Admin-only model routing, pricing, user-group, local-model, and audit-management UI/APIs are implemented on top of the model-router foundation. |
+
+### Business
+
+| Area | Issue | Required outcome |
+| --- | --- | --- |
+| Paid subscription commercial launch package | #390 | Pricing, plan limits, refund/cancellation policy, support/SLA, checkout wording, complaint process, and subscription operations are owner-approved and aligned with payment/invoicing. |
+| Grant and funding readiness | none yet | Track suitable Slovak/EU funding routes, prepare business plan, innovation narrative, budget, pilots, and compliance evidence before applying. Create a task when a concrete call or application target is chosen. |
+| Production operating model | linked to #385 / #388 / #390 | Define who approves releases, monitors incidents, handles user support, processes refunds, and owns legal/compliance escalations. |
+
+### Legal
+
+| Area | Issue | Required outcome |
+| --- | --- | --- |
+| Consent, DSAR, retention, and AI transparency | #389 | GDPR consent ledger, data subject rights, retention/deletion jobs, AI response transparency metadata, and compliance event logging are implemented. |
+| Slovak legal-service positioning and advertising review | #391 | JurisDigta marketing, checkout, onboarding, and product wording are reviewed so the product is not misrepresented as unauthorized lawyer representation or guaranteed legal advice. |
+| Customer-facing documents | #390 / #391 | Terms of Service, Privacy Policy, Cookie Policy, Refund/Cancellation Policy, withdrawal/withdrawal-exception wording, complaint process, and AI limitations notice are ready in SK, EN, and GE before public paid launch. |
+| Third-party processor and AI provider governance | #389 / #387 | Provider list, data-processing basis, external-model acknowledgement, EU data-zone policy, and processor records are documented and implemented. |
+
+## Weekly Report Requirements
+
+Every Monday report must include:
+
+1. Technical blockers and changed status since last review.
+2. Business blockers and any owner decisions needed.
+3. Legal blockers and any official-source changes that affect launch.
+4. Newly created GitHub tasks, if the automation found a missing blocker.
+5. Top 5 next actions for the coming week.
+
+The automation must avoid duplicate issues. It should search open and closed
+issues before creating a new blocker task, then add new tasks to Project 5 with
+status `Ready` when GitHub Project access is available.
+
+## Compliance Baseline
+
+Every production-readiness item must be evaluated against GDPR and the EU AI
+Act. The default controls are privacy by design, data minimization, explicit
+consent where required, retention/deletion controls, user transparency,
+traceable logging, and human oversight for legal-risk outputs.
+
+## Minimal Runnable Example
+
+The repository default smoke check remains:
+
+```powershell
+python examples/minimal_demo.py
+```


### PR DESCRIPTION
## Summary
- add weekly JurisDigta production-readiness Codex automation template
- document the Technical / Business / Legal production blocker review
- link newly created blocker tasks #387-#391 into the readiness checklist

## Validation
- `git diff --check`
- `.\scripts\sync_codex_automations.ps1 -DryRun`
- `$env:PYTHONPATH='src'; python examples/minimal_demo.py`

## Notes
The live app automation was also created as `jurisdigta-weekly-prod-readiness-review` and scheduled every Monday morning.