### PR TITLE
[codex] Fix generated document download persistence

### DIFF
--- a/.github/workflows/self_managed_prod_deploy.yml
+++ b/.github/workflows/self_managed_prod_deploy.yml
@@ -19,7 +19,31 @@ on:
         default: false
 
 jobs:
+  e2e_gate:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend/aijurisdictionfronend
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/aijurisdictionfronend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run frontend E2E tests
+        run: npm run test:e2e
+
   deploy:
+    needs: e2e_gate
     runs-on: [self-hosted, Linux, X64, jurisdigta-prod]
     environment: prod
     permissions:

--- a/.github/workflows/web_build_deploy.yml
+++ b/.github/workflows/web_build_deploy.yml
@@ -47,6 +47,12 @@ jobs:
       - name: Unit tests
         run: npm run test
 
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: E2E tests
+        run: npm run test:e2e
+
       - name: Build
         run: npm run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ frontend/**/node_modules/
 frontend/**/dist/
 frontend/**/.vite/
 frontend/**/output/
+frontend/**/test-results/
+frontend/**/playwright-report/
 frontend_design/**/node_modules/
 frontend_design/**/dist/
 frontend_design/**/.vite/

--- a/api/aijuristiction-api/app/chat/api.py
+++ b/api/aijuristiction-api/app/chat/api.py
@@ -3036,7 +3036,17 @@ def _persist_generated_case_document_if_needed(*, session: Session, content: str
     visible_text = _user_visible_text(content).strip()
     drafts = _generated_case_document_drafts_for_storage(visible_text, timestamp=timestamp)
     if not drafts:
-        return []
+        if not _looks_like_fake_download_response(content):
+            return []
+        store = _get_store()
+        if _has_generated_case_documents(store=store, case_id=case_id):
+            return []
+        drafts = _generated_case_document_drafts_from_previous_assistant_message(
+            session=session,
+            timestamp=timestamp,
+        )
+        if not drafts:
+            return []
     return _persist_generated_case_document_drafts(session=session, case_id=case_id, drafts=drafts)
 
 
@@ -3114,6 +3124,37 @@ def _generated_case_document_drafts_for_storage(
             filename=_generated_case_document_filename_for_storage(document_body, timestamp=timestamp),
             body=document_body,
         )
+    ]
+
+
+def _generated_case_document_drafts_from_previous_assistant_message(
+    *,
+    session: Session,
+    timestamp: str,
+) -> list[_GeneratedCaseDocumentDraft]:
+    session_id = getattr(session, "id", None)
+    if session_id is None:
+        return []
+    previous_assistant_messages = [
+        message.content
+        for message in _repository.list_messages(session_id)
+        if message.role == MessageRole.ASSISTANT
+    ]
+    source = _pick_document_message(previous_assistant_messages)
+    if not source:
+        return []
+    visible_source = _user_visible_text(source).strip()
+    drafts = _generated_case_document_drafts_for_storage(visible_source, timestamp=timestamp)
+    if drafts:
+        return drafts
+    sections = _extract_visible_document_sections_for_export(visible_source)
+    return [
+        _GeneratedCaseDocumentDraft(
+            filename=_generated_case_document_filename_for_storage(section["content"], timestamp=timestamp),
+            body=section["content"],
+        )
+        for section in sections
+        if section.get("content")
     ]
 
 
