### PR TITLE
Fix free plan local model routing

### DIFF
--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -76,6 +76,7 @@ Required setup for chat model routing:
 
 - Free/default users use the seeded `local_ollama_default` route: provider `local_ollama`, base URL `http://127.0.0.1:11434/v1`, exact model `qwen3.6:27b`.
 - Paid `case`, `basic`, `premium`, and `unlimited` users use the seeded Azure Foundry route `azure_foundry_gpt_4o_mini`: exact model/deployment `gpt-4o-mini`.
+- A paid subscription is considered active for routing only while `starts_at` has begun and `ends_at` is empty or in the future. Expired paid rows fall back to the Free/local Ollama route.
 - Azure Foundry chat endpoint belongs in `ai_model_providers.base_url`.
 - Azure Foundry API key or token belongs in encrypted `ai_model_credentials`, managed through `/v1/admin/ai-models`.
 - Set `AI_MODEL_CREDENTIAL_ENCRYPTION_KEY` and `JURISDIGTA_ADMIN_EMAILS` in deployed environments.

--- a/api/aijuristiction-api/tests/test_ai_model_routing.py
+++ b/api/aijuristiction-api/tests/test_ai_model_routing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 import importlib.util
 from pathlib import Path
 from typing import Any
@@ -72,6 +73,45 @@ def test_case_plan_routes_to_seeded_azure_foundry_gpt_4o_mini_model(
     assert routed.route_type == "external"
     assert routed.plan_code == "case"
     assert routed.subscription_id == subscription.subscription_id
+
+
+def test_expired_paid_subscription_routes_as_free_local_model(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    store = _store(tmp_path)
+    user = store.create_user(email="expired@example.com", password="secret", full_name="Expired User")
+    subscription = store.request_subscription_change(user_id=user.user_id, plan_code="case")
+    paid_subscription = store.update_subscription_status(
+        subscription_id=subscription.subscription_id,
+        status="paid",
+    )
+    past_end = (datetime.now(UTC) - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+    with store._connect() as conn:
+        store._execute(
+            conn,
+            "UPDATE user_subscriptions SET ends_at = ? WHERE subscription_id = ?",
+            (past_end, paid_subscription.subscription_id),
+        )
+        conn.commit()
+
+    plan = store.get_effective_subscription_plan(user_id=user.user_id)
+    effective_subscription = store.get_effective_user_subscription(user_id=user.user_id)
+    routed = get_routed_llm_client(
+        store=store,
+        user_id=user.user_id,
+        task_type="chat_reply",
+    )
+
+    assert effective_subscription is not None
+    assert effective_subscription.plan_code == "free"
+    assert plan.plan_code == "free"
+    assert routed.plan_code == "free"
+    assert routed.subscription_id == effective_subscription.subscription_id
+    assert routed.provider == "local_ollama"
+    assert routed.route_type == "free_local"
+    assert routed.model == "qwen3.6:27b"
 
 
 def test_model_credentials_are_encrypted_and_revealed_only_when_requested(

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -1521,6 +1521,125 @@ def test_reply_endpoint_includes_signed_in_profile_defaults_in_lawyer_prompt(mon
     assert "Client full name: Marek Matonok" in captured_prompts[-1]
 
 
+def test_free_plan_chat_reply_records_local_model_route_e2e(monkeypatch, tmp_path) -> None:
+    from app.chat.repository import InMemoryChatRepository
+    import app.chat.api as chat_api
+    import app.users.api as users_api
+    from aijurisdictionagents.llm.routing import RoutedLLMClient
+
+    class _NoopEmailScheduler:
+        def enqueue(self, *, recipient: str, subject: str, body: str, metadata: dict[str, object]) -> str:
+            return "email-ignored"
+
+    class _FakeLocalLLM:
+        def complete(self, agent_name, system_prompt, conversation, documents):
+            return "Free local model answer from test."
+
+    class _NoopDocumentProcessor:
+        def __init__(self, store):
+            self.store = store
+
+        def process_documents(self, documents):
+            return None
+
+    def _routed_free_client(*, store, user_id, task_type="default", external_acknowledged=False):
+        plan = store.get_effective_subscription_plan(user_id=user_id)
+        subscription = store.get_effective_user_subscription(user_id=user_id)
+        route = store.resolve_ai_model_route(
+            user_id=user_id,
+            plan_code=plan.plan_code,
+            task_type=task_type,
+            external_acknowledged=external_acknowledged,
+        )
+        assert route.provider is not None
+        assert route.model_profile is not None
+        return RoutedLLMClient(
+            client=_FakeLocalLLM(),
+            route=route,
+            plan=plan,
+            subscription=subscription,
+            provider=route.provider.provider_code,
+            model=route.model_profile.deployment_name or route.model_profile.model_code,
+            route_type=route.route_type,
+            fallback_reason="",
+        )
+
+    monkeypatch.setenv("DB_OPTION", "local")
+    monkeypatch.setenv("STORAGE_OPTION", "local")
+    monkeypatch.setenv("DB_LOCAL", str(tmp_path / "api.sqlite3"))
+    monkeypatch.setenv("STORE_LOCAL", str(tmp_path / "blob"))
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.setattr(chat_api, "_repository", InMemoryChatRepository())
+    monkeypatch.setattr(chat_api, "get_routed_llm_client", _routed_free_client)
+    monkeypatch.setattr(chat_api, "DocumentProcessor", _NoopDocumentProcessor)
+    app.dependency_overrides[users_api.get_email_scheduler] = lambda: _NoopEmailScheduler()
+    try:
+        sign_up_response = client.post(
+            "/v1/users/sign-up",
+            headers=AUTH_HEADERS,
+            json={
+                "phone_number": "+421900777888",
+                "email": "free-local-e2e@example.com",
+                "password": "secret",
+                "first_name": "Free",
+                "last_name": "Local",
+            },
+        )
+        assert sign_up_response.status_code == 201
+        user_id = sign_up_response.json()["user_id"]
+        subscriptions_response = client.get(
+            f"/v1/users/{user_id}/subscriptions",
+            headers=AUTH_HEADERS,
+        )
+        assert subscriptions_response.status_code == 200
+        assert subscriptions_response.json()[0]["plan_code"] == "free"
+
+        case_response = client.post(
+            "/v1/cases",
+            headers=AUTH_HEADERS,
+            json={"user_id": user_id, "title": "Free local routing e2e"},
+        )
+        assert case_response.status_code == 201
+        case_id = case_response.json()["case_id"]
+
+        session_response = client.post(
+            "/v1/chat/sessions",
+            headers=AUTH_HEADERS,
+            json={
+                "user_id": user_id,
+                "case_id": case_id,
+                "country": "US",
+                "discussion_type": "advice",
+                "language": "EN",
+            },
+        )
+        assert session_response.status_code == 200
+        session_id = session_response.json()["id"]
+
+        reply_response = client.post(
+            f"/v1/chat/sessions/{session_id}/reply",
+            headers=AUTH_HEADERS,
+            json={"content": "Please review my tenant dispute and suggest next steps."},
+        )
+        assert reply_response.status_code == 200
+        assert reply_response.json()["content"] == "Free local model answer from test."
+
+        audit_response = client.get(
+            f"/v1/cases/{case_id}/ai-model-audit?user_id={user_id}&limit=5",
+            headers=AUTH_HEADERS,
+        )
+        assert audit_response.status_code == 200
+    finally:
+        app.dependency_overrides.pop(users_api.get_email_scheduler, None)
+
+    entries = audit_response.json()["entries"]
+    assert len(entries) == 1
+    assert entries[0]["provider"] == "local_ollama"
+    assert entries[0]["model"] == "qwen3.6:27b"
+    assert entries[0]["route_type"] == "free_local"
+    assert entries[0]["task_type"] == "chat_reply"
+
+
 def test_mcp_law_context_uses_search_and_law_text_tools(monkeypatch) -> None:
     from app.chat.mcp_law_context import build_mcp_law_context
 

--- a/docs/API_DATABASE_LAYER.md
+++ b/docs/API_DATABASE_LAYER.md
@@ -153,6 +153,10 @@ The API database now seeds four subscription plans and tracks user subscription 
 
 Status model: `pending`, `paying`, `paid`, `canceled`, `expired`.
 For monthly plans, `starts_at` and `ends_at` are set when status switches to `paid`.
+Runtime entitlement checks treat a paid subscription as active only when its
+`starts_at` has begun and `ends_at` is empty or in the future. Expired paid
+subscriptions fall back to the Free plan, which also keeps chat model routing on
+the local Ollama route instead of an external provider.
 
 `JURISDIGTA_UNLIMITED_ACCESS_EMAILS` defines a comma- or semicolon-separated
 case-insensitive allowlist for controlled test/operator accounts. Allowlisted users

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import tempfile
+from datetime import UTC, datetime, timedelta
 
 from aijurisdictionagents.agents.audio_action_tools import AIAudioToolRecognizerAgent
 from aijurisdictionagents.api_db import ApiDatabaseStore
@@ -66,6 +67,28 @@ with tempfile.TemporaryDirectory(prefix="jurisdigta-minimal-", ignore_cleanup_er
         plan_code="case",
         task_type="chat_reply",
     )
+    expired_subscription = demo_store.request_subscription_change(
+        user_id=demo_user.user_id,
+        plan_code="case",
+    )
+    paid_subscription = demo_store.update_subscription_status(
+        subscription_id=expired_subscription.subscription_id,
+        status="paid",
+    )
+    past_end = (datetime.now(UTC) - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+    with demo_store._connect() as conn:
+        demo_store._execute(
+            conn,
+            "UPDATE user_subscriptions SET ends_at = ? WHERE subscription_id = ?",
+            (past_end, paid_subscription.subscription_id),
+        )
+        conn.commit()
+    expired_plan = demo_store.get_effective_subscription_plan(user_id=demo_user.user_id)
+    expired_route = demo_store.resolve_ai_model_route(
+        user_id=demo_user.user_id,
+        plan_code=expired_plan.plan_code,
+        task_type="chat_reply",
+    )
     print(
         "model_routing_free => "
         f"{free_route.provider.provider_code}/{free_route.model_profile.model_code}"
@@ -73,6 +96,11 @@ with tempfile.TemporaryDirectory(prefix="jurisdigta-minimal-", ignore_cleanup_er
     print(
         "model_routing_case => "
         f"{case_route.provider.provider_code}/{case_route.model_profile.model_code}"
+    )
+    print(
+        "model_routing_expired_paid => "
+        f"{expired_plan.plan_code}/"
+        f"{expired_route.provider.provider_code}/{expired_route.model_profile.model_code}"
     )
 print(
     "ai_model_admin => /app/admin/ai-models manages model providers, prices, "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aijurisdictionagents"
-version = "1.0.260395"
+version = "1.0.260396"
 description = "Multi-agent legal discussion scaffold."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260395"
+__version__ = "1.0.260396"

--- a/src/aijurisdictionagents/api_db/store.py
+++ b/src/aijurisdictionagents/api_db/store.py
@@ -3169,6 +3169,7 @@ class ApiDatabaseStore:
         return int(row[0]) if row else 0
 
     def get_effective_user_subscription(self, *, user_id: str) -> UserSubscription | None:
+        now = _now_iso()
         with self._connect() as conn:
             row = self._fetchone(
                 conn,
@@ -3176,11 +3177,14 @@ class ApiDatabaseStore:
                 SELECT subscription_id, user_id, plan_code, status, starts_at, ends_at,
                        case_ids_json, created_at, updated_at
                 FROM user_subscriptions
-                WHERE user_id = ? AND status = 'paid'
+                WHERE user_id = ?
+                  AND status = 'paid'
+                  AND (starts_at IS NULL OR starts_at = '' OR starts_at <= ?)
+                  AND (ends_at IS NULL OR ends_at = '' OR ends_at > ?)
                 ORDER BY created_at DESC
                 LIMIT 1
                 """,
-                (user_id,),
+                (user_id, now, now),
             )
         return _row_to_user_subscription(row) if row is not None else None
 
@@ -3195,6 +3199,7 @@ class ApiDatabaseStore:
                 UNLIMITED_ACCESS_LIMIT,
                 None,
             )
+        now = _now_iso()
         with self._connect() as conn:
             row = self._fetchone(
                 conn,
@@ -3203,11 +3208,14 @@ class ApiDatabaseStore:
                        sp.max_cases, sp.max_documents_per_case, sp.case_ttl_days
                 FROM user_subscriptions us
                 JOIN subscription_plans sp ON sp.plan_code = us.plan_code
-                WHERE us.user_id = ? AND us.status = 'paid'
+                WHERE us.user_id = ?
+                  AND us.status = 'paid'
+                  AND (us.starts_at IS NULL OR us.starts_at = '' OR us.starts_at <= ?)
+                  AND (us.ends_at IS NULL OR us.ends_at = '' OR us.ends_at > ?)
                 ORDER BY us.created_at DESC
                 LIMIT 1
                 """,
-                (user_id,),
+                (user_id, now, now),
             )
         if row is None:
             return SubscriptionPlan('free', 'Free', 'none', 0, 1, 2, 1)


### PR DESCRIPTION
## Summary
- Treat paid subscriptions as effective for routing only when their start/end window is active.
- Fall back to the Free plan when a paid subscription has expired so Free users route to local Ollama instead of Azure Foundry.
- Add e2e coverage that creates a Free user, sends a chat reply through the API, and verifies the model audit records local_ollama / free_local / qwen3.6:27b.

## Validation
- python examples/minimal_demo.py
- python -m pytest api/aijuristiction-api/tests/test_chat.py::test_free_plan_chat_reply_records_local_model_route_e2e api/aijuristiction-api/tests/test_ai_model_routing.py::test_expired_paid_subscription_routes_as_free_local_model -q
- scripts/validate_api.ps1 via pre-commit: ruff check app tests; mypy app

Note: full api/aijuristiction-api/tests suite was attempted locally and timed out after 10 minutes, so the blocking validation is the targeted regression/e2e set plus lint/type checks.