### PR TITLE
Implement subscription invoice payment flow

### DIFF
--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -77,6 +77,7 @@ Required setup for chat model routing:
 - Free/default users use the seeded `local_ollama_default` route: provider `local_ollama`, base URL `http://127.0.0.1:11434/v1`, exact model `qwen3.6:27b`.
 - Paid `case`, `basic`, `premium`, and `unlimited` users use the seeded Azure Foundry route `azure_foundry_gpt_4o_mini`: exact model/deployment `gpt-4o-mini`.
 - A paid subscription is considered active for routing only while `starts_at` has begun and `ends_at` is empty or in the future. Expired paid rows fall back to the Free/local Ollama route.
+- Subscription checkout creates a `pending` subscription only. The subscription becomes active only after `/v1/users/subscriptions/{subscription_id}/confirm-payment` confirms payment, which queues a payment-confirmed email with a generated invoice attached as both PDF and UBL XML.
 - The assistant UI should read `/v1/model-routing/effective` for the signed-in user before displaying model disclosure text. This endpoint returns only privacy-minimized route metadata, so Free users see the same local Ollama model that the backend will actually use.
 - Azure Foundry chat endpoint belongs in `ai_model_providers.base_url`.
 - Azure Foundry API key or token belongs in encrypted `ai_model_credentials`, managed through `/v1/admin/ai-models`.