@@ -3477,6 +3518,16 @@ def _next_generated_case_document_version(*, store: ApiDatabaseStore, case_id: s
     return (max(versions) + 1) if versions else 1
 
 
+def _has_generated_case_documents(*, store: ApiDatabaseStore, case_id: str) -> bool:
+    list_case_documents = getattr(store, "list_case_documents", None)
+    if not callable(list_case_documents):
+        return False
+    return any(
+        getattr(document, "kind", "") == "generated_document"
+        for document in list_case_documents(case_id=case_id)
+    )
+
+
 def _case_document_download_url(*, session: Session, doc_id: str) -> str:
     case_id = quote((session.case_id or "").strip(), safe="")
     encoded_doc_id = quote(doc_id, safe="")
@@ -3621,10 +3672,18 @@ def _looks_like_fake_download_link(line: str) -> bool:
         return False
     return bool(
         re.match(
-            r"^\d+\.\s*\[[^\]]+\]\(\s*documents/[^)]+\)$",
+            r"^(?:[-*]\s*|\d+\.\s*)?\[[^\]]+\]\(\s*documents/[^)]+\)$",
             stripped,
             flags=re.IGNORECASE,
         )
+    )
+
+
+def _looks_like_fake_download_response(content: str) -> bool:
+    normalized = _canonicalize_document_text(content)
+    return "documents/" in content.lower() or (
+        any(marker in normalized for marker in ("na stiahnutie", "download", "stiahnut"))
+        and any(marker in normalized for marker in ("dokument", "document"))
     )
 
 

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260473"
+version = "1.0.260474"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -5710,6 +5710,87 @@ def test_user_visible_text_strips_fake_relative_download_links_and_json_preamble
     assert export_response.content.startswith(b"%PDF")
 
 
+def test_unstructured_relative_download_link_uses_previous_draft_for_case_document(monkeypatch) -> None:
+    import app.chat.api as chat_api
+    from app.chat.models import Message, MessageRole, Session
+    from app.chat.repository import InMemoryChatRepository
+
+    stored_documents: list[dict[str, object]] = []
+
+    class _FakeStore:
+        def list_case_documents(self, *, case_id: str):
+            return []
+
+        def add_case_document(
+            self,
+            *,
+            case_id: str,
+            kind: str,
+            version: int,
+            original_filename: str,
+            payload: bytes,
+            uploaded_by_user_id: str | None = None,
+        ) -> str:
+            stored_documents.append(
+                {
+                    "case_id": case_id,
+                    "kind": kind,
+                    "version": version,
+                    "original_filename": original_filename,
+                    "payload": payload.decode("utf-8"),
+                    "uploaded_by_user_id": uploaded_by_user_id,
+                }
+            )
+            return "doc-generated-1"
+
+    repository = InMemoryChatRepository()
+    session_id = uuid4()
+    user_id = uuid4()
+    session = Session(
+        id=session_id,
+        user_id=user_id,
+        case_id="case-123",
+        country="SK",
+        language="SK",
+        discussion_type="advice",
+    )
+    repository.create_session(session)
+    repository.add_message(
+        Message(
+            session_id=session_id,
+            role=MessageRole.ASSISTANT,
+            agent_name="LawyerSlovakia",
+            content=(
+                "**Splnomocnenie**\n\n"
+                "Splnomocniteľ: Esolutions SK s.r.o.\n"
+                "Splnomocnenec: Marek Matonok\n"
+                "Predmet splnomocnenia: používanie firemného vozidla PP472DT.\n\n"
+                "Podpis splnomocniteľa:\n"
+                "________________________"
+            ),
+        )
+    )
+    current_reply = (
+        "USER-FACING: Splnomocnenie bolo úspešne pripravené a je pripravené na stiahnutie.\n"
+        "Môžete si ho stiahnuť pomocou nasledujúceho odkazu:\n\n"
+        "[Stiahnuť splnomocnenie](documents/splnomocnenie_ESolutions_SK.pdf)"
+    )
+
+    monkeypatch.setattr(chat_api, "_repository", repository)
+    monkeypatch.setattr(chat_api, "_get_store", lambda: _FakeStore())
+
+    visible = chat_api._user_visible_text(current_reply)
+    doc_ids = chat_api._persist_generated_case_document_if_needed(session=session, content=current_reply)
+
+    assert "documents/" not in visible
+    assert "Stiahnuť splnomocnenie" not in visible
+    assert doc_ids == ["doc-generated-1"]
+    assert stored_documents[0]["kind"] == "generated_document"
+    assert stored_documents[0]["uploaded_by_user_id"] == str(user_id)
+    assert "Splnomocniteľ: Esolutions SK s.r.o." in str(stored_documents[0]["payload"])
+    assert "PP472DT" in str(stored_documents[0]["payload"])
+
+
 def test_completed_read_user_session_returns_document_status_followup() -> None:
     from app.chat import api as chat_api
     from app.chat.models import Message, MessageRole, SessionResult

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -176,6 +176,8 @@ These are used by the web frontend deployment workflow:
 | --- | --- |
 | `AZURE_FRONTEND_CONTAINER_APP_NAME` | Frontend Azure Container App name |
 
+The frontend deployment workflow runs the full frontend gate before deployment: lint, unit tests, Playwright E2E tests, and build. `npm run test:e2e` starts the Vite app locally and uses mocked API responses, so no additional GitHub Environment variables or secrets are required for the E2E gate. If any Playwright test fails, `web_build_deploy` stops before building or deploying the Azure Container App image.
+
 The frontend workflow also reuses these shared Azure deployment variables:
 
 - `AZURE_CLIENT_ID`
@@ -325,6 +327,8 @@ the selected GitHub Environment contains stale or mismatched signing secrets.
 ## 11. Configure Self-Managed Production Server Variables
 
 These are used by `.github/workflows/self_managed_prod_deploy.yml` to deploy API, MCP, frontend web, the document processor, laws collector, and system status monitoring to the Ubuntu `jurisdigta-server`.
+
+Before the SSH deployment job starts, the workflow runs a GitHub-hosted `e2e_gate` job with `npm ci`, Chromium installation, and `npm run test:e2e` from `frontend/aijurisdictionfronend`. The E2E tests use local Vite plus mocked API responses, so the `prod` environment does not need extra secrets for this gate. If any E2E test fails, the deploy job is skipped and production is not updated.
 
 The workflow must run on a repository self-hosted runner with labels `self-hosted`, `Linux`, `X64`, and `jurisdigta-prod`. Keep this runner on the trusted server or trusted private network that can reach `jurisdigta-server` over SSH. Do not run the production deployment from a GitHub-hosted runner when `JURISDIGTA_SSH_HOST` is a private LAN address such as `192.168.1.50`.
 

--- a/docs/manual_infrastucture_setup.md
+++ b/docs/manual_infrastucture_setup.md
@@ -301,7 +301,7 @@ If the repository is not cloned yet, run the same script from a temporary copy o
 24. Add systemd units or timers only after the exact smoke deployment commands are validated.
 25. Configure the GitHub `prod` Environment values documented in `docs/GITHUB_ENVIRONMENTS.md`.
 26. Register a repository self-hosted GitHub Actions runner on the trusted server or private network with labels `self-hosted`, `Linux`, `X64`, and `jurisdigta-prod`.
-27. Run `Self-Managed Prod Deploy` from GitHub Actions after the server-local environment file is complete.
+27. Run `Self-Managed Prod Deploy` from GitHub Actions after the server-local environment file is complete. The workflow first runs the frontend Playwright E2E gate on GitHub-hosted Ubuntu; if any E2E test fails, the SSH deployment job does not start.
 
 ### Ollama Local Model Service Setup
 
@@ -435,7 +435,7 @@ The self-managed production deployment script performs the Ollama install, local
 - `systemctl status cloudflared --no-pager` shows the Cloudflare tunnel active when public hostnames are enabled.
 - If Cloudflare Tunnel public hostnames are enabled, `curl -fsS https://api.jurisdigta.eu/health`, `curl -fsS https://agent.jurisdigta.eu/health`, `curl -I https://agent.jurisdigta.eu/app/assistant`, `curl -I https://mcp.jurisdigta.eu/.well-known/oauth-protected-resource/MCP`, and `curl -I https://admin.jurisdigta.eu/grafana/` succeed from outside the server.
 - If the frontend web container is enabled, `curl -fsS http://127.0.0.1:8090/health` and `curl -I http://127.0.0.1:8090/privacy` succeed on the server.
-- GitHub Actions workflow `Self-Managed Prod Deploy` completes for `repo_ref=main`.
+- GitHub Actions workflow `Self-Managed Prod Deploy` completes for `repo_ref=main` only after the frontend Playwright E2E gate passes.
 - Cloudflare Access protects `agent.jurisdigta.eu` and `admin.jurisdigta.eu` before public use.
 - UFW allows only expected ingress, typically SSH; do not expose PostgreSQL, API, Grafana, Prometheus, or exporter ports directly.
 

--- a/frontend/aijurisdictionfronend/README.md
+++ b/frontend/aijurisdictionfronend/README.md
@@ -20,6 +20,16 @@ npm run dev
 
 Open `http://localhost:5173`.
 
+## E2E Regression Tests
+
+Run the browser regression suite with:
+
+```bash
+npm run test:e2e
+```
+
+The suite starts Vite locally and uses mocked JurisDigta API responses. Deployment workflows run this Playwright gate before deployment so a failed document-download or document-listing regression blocks release.
+
 ## API Chat Integration (Task #238)
 
 The signed-in workspace now uses the live API for case communication in all three modes (`Chat`, `Voice`, `Video`).

--- a/frontend/aijurisdictionfronend/e2e/generated-document-download.spec.ts
+++ b/frontend/aijurisdictionfronend/e2e/generated-document-download.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "@playwright/test";
+
+const authUser = {
+  userId: "user-e2e",
+  email: "marek@example.test",
+  name: "Marek Matonok"
+};
+
+const apiCase = {
+  case_id: "case-generated-doc",
+  user_id: authUser.userId,
+  company_id: null,
+  title: "test generated document",
+  status: "in_progress",
+  created_at: "2026-06-26T10:00:00Z",
+  updated_at: "2026-06-26T10:05:00Z"
+};
+
+const generatedDocument = {
+  doc_id: "doc-generated-splnomocnenie",
+  kind: "generated_document",
+  version: 1,
+  original_filename: "splnomocnenie_ESolutions_SK.pdf",
+  processing_status: "processed",
+  processing_error: null,
+  processed_at: "2026-06-26T10:05:00Z",
+  created_at: "2026-06-26T10:05:00Z"
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.route("**/v1/cases?user_id=**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify([apiCase])
+    });
+  });
+
+  await page.route("**/v1/cases/case-generated-doc/history?**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        has_more: false,
+        documents: [generatedDocument],
+        messages: [
+          {
+            communication_id: "msg-user-1",
+            role: "user",
+            content: "ano",
+            agent_name: null,
+            created_at: "2026-06-26T10:04:00Z"
+          },
+          {
+            communication_id: "msg-assistant-1",
+            role: "assistant",
+            content:
+              "USER-FACING: Splnomocnenie bolo úspešne pripravené a je pripravené na stiahnutie.\n\n" +
+              "Môžete si ho stiahnuť pomocou nasledujúceho odkazu:\n\n" +
+              "[Stiahnuť splnomocnenie](documents/splnomocnenie_ESolutions_SK.pdf)",
+            agent_name: "LawyerSlovakia",
+            created_at: "2026-06-26T10:05:00Z"
+          }
+        ]
+      })
+    });
+  });
+
+  await page.addInitScript((user) => {
+    window.sessionStorage.setItem("jurisdigta.web.auth.user.v1", JSON.stringify(user));
+  }, authUser);
+});
+
+test("generated documents are downloadable and listed for the selected case", async ({ page }) => {
+  await page.goto("/app/assistant");
+
+  await expect(page.getByRole("button", { name: /test generated document/i })).toBeVisible();
+  await page.getByRole("button", { name: /test generated document/i }).click();
+
+  await expect(page.getByRole("heading", { name: /dokumenty|documents/i })).toBeVisible();
+  await expect(page.getByRole("button", { name: /splnomocnenie_ESolutions_SK\.pdf/i })).toBeVisible();
+
+  const documentActions = page.getByLabel("Generated documents");
+  await expect(documentActions.getByRole("link", { name: /splnomocnenie_ESolutions_SK\.pdf/i })).toBeVisible();
+  await expect(
+    documentActions.getByRole("link", { name: /splnomocnenie_ESolutions_SK\.pdf/i })
+  ).toHaveAttribute(
+    "href",
+    /\/app\/documents\/view\?caseId=case-generated-doc&docId=doc-generated-splnomocnenie/
+  );
+
+  await expect(page.locator(".assistant-thread__viewport")).not.toContainText("documents/splnomocnenie_ESolutions_SK.pdf");
+  await expect(page.locator(".assistant-thread__viewport")).not.toContainText("Stiahnuť splnomocnenie");
+});

