### PR TITLE
[codex] Restore formatted document preview rendering

### DIFF
--- a/api/aijuristiction-api/e2e-playwright/tests/frontend-document-preview-formatting.spec.ts
+++ b/api/aijuristiction-api/e2e-playwright/tests/frontend-document-preview-formatting.spec.ts
@@ -1,0 +1,131 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const frontendBaseURL = process.env.FRONTEND_BASE_URL;
+const authSessionKey = 'jurisdigta.web.auth.user.v1';
+const caseStorageKey = 'aijurisdictionfrontend.mock.cases.v1';
+
+const assistantDraft = `LawyerSlovakia: USERT-FACING: Pripravujem splnomocnenie pre Emiliu Testovu na pouzivanie firemneho auta firmy ESolutions SK s.r.o. s nasledujucimi udajmi:
+
+**Splnomocnenie**
+
+**Splnomocnitel:**
+Marek Matonok
+ESolutions SK s.r.o.
+Partizanska 665,
+059 18 Spisske Bystre
+
+**Splnomocnenec:**
+Emilia Testova
+
+**Predmet splnomocnenia:**
+Pouzivanie firemneho auta firmy ESolutions SK s.r.o.
+
+**SPZ vozidla:** PP472DT
+
+**Doba platnosti splnomocnenia:**
+Od 1. jula 2026 do 31. decembra 2026
+
+Datum: 25. juna 2026
+Podpis: ______________________`;
+
+async function seedAuthenticatedMockCase(page: Page) {
+  await page.route('**/v1/cases?**', async (route) => {
+    await route.fulfill({
+      status: 503,
+      contentType: 'application/json',
+      body: JSON.stringify({ detail: 'Use mock case storage for this frontend rendering test.' }),
+    });
+  });
+
+  await page.addInitScript(
+    ({ authKey, storageKey, draft }) => {
+      window.localStorage.setItem('aj_frontend_lang', 'en');
+      window.sessionStorage.setItem(
+        authKey,
+        JSON.stringify({
+          userId: 'document-preview-test-user',
+          email: 'document-preview@example.test',
+          name: 'Document Preview Test User',
+          role: 'JurisDigta user',
+        }),
+      );
+      window.localStorage.setItem(
+        storageKey,
+        JSON.stringify([
+          {
+            id: 'document-preview-case',
+            title: 'Document preview formatting bug',
+            description: 'Mock case for assistant document preview formatting.',
+            status: 'In progress',
+            createdAt: '2026-06-26T10:00:00.000Z',
+            interactionHistory: [
+              {
+                id: 'document-preview-user-message',
+                createdAt: '2026-06-26T10:00:01.000Z',
+                actor: 'You',
+                message: 'Priprav splnomocnenie pre firemne auto.',
+              },
+              {
+                id: 'document-preview-assistant-message',
+                createdAt: '2026-06-26T10:00:02.000Z',
+                actor: 'AI Lawyer',
+                message: draft,
+              },
+            ],
+            selectedRole: 'AI Lawyer',
+            selectedMode: 'Draft',
+            selectedCommunicationMode: 'Chat',
+            workspace: {
+              meta: 'SK | 0 docs',
+              objective: 'Verify assistant document preview formatting.',
+              nextAction: 'Review generated draft preview.',
+              jurisdiction: 'SK',
+              output: 'Formatted document preview',
+            },
+            jurisdiction: 'SK',
+            opposingParty: 'None',
+            documents: [],
+            source: 'mock',
+          },
+        ]),
+      );
+    },
+    { authKey: authSessionKey, storageKey: caseStorageKey, draft: assistantDraft },
+  );
+}
+
+test('assistant legal draft renders as formatted JurisDigta document preview', async ({ page }, testInfo) => {
+  test.skip(!frontendBaseURL, 'Set FRONTEND_BASE_URL to run frontend document preview checks.');
+
+  await page.setViewportSize({ width: 1146, height: 681 });
+  await seedAuthenticatedMockCase(page);
+  await page.goto(`${frontendBaseURL}/app/chat`);
+
+  const caseButton = page.locator('.case-item').filter({ hasText: 'Document preview formatting bug' }).first();
+  await expect(caseButton).toBeVisible({ timeout: 20_000 });
+  await caseButton.click();
+
+  await expect(page.getByText('Pripravujem splnomocnenie pre Emiliu Testovu')).toBeVisible();
+
+  const preview = page.locator('.assistant-document-preview').first();
+  await expect(preview).toBeVisible();
+  await expect(preview.locator('.assistant-document-preview__letterhead span')).toHaveText('JurisDigta');
+  await expect(preview.locator('.assistant-document-preview__letterhead small')).toHaveText('Document preview');
+  await expect(preview.locator('.assistant-document-preview__page-marker')).toContainText('A4 preview 1');
+  await expect(preview.getByRole('heading', { name: 'Splnomocnenie' })).toBeVisible();
+  await expect(preview).toContainText('Marek Matonok');
+  await expect(preview).toContainText('Emilia Testova');
+  await expect(preview).toContainText('PP472DT');
+  await expect(preview).not.toContainText('**');
+  await expect(page.getByText(/USER[T]?-FACING/i)).toHaveCount(0);
+  await expect(page.getByText('LawyerSlovakia')).toHaveCount(0);
+
+  const sheetBox = await preview.locator('.assistant-document-preview__sheet').boundingBox();
+  expect(sheetBox?.width ?? 0).toBeGreaterThan(520);
+  expect(sheetBox?.height ?? 0).toBeGreaterThan(500);
+
+  await testInfo.attach('jurisdigta-document-preview.png', {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: 'image/png',
+  });
+});

