### PR TITLE
Show effective model route in assistant

### DIFF
--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -77,6 +77,7 @@ Required setup for chat model routing:
 - Free/default users use the seeded `local_ollama_default` route: provider `local_ollama`, base URL `http://127.0.0.1:11434/v1`, exact model `qwen3.6:27b`.
 - Paid `case`, `basic`, `premium`, and `unlimited` users use the seeded Azure Foundry route `azure_foundry_gpt_4o_mini`: exact model/deployment `gpt-4o-mini`.
 - A paid subscription is considered active for routing only while `starts_at` has begun and `ends_at` is empty or in the future. Expired paid rows fall back to the Free/local Ollama route.
+- The assistant UI should read `/v1/model-routing/effective` for the signed-in user before displaying model disclosure text. This endpoint returns only privacy-minimized route metadata, so Free users see the same local Ollama model that the backend will actually use.
 - Azure Foundry chat endpoint belongs in `ai_model_providers.base_url`.
 - Azure Foundry API key or token belongs in encrypted `ai_model_credentials`, managed through `/v1/admin/ai-models`.
 - Set `AI_MODEL_CREDENTIAL_ENCRYPTION_KEY` and `JURISDIGTA_ADMIN_EMAILS` in deployed environments.

--- a/api/aijuristiction-api/app/effective_model_routing_api.py
+++ b/api/aijuristiction-api/app/effective_model_routing_api.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from app.security import require_api_key
+from aijurisdictionagents.api_db import ApiDatabaseStore
+
+
+router = APIRouter(
+    prefix="/v1/model-routing",
+    tags=["model-routing"],
+    dependencies=[Depends(require_api_key)],
+)
+
+
+class EffectiveModelRouteResponse(BaseModel):
+    plan_code: str
+    route_type: str
+    provider: str
+    provider_display_name: str
+    model: str
+    model_profile_id: str
+    is_local: bool
+    is_external: bool
+    label: str
+
+
+def get_store() -> ApiDatabaseStore:
+    store = ApiDatabaseStore.from_env()
+    store.initialize()
+    return store
+
+
+@router.get("/effective", response_model=EffectiveModelRouteResponse)
+def get_effective_model_route(
+    user_id: str | None = None,
+    task_type: str = "chat_reply",
+    store: ApiDatabaseStore = Depends(get_store),
+) -> EffectiveModelRouteResponse:
+    normalized_user_id = (user_id or "").strip()
+    plan = (
+        store.get_effective_subscription_plan(user_id=normalized_user_id)
+        if normalized_user_id
+        else store.get_subscription_plan(plan_code="free")
+    )
+    route = store.resolve_ai_model_route(
+        user_id=normalized_user_id,
+        plan_code=plan.plan_code,
+        task_type=task_type.strip() or "chat_reply",
+    )
+    provider = route.provider
+    profile = route.model_profile
+    provider_code = provider.provider_code if provider is not None else ""
+    model_code = profile.model_code if profile is not None else ""
+    provider_name = provider.display_name if provider is not None else provider_code
+    return EffectiveModelRouteResponse(
+        plan_code=plan.plan_code,
+        route_type=route.route_type,
+        provider=provider_code,
+        provider_display_name=provider_name,
+        model=model_code,
+        model_profile_id=profile.model_profile_id if profile is not None else "",
+        is_local=bool(provider.is_local) if provider is not None else False,
+        is_external=bool(provider.is_external) if provider is not None else False,
+        label=_public_route_label(provider_name=provider_name, model_code=model_code, route_type=route.route_type),
+    )
+
+
+def _public_route_label(*, provider_name: str, model_code: str, route_type: str) -> str:
+    if not provider_name and not model_code:
+        return route_type or "Model routing"
+    if not provider_name:
+        return model_code
+    if not model_code:
+        return provider_name
+    return f"{provider_name} - {model_code}"

--- a/api/aijuristiction-api/app/main.py
+++ b/api/aijuristiction-api/app/main.py
@@ -22,6 +22,7 @@ from app.admin_users_api import router as admin_users_router
 from app.ai_model_admin_api import router as ai_model_admin_router
 from app.contact_api import router as contact_router
 from app.document_templates.api import router as document_templates_router