--- a/frontend/aijurisdictionfronend/package-lock.json
+++ b/frontend/aijurisdictionfronend/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
+        "@playwright/test": "^1.61.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.3.5",
@@ -1382,6 +1383,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -5440,6 +5457,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",

--- a/frontend/aijurisdictionfronend/package.json
+++ b/frontend/aijurisdictionfronend/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@assistant-ui/react": "^0.14.23",
@@ -19,6 +20,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.12.0",
+    "@playwright/test": "^1.61.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.5",

--- a/frontend/aijurisdictionfronend/playwright.config.ts
+++ b/frontend/aijurisdictionfronend/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000
+  },
+  reporter: [["list"]],
+  use: {
+    baseURL: "http://127.0.0.1:5189",
+    trace: "retain-on-failure"
+  },
+  webServer: {
+    command: "npm run dev -- --host 127.0.0.1 --port 5189 --strictPort",
+    url: "http://127.0.0.1:5189",
+    reuseExistingServer: false,
+    timeout: 60_000
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] }
+    }
+  ]
+});

--- a/frontend/aijurisdictionfronend/src/__tests__/assistantWorkspace.test.tsx
+++ b/frontend/aijurisdictionfronend/src/__tests__/assistantWorkspace.test.tsx
@@ -408,4 +408,25 @@ Generated document:
       }
     ]);
   });