--- a/api/aijuristiction-api/app/services/email_templates.py
+++ b/api/aijuristiction-api/app/services/email_templates.py
@@ -75,8 +75,15 @@ def build_subscription_status_email(*, full_name: str, plan_code: str, status: s
     normalized_status = _display_value(status)
     if status == "paid":
         subject = "Payment confirmed"
-        paragraphs = ["Payment for your subscription was confirmed and your plan is active."]
-        body = f"Hello {name},\n\npayment for your '{plan}' subscription was confirmed and your plan is active.\n"
+        paragraphs = [
+            "Payment for your subscription was confirmed and your plan is active.",
+            "Your invoice is attached as a PDF and UBL XML file.",
+        ]
+        body = (
+            f"Hello {name},\n\n"
+            f"payment for your '{plan}' subscription was confirmed and your plan is active.\n"
+            "Your invoice is attached as a PDF and UBL XML file.\n"
+        )
     elif status == "failed":
         subject = "Payment failed"
         paragraphs = ["Payment for your subscription failed. Please retry your payment method."]

--- a/api/aijuristiction-api/app/services/subscription_invoices.py
+++ b/api/aijuristiction-api/app/services/subscription_invoices.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, ROUND_HALF_UP
+from io import BytesIO
+from typing import Any, cast
+from xml.etree import ElementTree
+
+from reportlab.lib.pagesizes import A4  # type: ignore[import-untyped]
+from reportlab.pdfgen import canvas  # type: ignore[import-untyped]
+
+from aijurisdictionagents.api_db import SubscriptionPlan, User, UserSubscription
+
+
+@dataclass(frozen=True)
+class SubscriptionInvoice:
+    invoice_id: str
+    issued_at: str
+    user: User
+    subscription: UserSubscription
+    plan: SubscriptionPlan
+    payment_provider: str
+    payment_id: str
+    amount_eur: Decimal
+
+    @property
+    def invoice_number(self) -> str:
+        year = self.issued_at[:4] or "0000"
+        suffix = self.subscription.subscription_id.replace("-", "")[:8].upper()
+        return f"JD-{year}-{suffix}"
+
+
+def build_subscription_invoice(
+    *,
+    user: User,
+    subscription: UserSubscription,
+    plan: SubscriptionPlan,
+    payment_provider: str,
+    payment_id: str,
+) -> SubscriptionInvoice:
+    issued_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    invoice_id = f"inv_{subscription.subscription_id.replace('-', '')[:16]}"
+    return SubscriptionInvoice(
+        invoice_id=invoice_id,
+        issued_at=issued_at,
+        user=user,
+        subscription=subscription,
+        plan=plan,
+        payment_provider=payment_provider,
+        payment_id=payment_id,
+        amount_eur=_eur(plan.price_eur),
+    )
+
+
+def build_subscription_invoice_attachments(invoice: SubscriptionInvoice) -> list[dict[str, Any]]:
+    pdf_bytes = render_subscription_invoice_pdf(invoice)
+    xml_bytes = render_subscription_invoice_ubl(invoice)
+    filename_root = invoice.invoice_number.lower()
+    return [
+        {
+            "filename": f"{filename_root}.pdf",
+            "mime_type": "application/pdf",
+            "content_base64": base64.b64encode(pdf_bytes).decode("ascii"),
+            "disposition": "attachment",
+        },
+        {
+            "filename": f"{filename_root}.xml",
+            "mime_type": "application/xml",
+            "content_base64": base64.b64encode(xml_bytes).decode("ascii"),
+            "disposition": "attachment",
+        },
+    ]
+
+
+def render_subscription_invoice_pdf(invoice: SubscriptionInvoice) -> bytes:
+    buffer = BytesIO()
+    pdf = canvas.Canvas(buffer, pagesize=A4, pageCompression=0)
+    width, height = A4
+    margin = 56
+    y = height - margin
+
+    pdf.setTitle(invoice.invoice_number)
+    pdf.setFont("Helvetica-Bold", 18)
+    pdf.drawString(margin, y, "JurisDigta Invoice")
+    y -= 36
+
+    pdf.setFont("Helvetica", 10)
+    rows = [
+        ("Invoice number", invoice.invoice_number),
+        ("Issued at", invoice.issued_at),
+        ("Supplier", "JurisDigta"),
+        ("Buyer", invoice.user.full_name),
+        ("Buyer email", invoice.user.email),
+        ("Subscription", invoice.plan.display_name),
+        ("Payment provider", invoice.payment_provider),
+        ("Payment reference", invoice.payment_id),
+    ]
+    for label, value in rows:
+        pdf.setFont("Helvetica-Bold", 10)
+        pdf.drawString(margin, y, f"{label}:")
+        pdf.setFont("Helvetica", 10)
+        pdf.drawString(margin + 130, y, _pdf_value(value))
+        y -= 18
+
+    y -= 12
+    pdf.setFont("Helvetica-Bold", 11)
+    pdf.drawString(margin, y, "Description")
+    pdf.drawRightString(width - margin, y, "Amount")
+    y -= 10
+    pdf.line(margin, y, width - margin, y)
+    y -= 18
+
+    pdf.setFont("Helvetica", 10)
+    pdf.drawString(margin, y, f"{invoice.plan.display_name} subscription")
+    pdf.drawRightString(width - margin, y, f"{_money(invoice.amount_eur)} EUR")
+    y -= 24
+    pdf.line(margin, y, width - margin, y)
+    y -= 20
+    pdf.setFont("Helvetica-Bold", 12)
+    pdf.drawRightString(width - margin, y, f"Total: {_money(invoice.amount_eur)} EUR")
+    y -= 36
+
+    pdf.setFont("Helvetica", 9)
+    pdf.drawString(
+        margin,
+        y,
+        "Generated from the subscription payment confirmation record. Review before accounting use.",
+    )
+    pdf.showPage()
+    pdf.save()
+    return buffer.getvalue()
+
+
+def render_subscription_invoice_ubl(invoice: SubscriptionInvoice) -> bytes:
+    invoice_element = ElementTree.Element("Invoice", {"xmlns": "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"})
+    _child(invoice_element, "CustomizationID", "urn:cen.eu:en16931:2017")
+    _child(invoice_element, "ProfileID", "urn:fdc:peppol.eu:2017:poacc:billing:01:1.0")
+    _child(invoice_element, "ID", invoice.invoice_number)
+    _child(invoice_element, "IssueDate", invoice.issued_at[:10])
+    _child(invoice_element, "InvoiceTypeCode", "380")
+    _child(invoice_element, "DocumentCurrencyCode", "EUR")
+    _child(invoice_element, "BuyerReference", invoice.user.user_id)
+
+    supplier = _child(invoice_element, "AccountingSupplierParty")
+    supplier_party = _child(supplier, "Party")
+    _child(supplier_party, "Name", "JurisDigta")
+
+    customer = _child(invoice_element, "AccountingCustomerParty")
+    customer_party = _child(customer, "Party")
+    _child(customer_party, "Name", invoice.user.full_name)
+    contact = _child(customer_party, "Contact")
+    _child(contact, "ElectronicMail", invoice.user.email)
+
+    payment = _child(invoice_element, "PaymentMeans")
+    _child(payment, "PaymentMeansCode", "68")
+    _child(payment, "PaymentID", invoice.payment_id)
+
+    total = _child(invoice_element, "LegalMonetaryTotal")
+    amount = _money(invoice.amount_eur)
+    _child(total, "LineExtensionAmount", amount, {"currencyID": "EUR"})
+    _child(total, "TaxExclusiveAmount", amount, {"currencyID": "EUR"})
+    _child(total, "TaxInclusiveAmount", amount, {"currencyID": "EUR"})
+    _child(total, "PayableAmount", amount, {"currencyID": "EUR"})
+
+    line = _child(invoice_element, "InvoiceLine")
+    _child(line, "ID", "1")
+    _child(line, "InvoicedQuantity", "1", {"unitCode": "EA"})
+    _child(line, "LineExtensionAmount", amount, {"currencyID": "EUR"})
+    item = _child(line, "Item")
+    _child(item, "Name", f"{invoice.plan.display_name} subscription")
+    price = _child(line, "Price")
+    _child(price, "PriceAmount", amount, {"currencyID": "EUR"})
+
+    ElementTree.indent(invoice_element, space="  ")
+    return cast(bytes, ElementTree.tostring(invoice_element, encoding="utf-8", xml_declaration=True))
+
+
+def _child(
+    parent: ElementTree.Element,
+    tag: str,
+    text: str | None = None,
+    attributes: dict[str, str] | None = None,
+) -> ElementTree.Element:
+    child = ElementTree.SubElement(parent, tag, attributes or {})
+    if text is not None:
+        child.text = text
+    return child
+
+
+def _eur(value: int) -> Decimal:
+    return Decimal(value).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _money(value: Decimal) -> str:
+    return str(value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
+
+
+def _pdf_value(value: str) -> str:
+    return " ".join(str(value or "").split())[:96]

--- a/api/aijuristiction-api/app/users/api.py
+++ b/api/aijuristiction-api/app/users/api.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 from app.mcp_tokens import create_mcp_api_token
 from app.security import require_api_key
 from app.services.email_scheduler import EmailScheduler
+from app.services.subscription_invoices import build_subscription_invoice
 from app.users.notifications import (
     queue_registration_email,
     queue_subscription_change_email,
@@ -801,7 +802,6 @@ def checkout_subscription_change(
 
     try:
         subscription = store.request_subscription_change(user_id=user_id, plan_code=plan_code)
-        subscription = store.update_subscription_status(subscription_id=subscription.subscription_id, status="paying")
     except Exception as exc:
         if not _is_integrity_error(exc):
             raise
@@ -855,7 +855,17 @@ def confirm_subscription_payment(
 
     payment["payment_status"] = "paid"
     item = store.update_subscription_status(subscription_id=subscription_id, status="paid")
-    queue_subscription_status_email(scheduler=scheduler, user=user, item=item)
+    plan = next((plan for plan in store.list_subscription_plans() if plan.plan_code == item.plan_code), None)
+    if plan is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid plan code")
+    invoice = build_subscription_invoice(
+        user=user,
+        subscription=item,
+        plan=plan,
+        payment_provider=str(payment["payment_provider"]),
+        payment_id=payload.payment_id,
+    )
+    queue_subscription_status_email(scheduler=scheduler, user=user, item=item, invoice=invoice)
     return _to_subscription_response(item)
 
 

--- a/api/aijuristiction-api/app/users/notifications.py
+++ b/api/aijuristiction-api/app/users/notifications.py
@@ -9,6 +9,7 @@ from app.services.email_templates import (
     build_subscription_status_email,
     build_welcome_email,
 )
+from app.services.subscription_invoices import SubscriptionInvoice, build_subscription_invoice_attachments
 
 from aijurisdictionagents.api_db import User, UserSubscription
 
@@ -39,7 +40,13 @@ def queue_subscription_change_email(*, scheduler: EmailScheduler, user: User, it
     )
 
 
-def queue_subscription_status_email(*, scheduler: EmailScheduler, user: User, item: UserSubscription) -> None:
+def queue_subscription_status_email(
+    *,
+    scheduler: EmailScheduler,
+    user: User,
+    item: UserSubscription,
+    invoice: SubscriptionInvoice | None = None,
+) -> None:
     email = build_subscription_status_email(
         full_name=user.full_name,
         plan_code=item.plan_code,
@@ -55,6 +62,12 @@ def queue_subscription_status_email(*, scheduler: EmailScheduler, user: User, it
         event = "subscription_status"
         context = "subscription_status"
     metadata = email.metadata(event=event, subscription_id=item.subscription_id)
+    if invoice is not None:
+        metadata["invoice_id"] = invoice.invoice_id
+        metadata["invoice_number"] = invoice.invoice_number
+        metadata["payment_id"] = invoice.payment_id
+        metadata["payment_provider"] = invoice.payment_provider
+        metadata["attachments"] = list(metadata["attachments"]) + build_subscription_invoice_attachments(invoice)
     if item.status not in {"paid", "failed"}:
         metadata["status"] = item.status
     _queue_email_safely(

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260477"
+version = "1.0.260478"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_users.py
+++ b/api/aijuristiction-api/tests/test_users.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+import base64
 import hashlib
+import json
 import sqlite3
 from pathlib import Path
 
@@ -797,6 +799,14 @@ def test_case_subscription_checkout_and_payment_confirmation(monkeypatch, tmp_pa
     assert checkout["payment_status"] == "pending"
     assert checkout["checkout_url"].startswith("https://www.sandbox.paypal.com")
 
+    subscriptions_before_payment = client.get(f"/v1/users/{user_id}/subscriptions", headers=AUTH_HEADERS)
+    assert subscriptions_before_payment.status_code == 200
+    pending_subscription = subscriptions_before_payment.json()[0]
+    assert pending_subscription["subscription_id"] == checkout["subscription_id"]
+    assert pending_subscription["status"] == "pending"
+    assert pending_subscription["starts_at"] is None
+    assert pending_subscription["ends_at"] is None
+
     confirm_response = client.post(
         f"/v1/users/subscriptions/{checkout['subscription_id']}/confirm-payment",
         headers=AUTH_HEADERS,
@@ -816,6 +826,25 @@ def test_case_subscription_checkout_and_payment_confirmation(monkeypatch, tmp_pa
         "Welcome to AI Jurisdiction",
         "Payment confirmed",
     ]
+
+    with sqlite3.connect(tmp_path / "email.sqlite3") as conn:
+        metadata_json = conn.execute(
+            "SELECT metadata_json FROM email_outbox WHERE subject = ?",
+            ("Payment confirmed",),
+        ).fetchone()[0]
+    metadata = json.loads(metadata_json)
+    assert metadata["event"] == "subscription_payment"
+    assert metadata["invoice_id"].startswith("inv_")
+    assert metadata["invoice_number"].startswith("JD-")
+    invoice_attachments = [
+        item for item in metadata["attachments"] if item.get("disposition") == "attachment"
+    ]
+    assert [item["mime_type"] for item in invoice_attachments] == ["application/pdf", "application/xml"]
+    assert base64.b64decode(invoice_attachments[0]["content_base64"]).startswith(b"%PDF")
+    invoice_xml = base64.b64decode(invoice_attachments[1]["content_base64"]).decode("utf-8")
+    assert "<Invoice" in invoice_xml
+    assert "<ID>" in invoice_xml
+    assert "<PayableAmount currencyID=\"EUR\">10.00</PayableAmount>" in invoice_xml
 
 
 def test_disabled_subscription_checkout_is_rejected(monkeypatch, tmp_path: Path) -> None:

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -20,6 +20,10 @@ print(
     "OTP/code emails remain plain text."
 )
 print(
+    "subscription_invoice_checkout => checkout keeps subscriptions pending until payment confirmation; "
+    "confirmation queues the invoice email with PDF and UBL XML attachments."
+)
+print(
     "mcp_auth_ux => browser MCP login/sign-up pages localize Slovak/English via Accept-Language; "
     "invalid OTP submissions re-render HTML warnings instead of JSON errors."
 )


### PR DESCRIPTION
## Summary
- keep checkout-created subscriptions pending until payment confirmation
- generate subscription invoice PDF and UBL XML attachments on confirmed payment
- queue the invoice with the payment-confirmed email and document the behavior

Closes #364

## Verification
- .\\scripts\\validate_api.ps1
- .\\conda\\python.exe -m pytest api\\aijuristiction-api\\tests\\test_users.py::test_case_subscription_checkout_and_payment_confirmation api\\aijuristiction-api\\tests\\test_email_templates.py -q
- .\\conda\\python.exe examples\\minimal_demo.py

Note: full API test suite is blocked in this local bundled runtime by unrelated OpenSSL Applink failure in test_ai_model_routing.py::test_expired_paid_subscription_routes_as_free_local_model.