--- a/examples/frontend_document_preview_issue_401_minimal_demo.py
+++ b/examples/frontend_document_preview_issue_401_minimal_demo.py
@@ -1,0 +1,54 @@
+"""Minimal sanity check for issue #401 document preview formatting coverage.
+
+This does not replace the Playwright E2E test. It gives a fast local check that
+the frontend parser and E2E fixture keep the JurisDigta document-preview
+contract for assistant drafts that contain internal audience labels.
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ASSISTANT_WORKSPACE = REPO_ROOT / "frontend" / "aijurisdictionfronend" / "src" / "pages" / "AssistantWorkspace.tsx"
+E2E_SPEC = (
+    REPO_ROOT
+    / "api"
+    / "aijuristiction-api"
+    / "e2e-playwright"
+    / "tests"
+    / "frontend-document-preview-formatting.spec.ts"
+)
+
+
+def main() -> None:
+    workspace_source = ASSISTANT_WORKSPACE.read_text(encoding="utf-8")
+    e2e_source = E2E_SPEC.read_text(encoding="utf-8")
+    required_workspace_markers = [
+        "internalAudienceLabelPattern",
+        "assistantAgentPrefixPattern",
+        "documentTitlePattern",
+        "JurisDigta",
+    ]
+    required_e2e_markers = [
+        "USERT-FACING",
+        "LawyerSlovakia",
+        "assistant legal draft renders as formatted JurisDigta document preview",
+        "assistant-document-preview__sheet",
+    ]
+
+    missing = [
+        marker
+        for marker in required_workspace_markers
+        if marker not in workspace_source
+    ] + [marker for marker in required_e2e_markers if marker not in e2e_source]
+
+    if missing:
+        raise SystemExit(f"Document preview issue #401 guardrails are incomplete: {missing}")
+
+    print("Issue #401 document preview guardrails are present.")
+    print(f"Parser: {ASSISTANT_WORKSPACE.relative_to(REPO_ROOT)}")
+    print(f"E2E: {E2E_SPEC.relative_to(REPO_ROOT)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/aijurisdictionfronend/README.md
+++ b/frontend/aijurisdictionfronend/README.md
@@ -324,6 +324,19 @@ Issue #398 assistant model disclosure minimal demo:
 python examples/frontend_assistant_model_disclosure_issue_398_minimal_demo.py
 ```
 
+Issue #401 document preview formatting minimal demo:
+
+```bash
+python examples/frontend_document_preview_issue_401_minimal_demo.py
+```
+
+Issue #401 browser regression check:
+
+```bash
+cd api/aijuristiction-api/e2e-playwright
+FRONTEND_BASE_URL=http://127.0.0.1:5173 npx playwright test tests/frontend-document-preview-formatting.spec.ts
+```
+
 Issue #369 case-create layout minimal demo:
 
 ```bash

--- a/frontend/aijurisdictionfronend/src/__tests__/assistantWorkspace.test.tsx
+++ b/frontend/aijurisdictionfronend/src/__tests__/assistantWorkspace.test.tsx
@@ -393,6 +393,44 @@ Signature: ______________________`);
     expect(presentation.documentLinks).toEqual([]);
   });
 
+  it("strips internal audience labels and previews a legal draft without separators", () => {
+    const presentation = parseAssistantMessagePresentation(`LawyerSlovakia: USER-FACING: Pripravujem splnomocnenie pre Emiliu Testovu na pouzivanie firemneho auta firmy ESolutions SK s.r.o. s nasledujucimi udajmi:
+
+**Splnomocnenie**
+
+**Splnomocnitel:**
+Marek Matonok
+ESolutions SK s.r.o.
+Partizanska 665,
+059 18 Spisske Bystre
+
+**Splnomocnenec:**
+Emilia Testova
+
+**Predmet splnomocnenia:**
+Pouzivanie firemneho auta firmy ESolutions SK s.r.o.
+
+**SPZ vozidla:** PP472DT
+
+**Doba platnosti splnomocnenia:**
+Od 1. jula 2026 do 31. decembra 2026
+
+Datum: 25. juna 2026
+Podpis: ______________________`);
+
+    expect(presentation.conversationalText).toBe(
+      "Pripravujem splnomocnenie pre Emiliu Testovu na pouzivanie firemneho auta firmy ESolutions SK s.r.o. s nasledujucimi udajmi:"
+    );
+    expect(presentation.conversationalText).not.toContain("USER-FACING");
+    expect(presentation.conversationalText).not.toContain("LawyerSlovakia");
+    expect(presentation.documentPreviews).toHaveLength(1);
+    expect(presentation.documentPreviews[0]).toEqual({
+      title: "Splnomocnenie",
+      body: expect.stringContaining("Marek Matonok")
+    });
+    expect(presentation.documentPreviews[0]?.body).toContain("PP472DT");
+  });
+
   it("moves generated PDF links into separate document actions", () => {
     const presentation = parseAssistantMessagePresentation(`Splnomocnenie je pripravene.
 

--- a/frontend/aijurisdictionfronend/src/pages/AssistantWorkspace.tsx
+++ b/frontend/aijurisdictionfronend/src/pages/AssistantWorkspace.tsx
@@ -167,12 +167,29 @@ type AssistantMessagePresentation = {
 };
 
 const separatorLinePattern = /^\s*-{3,}\s*$/;
+const internalAudienceLabelPattern = /^\s*(?:USER|USERT)-FACING\s*:\s*/i;
+const assistantAgentPrefixPattern = /^\s*(?:LawyerSlovakia|[A-Za-z]+Slovakia)\s*:\s*/;
+const documentTitlePattern = /^\s*(?:#{1,4}\s+.+|\*\*(?![^*]{1,80}:\*\*$).+\*\*)\s*$/;
 
 const stripMarkdownHeading = (line: string): string =>
   line
     .trim()
     .replace(/^#{1,4}\s+/, "")
     .replace(/^\*\*(.+)\*\*$/, "$1")
+    .trim();
+
+const cleanDocumentLine = (line: string): string =>
+  stripMarkdownHeading(line).replace(/\*\*([^*]+)\*\*/g, "$1");
+
+const normalizeVisibleAssistantText = (text: string): string =>
+  text
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line, index) => {
+      const withoutAgent = index === 0 ? line.replace(assistantAgentPrefixPattern, "") : line;
+      return withoutAgent.replace(internalAudienceLabelPattern, "").trimEnd();
+    })
+    .join("\n")
     .trim();
 
 const removeInternalDocumentLinks = (text: string): { text: string; links: AssistantDocumentLink[] } => {
@@ -193,10 +210,10 @@ const removeInternalDocumentLinks = (text: string): { text: string; links: Assis
   };
 };
 
-const looksLikeDocumentPreview = (chunk: string, hasSeparators: boolean): boolean => {
+const looksLikeDocumentPreview = (chunk: string): boolean => {
   const normalized = chunk.toLowerCase();
   const firstLine = chunk.split("\n").find((line) => line.trim()) ?? "";
-  const hasDocumentHeading = /^(\*\*.+\*\*|#{1,4}\s+.+)$/.test(firstLine.trim());
+  const hasDocumentHeading = documentTitlePattern.test(firstLine.trim());
   const hasLegalBody =
     normalized.includes("podpis") ||
     normalized.includes("signature") ||
@@ -205,11 +222,46 @@ const looksLikeDocumentPreview = (chunk: string, hasSeparators: boolean): boolea
     normalized.includes("i, the undersigned") ||
     normalized.includes("ja, dolu podp\u00edsan");
 
-  return hasSeparators && hasDocumentHeading && hasLegalBody && chunk.trim().length > 120;
+  return hasDocumentHeading && hasLegalBody && chunk.trim().length > 80;
+};
+
+const splitChunkIntoPresentationParts = (chunk: string): { conversational: string[]; documents: string[] } => {
+  const lines = chunk.split("\n");
+  const documentStartIndexes = lines.reduce<number[]>((indexes, line, index) => {
+    if (documentTitlePattern.test(line.trim())) {
+      indexes.push(index);
+    }
+    return indexes;
+  }, []);
+
+  if (documentStartIndexes.length === 0) {
+    return { conversational: [chunk], documents: [] };
+  }
+
+  const conversational: string[] = [];
+  const documents: string[] = [];
+  const firstDocumentIndex = documentStartIndexes[0] ?? 0;
+  const intro = lines.slice(0, firstDocumentIndex).join("\n").trim();
+  if (intro) {
+    conversational.push(intro);
+  }
+
+  documentStartIndexes.forEach((startIndex, index) => {
+    const endIndex = documentStartIndexes[index + 1] ?? lines.length;
+    const candidate = lines.slice(startIndex, endIndex).join("\n").trim();
+    if (looksLikeDocumentPreview(candidate)) {
+      documents.push(candidate);
+    } else {
+      conversational.push(candidate);
+    }
+  });
+
+  return { conversational, documents };
 };
 
 export const parseAssistantMessagePresentation = (text: string): AssistantMessagePresentation => {
-  const { text: textWithoutLinks, links } = removeInternalDocumentLinks(text.replace(/\r\n/g, "\n"));
+  const normalizedText = normalizeVisibleAssistantText(text);
+  const { text: textWithoutLinks, links } = removeInternalDocumentLinks(normalizedText);
   if (!textWithoutLinks) {
     return {
       conversationalText: "",
@@ -227,20 +279,23 @@ export const parseAssistantMessagePresentation = (text: string): AssistantMessag
   const documentPreviews: AssistantDocumentPreview[] = [];
 
   chunks.forEach((chunk) => {
-    if (!looksLikeDocumentPreview(chunk, hasSeparators)) {
-      conversationalChunks.push(chunk);
-      return;
-    }
+    const candidateParts =
+      hasSeparators && looksLikeDocumentPreview(chunk)
+        ? { conversational: [], documents: [chunk] }
+        : splitChunkIntoPresentationParts(chunk);
 
-    const lines = chunk.split("\n");
-    const firstContentIndex = lines.findIndex((line) => line.trim());
-    const title = stripMarkdownHeading(lines[firstContentIndex] ?? "") || "Document preview";
-    const body = lines
-      .slice(firstContentIndex + 1)
-      .join("\n")
-      .trim();
+    conversationalChunks.push(...candidateParts.conversational);
+    candidateParts.documents.forEach((documentChunk) => {
+      const lines = documentChunk.split("\n");
+      const firstContentIndex = lines.findIndex((line) => line.trim());
+      const title = stripMarkdownHeading(lines[firstContentIndex] ?? "") || "Document preview";
+      const body = lines
+        .slice(firstContentIndex + 1)
+        .join("\n")
+        .trim();
 
-    documentPreviews.push({ title, body });
+      documentPreviews.push({ title, body });
+    });
   });
 
   return {
@@ -283,7 +338,7 @@ const renderDocumentBody = (body: string): React.ReactNode[] => {
     flushList();
     nodes.push(
       <p key={`paragraph-${nodes.length}`} className="assistant-document-preview__paragraph">
-        {lines.map(stripMarkdownHeading).join(" ")}
+        {lines.map(cleanDocumentLine).join(" ")}
       </p>
     );
   });

--- a/frontend/aijurisdictionfronend/src/styles/app.css
+++ b/frontend/aijurisdictionfronend/src/styles/app.css
@@ -658,7 +658,8 @@
 }
 
 .assistant-document-preview__sheet {
-  width: min(100%, 620px);
+  width: min(620px, calc(100vw - 3rem));
+  max-width: none;
   min-height: 760px;
   margin: 0 auto;
   padding: 2rem 2.2rem 2.4rem;


### PR DESCRIPTION
﻿## Summary
- Restores formatted JurisDigta A4-style document previews when assistant output contains `USER-FACING` / `USERT-FACING` wrappers or old `LawyerSlovakia` prefixes.
- Detects legal document drafts without requiring markdown separator lines, strips internal labels from visible chat text, and removes inline markdown markers from preview paragraphs.
- Adds unit coverage, a browser E2E regression, docs, and a minimal runnable guardrail example for issue #401.

## Root cause
The frontend preview parser only treated chunks as document previews when model output used separator lines. A different response shape with a `USER-FACING` wrapper and no separators stayed in the normal assistant message body, so the formatted preview styling was bypassed.

## Validation
- `npm test` from `frontend/aijurisdictionfronend` passed: 15 files, 69 tests.
- `npm run build` from `frontend/aijurisdictionfronend` passed.
- `FRONTEND_BASE_URL=http://127.0.0.1:5176 API_BASE_URL=http://127.0.0.1:8080 npx playwright test tests/frontend-document-preview-formatting.spec.ts` passed: 1/1.
- `python examples/frontend_document_preview_issue_401_minimal_demo.py` equivalent passed using the bundled Codex Python runtime.

## Compliance
No model routing, retention, database, or legal-content generation behavior changed. The change is limited to user-visible rendering and keeps the result labeled as a document preview for legal-risk transparency.

Closes #401