+
+  it("removes fake relative document download links from assistant history", () => {
+    const presentation = parseAssistantMessagePresentation(`USER-FACING: Splnomocnenie bolo uspesne pripravene a je pripravene na stiahnutie.
+
+Mozete si ho stiahnut pomocou nasledujuceho odkazu:
+
+[Stiahnut splnomocnenie](documents/splnomocnenie_ESolutions_SK.pdf)
+
+Generated document:
+- [splnomocnenie_ESolutions_SK.pdf](/app/documents/view?caseId=case-1&docId=doc-generated&kind=generated_document)`);
+
+    expect(presentation.conversationalText).toBe(
+      "USER-FACING: Splnomocnenie bolo uspesne pripravene a je pripravene na stiahnutie."
+    );
+    expect(presentation.documentLinks).toEqual([
+      {
+        label: "splnomocnenie_ESolutions_SK.pdf",
+        href: "/app/documents/view?caseId=case-1&docId=doc-generated&kind=generated_document"
+      }
+    ]);
+  });
 });

--- a/frontend/aijurisdictionfronend/src/pages/AssistantWorkspace.tsx
+++ b/frontend/aijurisdictionfronend/src/pages/AssistantWorkspace.tsx
@@ -149,6 +149,7 @@ const appendGeneratedDocumentsResponseBlock = (content: string, block: string): 
   block ? `${content.trim()}\n\n${block}`.trim() : content;
 
 const internalDocumentLinkPattern = /\[([^\]]+)]\((\/app\/documents\/view\?[^)\s]+)\)/g;
