### PR TITLE
Fix Ollama systemd setup in prod deploy

### DIFF
--- a/Deployment/server/deploy_jurisdigta_prod.sh
+++ b/Deployment/server/deploy_jurisdigta_prod.sh
@@ -228,14 +228,14 @@ install_ollama_service() {
   fi
 
   log "configuring Ollama localhost bind at $OLLAMA_HOST_BIND"
-  mkdir -p /etc/systemd/system/ollama.service.d
-  cat > /etc/systemd/system/ollama.service.d/jurisdigta-localhost.conf <<EOF
+  sudo install -d -m 755 /etc/systemd/system/ollama.service.d
+  cat <<EOF | sudo tee /etc/systemd/system/ollama.service.d/jurisdigta-localhost.conf >/dev/null
 [Service]
 Environment="OLLAMA_HOST=$OLLAMA_HOST_BIND"
 EOF
-  systemctl daemon-reload
-  systemctl enable --now ollama
-  systemctl restart ollama
+  sudo systemctl daemon-reload
+  sudo systemctl enable --now ollama
+  sudo systemctl restart ollama
 
   wait_for_http "Ollama" "$LOCAL_LLM_HEALTH_URL" 30 2
   log "pulling Ollama model $LOCAL_LLM_MODEL"

--- a/docs/manual_infrastucture_setup.md
+++ b/docs/manual_infrastucture_setup.md
@@ -174,6 +174,10 @@ Purpose: prepare the Ubuntu server `jurisdigta-server` at `192.168.1.50` for SSH
 - `Test-NetConnection` from Windows returns `TcpTestSucceeded : True`.
 - `ssh jurisdigta-server` accepts the host key and logs in as `jurisdigta-admin`.
 - Non-interactive validation returns `jurisdigta-server` and `jurisdigta-admin`.
+- Production deploys that install or configure Ollama require `jurisdigta-admin`
+  to have non-interactive sudo for system package installation and systemd
+  service management, including writing
+  `/etc/systemd/system/ollama.service.d/jurisdigta-localhost.conf`.
 
 ### Rollback Notes
 

--- a/tests/test_self_managed_deploy_script.py
+++ b/tests/test_self_managed_deploy_script.py
@@ -41,6 +41,10 @@ def test_deploy_installs_ollama_and_pulls_default_model() -> None:
     assert "install_ollama_service" in script
     assert "OLLAMA_HOST_BIND must stay 127.0.0.1:11434" in script
     assert 'curl -fsSL https://ollama.com/install.sh -o "$installer"' in script
+    assert "sudo install -d -m 755 /etc/systemd/system/ollama.service.d" in script
+    assert "sudo tee /etc/systemd/system/ollama.service.d/jurisdigta-localhost.conf" in script
+    assert "sudo systemctl daemon-reload" in script
+    assert "sudo systemctl enable --now ollama" in script
     assert 'Environment="OLLAMA_HOST=$OLLAMA_HOST_BIND"' in script
     assert 'ollama pull "$LOCAL_LLM_MODEL"' in script
     assert 'ollama list | grep -F "$LOCAL_LLM_MODEL"' in script


### PR DESCRIPTION
## Summary
- Fix the self-managed prod deploy script so Ollama systemd override writes use sudo.
- Keep Ollama bound to localhost while avoiding the observed `/etc/systemd/system` permission failure.
- Document the non-interactive sudo requirement for prod deploy users.

## Validation
- `C:\Program Files\Git\bin\bash.exe -n Deployment/server/deploy_jurisdigta_prod.sh`
- `C:\Users\maton\Projects\aijurisdictionagents\conda\python.exe -m pytest tests\test_self_managed_deploy_script.py`
- `git diff --check`

## Context
Prod deploy run 28232681293 failed at `mkdir: Permission denied` while configuring `/etc/systemd/system/ollama.service.d`.