+from app.effective_model_routing_api import router as effective_model_routing_router
 from app.flow_packs.api import router as flow_packs_router
 from app.laws_api import router as laws_router
 from app.logging_config import configure_logging
@@ -251,6 +252,7 @@ app.include_router(admin_users_router)
 app.include_router(ai_model_admin_router)
 app.include_router(contact_router)
 app.include_router(document_templates_router)
+app.include_router(effective_model_routing_router)
 app.include_router(flow_packs_router)
 app.include_router(laws_router)
 app.include_router(users_router)

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260476"
+version = "1.0.260477"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_ai_model_routing.py
+++ b/api/aijuristiction-api/tests/test_ai_model_routing.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import importlib.util
 from pathlib import Path
 from typing import Any
@@ -10,6 +10,9 @@ from fastapi.testclient import TestClient
 from app.main import app
 from aijurisdictionagents.api_db import ApiDatabaseStore
 from aijurisdictionagents.llm.routing import get_routed_llm_client
+
+
+client = TestClient(app)
 
 
 def _store(tmp_path: Path) -> ApiDatabaseStore:
@@ -87,7 +90,7 @@ def test_expired_paid_subscription_routes_as_free_local_model(
         subscription_id=subscription.subscription_id,
         status="paid",
     )
-    past_end = (datetime.now(UTC) - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+    past_end = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat().replace("+00:00", "Z")
     with store._connect() as conn:
         store._execute(
             conn,
@@ -112,6 +115,36 @@ def test_expired_paid_subscription_routes_as_free_local_model(
     assert routed.provider == "local_ollama"
     assert routed.route_type == "free_local"
     assert routed.model == "qwen3.6:27b"
+
+
+def test_effective_model_route_endpoint_reports_free_user_local_model(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "api.sqlite3"
+    blob_root = tmp_path / "blob"
+    monkeypatch.setenv("DB_OPTION", "local")
+    monkeypatch.setenv("DB_LOCAL", str(db_path))
+    monkeypatch.setenv("STORAGE_OPTION", "local")
+    monkeypatch.setenv("STORE_LOCAL", str(blob_root))
+    store = ApiDatabaseStore(db_path=db_path, blob_root=blob_root)
+    store.initialize()
+    user = store.create_user(email="route-label@example.com", password="secret", full_name="Route Label")
+
+    response = client.get(
+        f"/v1/model-routing/effective?user_id={user.user_id}&task_type=chat_reply",
+        headers={"x-api-key": "aijuris"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["plan_code"] == "free"
+    assert payload["route_type"] == "free_local"
+    assert payload["provider"] == "local_ollama"
+    assert payload["model"] == "qwen3.6:27b"
+    assert payload["is_local"] is True
+    assert payload["is_external"] is False
+    assert payload["label"] == "Local Ollama - qwen3.6:27b"
 
 
 def test_model_credentials_are_encrypted_and_revealed_only_when_requested(

--- a/docs/API_DATABASE_LAYER.md
+++ b/docs/API_DATABASE_LAYER.md
@@ -157,6 +157,10 @@ Runtime entitlement checks treat a paid subscription as active only when its
 `starts_at` has begun and `ends_at` is empty or in the future. Expired paid
 subscriptions fall back to the Free plan, which also keeps chat model routing on
 the local Ollama route instead of an external provider.
+The public `/v1/model-routing/effective` endpoint exposes only effective route
+metadata (`plan_code`, `route_type`, provider, model, and label) so clients can
+display the same model route the backend will use without exposing prompts,
+secrets, or case content.
 
 `JURISDIGTA_UNLIMITED_ACCESS_EMAILS` defines a comma- or semicolon-separated
 case-insensitive allowlist for controlled test/operator accounts. Allowlisted users

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -102,6 +102,10 @@ with tempfile.TemporaryDirectory(prefix="jurisdigta-minimal-", ignore_cleanup_er
         f"{expired_plan.plan_code}/"
         f"{expired_route.provider.provider_code}/{expired_route.model_profile.model_code}"
     )
+    print(
+        "model_disclosure_label => "
+        f"{expired_route.provider.display_name} - {expired_route.model_profile.model_code}"
+    )
 print(
     "ai_model_admin => /app/admin/ai-models manages model providers, prices, "
     "groups, route policies, and audit events through server-authorized admin APIs."

--- a/frontend/aijurisdictionfronend/src/__tests__/assistantWorkspace.test.tsx
+++ b/frontend/aijurisdictionfronend/src/__tests__/assistantWorkspace.test.tsx
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import AssistantWorkspace, { parseAssistantMessagePresentation } from "../pages/AssistantWorkspace";
-import { createChatSession, streamSession } from "../api/chatClient";
+import { createChatSession, fetchEffectiveModelRoute, streamSession } from "../api/chatClient";
 
 const labels: Record<string, string> = {
   assistantThreadsTitle: "Conversations",
@@ -118,6 +118,7 @@ vi.mock("../api/chatClient", async () => {
   return {
     ...actual,
     createChatSession: vi.fn(),
+    fetchEffectiveModelRoute: vi.fn(),
     streamSession: vi.fn()
   };
 });
@@ -169,6 +170,20 @@ vi.mock("@assistant-ui/react", () => ({
 }));
 
 describe("AssistantWorkspace", () => {
+  beforeEach(() => {
+    vi.mocked(fetchEffectiveModelRoute).mockResolvedValue({
+      plan_code: "free",
+      route_type: "free_local",
+      provider: "local_ollama",
+      provider_display_name: "Local Ollama",
+      model: "qwen3.6:27b",
+      model_profile_id: "local_ollama_default",
+      is_local: true,
+      is_external: false,
+      label: "Local Ollama - qwen3.6:27b"
+    });
+  });
+
   afterEach(() => {
     capturedAdapter = null;
     capturedRuntimeOptions = null;
@@ -176,20 +191,42 @@ describe("AssistantWorkspace", () => {
     caseActions.setCaseCommunicationMode.mockReset();
     caseActions.loadCaseData.mockReset();
     vi.mocked(createChatSession).mockReset();
+    vi.mocked(fetchEffectiveModelRoute).mockReset();
     vi.mocked(streamSession).mockReset();
     cleanup();
   });
 
-  it("renders assistant workspace with configuration controls", () => {
+  it("renders assistant workspace with the effective signed-in user model route", async () => {
+    vi.mocked(fetchEffectiveModelRoute).mockResolvedValue({
+      plan_code: "free",
+      route_type: "free_local",
+      provider: "local_ollama",
+      provider_display_name: "Local Ollama",
+      model: "qwen3.6:27b",
+      model_profile_id: "local_ollama_default",
+      is_local: true,
+      is_external: false,
+      label: "Local Ollama - qwen3.6:27b"
+    });
+
     render(<AssistantWorkspace />);
 
     expect(screen.getByRole("heading", { name: "JurisDigta Assistant" })).toBeDefined();
-    expect(screen.getByLabelText("AI model used for this chat").textContent).toContain("Azure Foundry model");
+    expect(await screen.findByText("Local Ollama - qwen3.6:27b")).toBeDefined();
+    expect(vi.mocked(fetchEffectiveModelRoute)).toHaveBeenCalledWith("user-1");
     expect(screen.getByRole("heading", { name: "Configurations" })).toBeDefined();
     expect(screen.getByRole("button", { name: "Chat" })).toBeDefined();
     expect(screen.getByText("AI lawyer")).toBeDefined();
     expect(screen.getByText("Opposing party")).toBeDefined();
     expect(screen.queryByText("Production access uses JurisDigta account login")).toBeNull();
+  });
+
+  it("falls back to the configured model label when route disclosure is unavailable", () => {
+    vi.mocked(fetchEffectiveModelRoute).mockRejectedValue(new Error("offline"));
+
+    render(<AssistantWorkspace />);
+
+    expect(screen.getByLabelText("AI model used for this chat").textContent).toContain("Azure Foundry model");
   });
 
   it("does not show the static MCP news panel in the assistant workspace", () => {

--- a/frontend/aijurisdictionfronend/src/api/chatClient.ts
+++ b/frontend/aijurisdictionfronend/src/api/chatClient.ts
@@ -29,6 +29,18 @@ export type ChatMessage = {
   created_at: string;
 };
 
+export type EffectiveModelRoute = {
+  plan_code: string;
+  route_type: string;
+  provider: string;
+  provider_display_name: string;
+  model: string;
+  model_profile_id: string;
+  is_local: boolean;
+  is_external: boolean;
+  label: string;
+};
+
 export type CreateChatSessionInput = {
   userId?: string;
   caseId?: string;
@@ -217,6 +229,20 @@ export const replyToSession = async (input: ReplyToSessionInput): Promise<ChatMe
     body: JSON.stringify({
       content: input.content
     })
+  });
+};
+
+export const fetchEffectiveModelRoute = async (userId?: string): Promise<EffectiveModelRoute> => {
+  const config = resolveApiConfig();
+  const params = new URLSearchParams({ task_type: "chat_reply" });
+  if (userId?.trim()) {
+    params.set("user_id", userId.trim());
+  }
+  return requestJson<EffectiveModelRoute>(`/v1/model-routing/effective?${params.toString()}`, {
+    method: "GET",
+    headers: {
+      "x-api-key": config.apiKey
+    }
   });
 };
 

--- a/frontend/aijurisdictionfronend/src/pages/AssistantWorkspace.tsx
+++ b/frontend/aijurisdictionfronend/src/pages/AssistantWorkspace.tsx
@@ -12,7 +12,13 @@ import {
 } from "@assistant-ui/react";
 import { BsArrowUpCircle } from "react-icons/bs";
 import { FiMessageSquare, FiMic, FiVideo } from "react-icons/fi";
-import { ApiRequestError, chatApiRuntimeConfig, createChatSession, streamSession } from "../api/chatClient";
+import {
+  ApiRequestError,
+  chatApiRuntimeConfig,
+  createChatSession,
+  fetchEffectiveModelRoute,
+  streamSession
+} from "../api/chatClient";
 import { useAuth } from "../auth/webAuth";
 import { useLanguage } from "../components/LanguageProvider";
 import { isUserVisibleGeneratedDocument, useCases } from "../state/CaseProvider";
@@ -707,9 +713,29 @@ const AssistantConfigurations: React.FC = () => {
 
 const AssistantWorkspace: React.FC = () => {
   const { t } = useLanguage();
+  const { user } = useAuth();
   const { activeCase } = useCases();
   const threadKey = React.useMemo(() => caseThreadKey(activeCase), [activeCase]);
-  const modelLabel = React.useMemo(() => chatApiRuntimeConfig().chatModelLabel, []);
+  const fallbackModelLabel = React.useMemo(() => chatApiRuntimeConfig().chatModelLabel, []);
+  const [modelLabel, setModelLabel] = React.useState(fallbackModelLabel);
+
+  React.useEffect(() => {
+    let isCurrent = true;
+    void fetchEffectiveModelRoute(user?.userId)
+      .then((route) => {
+        if (isCurrent && route.label.trim()) {
+          setModelLabel(route.label.trim());
+        }
+      })
+      .catch(() => {
+        if (isCurrent) {
+          setModelLabel(fallbackModelLabel);
+        }
+      });
+    return () => {
+      isCurrent = false;
+    };
+  }, [fallbackModelLabel, user?.userId]);
 
   return (
     <div className="page assistant-workspace-page">


### PR DESCRIPTION
## Summary
- Add `/v1/model-routing/effective` so the UI can fetch the signed-in user's effective route metadata.
- Update the assistant workspace model disclosure to show the backend route label instead of static `VITE_CHAT_MODEL_LABEL` when available.
- Keep static label as fallback if route disclosure cannot be loaded.

## Production diagnosis
- `mmatonok@gmail.com` resolves in prod to `plan=free`, `route_type=free_local`, `provider=local_ollama`, `model=qwen3.6:27b`.
- The visible Azure label came from the frontend's static model disclosure label, not the backend routing decision.

## Validation
- `npm test -- --run src/__tests__/assistantWorkspace.test.tsx`
- `npm run build`
- `python -m pytest api/aijuristiction-api/tests/test_ai_model_routing.py::test_effective_model_route_endpoint_reports_free_user_local_model -q`
- `scripts/validate_api.ps1` via pre-commit: ruff + mypy
- `python examples/minimal_demo.py`

Note: `test_expired_paid_subscription_routes_as_free_local_model` still passes in the repo's normal 3.11 env from the previous fix. In the bundled Python 3.12 runtime used here it hits an existing OpenSSL Applink issue while importing the routed OpenAI client; the new endpoint regression itself passes.