+const relativeDocumentLinkPattern = /\[([^\]]+)]\(\s*documents\/[^)\s]+\)/gi;
 
 type AssistantDocumentLink = {
   label: string;
@@ -177,15 +178,27 @@ const stripMarkdownHeading = (line: string): string =>
 
 const removeInternalDocumentLinks = (text: string): { text: string; links: AssistantDocumentLink[] } => {
   const links: AssistantDocumentLink[] = [];
-  const cleaned = text.replace(internalDocumentLinkPattern, (_match, label: string, href: string) => {
-    links.push({ label, href });
-    return "";
-  });
+  const cleaned = text
+    .replace(internalDocumentLinkPattern, (_match, label: string, href: string) => {
+      links.push({ label, href });
+      return "";
+    })
+    .replace(relativeDocumentLinkPattern, "");
   internalDocumentLinkPattern.lastIndex = 0;
+  relativeDocumentLinkPattern.lastIndex = 0;
   return {
     text: cleaned
       .split("\n")
-      .filter((line) => !/^Generated documents?:\s*$/i.test(line.trim()) && line.trim() !== "-")
+      .filter((line) => {
+        const normalized = line.trim().toLowerCase();
+        return (
+          !/^Generated documents?:\s*$/i.test(normalized) &&
+          normalized !== "-" &&
+          !normalized.includes("môžete si ho stiahnuť pomocou nasledujúceho odkazu") &&
+          !normalized.includes("mozete si ho stiahnut pomocou nasledujuceho odkazu") &&
+          !normalized.includes("download using the following link")
+        );
+      })
       .join("\n")
       .replace(/\n{3,}/g, "\n\n")
       .trim(),

--- a/frontend/aijurisdictionfronend/vite.config.ts
+++ b/frontend/aijurisdictionfronend/vite.config.ts
@@ -1,9 +1,12 @@
-﻿import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173
+  },
+  test: {
+    exclude: ["e2e/**", "node_modules/**", "dist/**"]
   }
 });


### PR DESCRIPTION
﻿## Summary
- Fix generated-document persistence when the confirmation turn only contains a fake relative `documents/...pdf` link by recovering the prior assistant draft and storing it as a visible `generated_document`.
- Hide polluted relative document links from assistant history while keeping real `/app/documents/view?...` generated PDF actions.
- Add Playwright E2E coverage for the selected-case document list and generated PDF action, and require E2E before frontend/self-managed deployments.

## Root Cause
The API could strip or expose model-invented relative download links, but it did not recover the previous draft body when the final confirmation response contained only the fake link. The frontend also rendered older relative links from case history because only internal `/app/documents/view?...` links were handled as document actions.

## Validation
- `./scripts/validate_api.ps1`
- `./conda/python.exe -m pytest api/aijuristiction-api/tests`
- `npm run lint`
- `npm run test`
- `npm run build`
- `npm run test:e2e`

Fixes #403
