### PR TITLE
Add payment process E2E coverage

### DIFF
--- a/.github/workflows/scheduled_e2e_status.yml
+++ b/.github/workflows/scheduled_e2e_status.yml
@@ -63,6 +63,7 @@ jobs:
             tests/chat.spec.ts \
             tests/chat-simulator.spec.ts \
             tests/mobile-auth-subscription.spec.ts \
+            tests/payment-process.spec.ts \
             tests/case-generated-document-pdf.spec.ts \
             --reporter=json > scheduled-e2e-results.json
           test_exit=$?

--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -923,6 +923,7 @@ Current E2E specs:
 - `tests/chat.spec.ts`
 - `tests/chat-simulator.spec.ts`
 - `tests/mobile-auth-subscription.spec.ts` (covers mobile login + subscription request flow against user endpoints)
+- `tests/payment-process.spec.ts` (simulates synthetic user checkout, sandbox payment confirmation, and payment guard rails)
 - Negative auth test in `tests/chat.spec.ts` runs only when `RUN_NEGATIVE_AUTH_TESTS=1`.
 
 Scheduled E2E status:
@@ -963,6 +964,23 @@ Run the mobile authentication + subscription lifecycle check used by the Flutter
 cd api/aijuristiction-api/e2e-playwright
 API_KEY=aijuris npx playwright test tests/mobile-auth-subscription.spec.ts
 ```
+
+Run the synthetic user payment-process simulation:
+
+```bash
+cd api/aijuristiction-api/e2e-playwright
+API_KEY=aijuris npm run test:payment
+```
+
+On Windows PowerShell:
+
+```powershell
+cd api/aijuristiction-api/e2e-playwright
+$env:API_KEY="aijuris"
+npm run test:payment
+```
+
+The payment E2E uses only generated test identities and the API's sandbox checkout contract. It does not send real payment-provider traffic or reuse production personal data.
 
 Run the chat simulator streaming test with fixture input and uploaded txt document:
 

--- a/api/aijuristiction-api/e2e-playwright/e2e-test-catalog.json
+++ b/api/aijuristiction-api/e2e-playwright/e2e-test-catalog.json
@@ -54,6 +54,24 @@
     "scheduled": true
   },
   {
+    "id": "payment-process-checkout-confirmation",
+    "file": "tests/payment-process.spec.ts",
+    "title": "payment process: user checks out Case plan and confirms sandbox payment",
+    "name": "Case plan payment process",
+    "description": "Simulates a synthetic user selecting the Case plan, receiving a sandbox checkout URL, confirming payment, and observing the paid subscription.",
+    "area": "Payments",
+    "scheduled": true
+  },
+  {
+    "id": "payment-process-guards",
+    "file": "tests/payment-process.spec.ts",
+    "title": "payment process guards: disabled plans and unknown payments do not activate subscriptions",
+    "name": "Payment process guard rails",
+    "description": "Verifies disabled paid plans remain unavailable and unknown payment IDs cannot activate a paying subscription.",
+    "area": "Payments",
+    "scheduled": true
+  },
+  {
     "id": "case-pdf-selected-slovak",
     "file": "tests/case-generated-document-pdf.spec.ts",
     "title": "case generated PDF renders selected Slovak document without assistant or English blocks",

--- a/api/aijuristiction-api/e2e-playwright/package.json
+++ b/api/aijuristiction-api/e2e-playwright/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "version": "0.1.1",
   "scripts": {
-    "test": "playwright test"
+    "test": "playwright test",
+    "test:payment": "playwright test tests/payment-process.spec.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2"

--- a/api/aijuristiction-api/e2e-playwright/tests/payment-process.spec.ts
+++ b/api/aijuristiction-api/e2e-playwright/tests/payment-process.spec.ts
@@ -1,0 +1,186 @@
+import { APIRequestContext, expect, test } from '@playwright/test';
+import { ensureLiveApiOrFail } from './helpers/liveApi';
+
+const apiKey = process.env.API_KEY ?? 'aijuris';
+
+type Plan = {
+  plan_code: string;
+  display_name: string;
+  price_eur: number;
+};
+
+type CheckoutResponse = {
+  subscription_id: string;
+  plan_code: string;
+  payment_provider: string;
+  payment_id: string;
+  payment_status: string;
+  amount_eur: number;
+  checkout_url: string;
+};
+
+type SubscriptionResponse = {
+  subscription_id: string;
+  user_id: string;
+  plan_code: string;
+  status: string;
+};
+
+function uniquePaymentIdentity() {
+  const nonce = `${Date.now()}${Math.floor(Math.random() * 10000)}`;
+  return {
+    phone: `+421901${nonce.slice(-6)}`,
+    email: `payment.playwright.${nonce}@example.com`,
+    password: `Payment-${nonce}`,
+  };
+}
+
+async function createSyntheticUser(request: APIRequestContext, baseURL: string | undefined) {
+  const identity = uniquePaymentIdentity();
+
+  const signUpResponse = await request.post(`${baseURL}/v1/users/sign-up`, {
+    headers: { 'x-api-key': apiKey },
+    data: {
+      phone_number: identity.phone,
+      email: identity.email,
+      password: identity.password,
+      first_name: 'Payment',
+      last_name: 'Simulator',
+      data_processing_consent_accepted: true,
+      data_processing_consent_version: 'e2e-payment-process',
+    },
+  });
+  expect(signUpResponse.status()).toBe(201);
+
+  const user = (await signUpResponse.json()) as { user_id: string; email: string };
+  expect(user.user_id).toBeTruthy();
+  expect(user.email).toBe(identity.email);
+  return user;
+}
+
+test.beforeEach(async ({ request, baseURL }) => {
+  await ensureLiveApiOrFail(request, baseURL);
+});
+
+test('payment process: user checks out Case plan and confirms sandbox payment', async ({ request, baseURL }) => {
+  const user = await createSyntheticUser(request, baseURL);
+
+  const plansResponse = await request.get(`${baseURL}/v1/users/subscriptions/plans`, {
+    headers: { 'x-api-key': apiKey },
+  });
+  expect(plansResponse.status()).toBe(200);
+  const plans = (await plansResponse.json()) as Plan[];
+  const casePlan = plans.find((plan) => plan.plan_code === 'case');
+  expect(casePlan).toBeTruthy();
+  expect(casePlan?.price_eur).toBe(10);
+
+  const checkoutResponse = await request.post(`${baseURL}/v1/users/${user.user_id}/subscriptions/checkout`, {
+    headers: { 'x-api-key': apiKey },
+    data: { plan_code: 'case', payment_provider: 'paypal' },
+  });
+  expect(checkoutResponse.status()).toBe(201);
+  const checkout = (await checkoutResponse.json()) as CheckoutResponse;
+
+  expect(checkout).toMatchObject({
+    plan_code: 'case',
+    payment_provider: 'paypal',
+    payment_status: 'pending',
+    amount_eur: 10,
+  });
+  expect(checkout.subscription_id).toBeTruthy();
+  expect(checkout.payment_id).toMatch(/^PAY-/);
+  const checkoutUrl = new URL(checkout.checkout_url);
+  expect(checkoutUrl.origin).toBe('https://www.sandbox.paypal.com');
+  expect(checkoutUrl.searchParams.get('paymentId')).toBe(checkout.payment_id);
+  expect(checkoutUrl.searchParams.get('token')).toBeTruthy();
+
+  const payingSubscriptionsResponse = await request.get(`${baseURL}/v1/users/${user.user_id}/subscriptions`, {
+    headers: { 'x-api-key': apiKey },
+  });
+  expect(payingSubscriptionsResponse.status()).toBe(200);
+  const payingSubscriptions = (await payingSubscriptionsResponse.json()) as SubscriptionResponse[];
+  expect(
+    payingSubscriptions.some(
+      (subscription) =>
+        subscription.subscription_id === checkout.subscription_id &&
+        subscription.plan_code === 'case' &&
+        subscription.status === 'paying'
+    )
+  ).toBeTruthy();
+
+  const confirmResponse = await request.post(
+    `${baseURL}/v1/users/subscriptions/${checkout.subscription_id}/confirm-payment`,
+    {
+      headers: { 'x-api-key': apiKey },
+      data: { payment_id: checkout.payment_id },
+    }
+  );
+  expect(confirmResponse.status()).toBe(200);
+  const confirmedSubscription = (await confirmResponse.json()) as SubscriptionResponse;
+  expect(confirmedSubscription).toMatchObject({
+    subscription_id: checkout.subscription_id,
+    user_id: user.user_id,
+    plan_code: 'case',
+    status: 'paid',
+  });
+
+  const finalSubscriptionsResponse = await request.get(`${baseURL}/v1/users/${user.user_id}/subscriptions`, {
+    headers: { 'x-api-key': apiKey },
+  });
+  expect(finalSubscriptionsResponse.status()).toBe(200);
+  const finalSubscriptions = (await finalSubscriptionsResponse.json()) as SubscriptionResponse[];
+  expect(
+    finalSubscriptions.some(
+      (subscription) =>
+        subscription.subscription_id === checkout.subscription_id &&
+        subscription.plan_code === 'case' &&
+        subscription.status === 'paid'
+    )
+  ).toBeTruthy();
+});
+
+test('payment process guards: disabled plans and unknown payments do not activate subscriptions', async ({
+  request,
+  baseURL,
+}) => {
+  const user = await createSyntheticUser(request, baseURL);
+
+  const disabledCheckoutResponse = await request.post(
+    `${baseURL}/v1/users/${user.user_id}/subscriptions/checkout`,
+    {
+      headers: { 'x-api-key': apiKey },
+      data: { plan_code: 'premium', payment_provider: 'paypal' },
+    }
+  );
+  expect(disabledCheckoutResponse.status()).toBe(503);
+  await expect(disabledCheckoutResponse.json()).resolves.toMatchObject({
+    detail: 'This subscription plan is coming soon.',
+  });
+
+  const checkoutResponse = await request.post(`${baseURL}/v1/users/${user.user_id}/subscriptions/checkout`, {
+    headers: { 'x-api-key': apiKey },
+    data: { plan_code: 'case', payment_provider: 'google_pay' },
+  });
+  expect(checkoutResponse.status()).toBe(201);
+  const checkout = (await checkoutResponse.json()) as CheckoutResponse;
+  expect(checkout.payment_provider).toBe('google_pay');
+  expect(new URL(checkout.checkout_url).origin).toBe('https://pay.google.com');
+
+  const wrongPaymentResponse = await request.post(
+    `${baseURL}/v1/users/subscriptions/${checkout.subscription_id}/confirm-payment`,
+    {
+      headers: { 'x-api-key': apiKey },
+      data: { payment_id: 'PAY-not-created-by-checkout' },
+    }
+  );
+  expect(wrongPaymentResponse.status()).toBe(404);
+  await expect(wrongPaymentResponse.json()).resolves.toMatchObject({ detail: 'Payment not found' });
+
+  const subscriptionsResponse = await request.get(`${baseURL}/v1/users/${user.user_id}/subscriptions`, {
+    headers: { 'x-api-key': apiKey },
+  });
+  expect(subscriptionsResponse.status()).toBe(200);
+  const subscriptions = (await subscriptionsResponse.json()) as SubscriptionResponse[];
+  const subscription = subscriptions.find((item) => item.subscription_id === checkout.subscription_id);
+  expect(subscription?.status).toBe('paying');
+});

--- a/docs/E2E_CONTRACT_TESTS.md
+++ b/docs/E2E_CONTRACT_TESTS.md
@@ -14,17 +14,33 @@ This repository now includes deterministic end-to-end simulations for two docume
    - Reviews it against the repository's simulated current prenajom compliance checklist.
    - Produces an updated lease text plus a PDF-like diff artifact showing old vs. new clauses.
 
+3. **Synthetic payment process**
+   - Creates a synthetic user through the live API.
+   - Selects the Case plan and receives a sandbox checkout URL.
+   - Confirms the simulated payment and verifies that the subscription becomes `paid`.
+   - Verifies guard rails: disabled plans stay unavailable, and unknown payment IDs do not activate subscriptions.
+
 ## Files
 
 - Root mirror test: `root_contract_end_to_end_test.py`
 - Main end-to-end tests: `e2etests/test_contract_end_to_end.py`
 - Workflow helpers: `src/aijurisdictionagents/e2e_workflows.py`
+- Payment-process Playwright spec: `api/aijuristiction-api/e2e-playwright/tests/payment-process.spec.ts`
 
 ## Run locally
 
 ```bash
 pytest e2etests/test_contract_end_to_end.py root_contract_end_to_end_test.py
 ```
+
+Run the Playwright payment-process simulation:
+
+```bash
+cd api/aijuristiction-api/e2e-playwright
+npm run test:payment
+```
+
+The payment-process E2E is GDPR/privacy-by-design safe for local and scheduled runs: it uses generated identities, local test storage, log-only email transport in CI, and the API sandbox checkout contract instead of a real payment-provider charge.
 
 ## Minimal runnable example
 

--- a/examples/payment_process_e2e_demo.py
+++ b/examples/payment_process_e2e_demo.py
@@ -1,0 +1,26 @@
+"""Print the minimal command for the Playwright payment-process E2E.
+
+Run from the repository root:
+
+    python examples/payment_process_e2e_demo.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    e2e_dir = repo_root / "api" / "aijuristiction-api" / "e2e-playwright"
+    spec = e2e_dir / "tests" / "payment-process.spec.ts"
+    if not spec.exists():
+        raise SystemExit(f"Missing payment E2E spec: {spec}")
+
+    print("Payment-process E2E minimal command:")
+    print(f"cd {e2e_dir}")
+    print("npm run test:payment")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds Playwright API E2E coverage for the synthetic Case-plan payment process.
- Covers sandbox checkout URL creation, payment confirmation to `paid`, disabled-plan rejection, and unknown payment-id guard rails.
- Registers the payment spec in the scheduled E2E catalog/workflow and documents local run commands plus GDPR-safe synthetic-data behavior.

Closes #363

## Validation
- `npm run test:payment` with `API_BASE_URL=http://127.0.0.1:8091`, `PW_START_API=1`, `LLM_PROVIDER=mock`, `DB_OPTION=local`, `EMAIL_TRANSPORT=log`: 2 passed.
- Pre-commit hook ran `scripts/validate_api.ps1`: ruff and mypy passed.