### PR TITLE
[codex] Add AI model token monitoring dashboards

### DIFF
--- a/Deployment/monitoring/README.md
+++ b/Deployment/monitoring/README.md
@@ -18,12 +18,13 @@ GET /v1/system/status?minutes=60
 - Last processed law, next law to check, latest laws collector run timestamps, and latest run duration.
 - Email sent counts, email queue counts, and aggregate email send duration from the outbox.
 - Document processor queue counts, processed document counts, latest run duration, and aggregate processing duration.
-- AI model token and cost telemetry after task #365 lands: input tokens, cached input tokens, output tokens, total tokens, estimated EUR cost, fallback count, and latency by case, provider, model, task type, plan, user, group, and hour/day/month window.
+- AI model token and cost telemetry: input tokens, cached input tokens, output tokens, total tokens, estimated EUR cost, request count, and fallback count by provider, model, task type, plan, route type, route class, and 1h/24h/7d/30d window.
 - Host CPU, memory, disk, filesystem, and kernel metrics through Node Exporter.
 - Docker container CPU, memory, filesystem, and restart behavior through cAdvisor.
 - Prometheus health and scrape status.
 - Docker stdout/stderr logs and server job log files through Grafana Alloy and Loki.
-- Provisioned AI model usage panels in `JurisDigta Application Performance` for aggregate status, cost, requests by route, input/output tokens by model, and top cost by plan/task/provider/model route.
+- Provisioned AI model usage panels in `JurisDigta Application Performance` for aggregate status, cost, requests by route, input/output/total tokens by model, and top cost by plan/task/provider/model route.
+- Provisioned masked top-10 case token panels in `JurisDigta Ollama And AI Models` for Grafana-only operational triage.
 
 ## Security Baseline
 
@@ -45,11 +46,15 @@ http://127.0.0.1:3000
 - If Grafana must be reachable through `admin.jurisdigta.eu`, publish it through Cloudflare Tunnel and protect it with Cloudflare Access plus Grafana login.
 - Keep dashboard panels operational only. Do not display user chat text, generated legal documents, API keys, database connection strings, or legal-risk user outputs.
 - Email and document processor panels must stay aggregate-only: queue counts, sent/processed counts, and timing gauges. Do not add recipients, filenames, case titles, extracted document text, verification codes, embeddings, or raw connection strings as labels.
-- AI model panels must stay metadata-only. Allowed labels include internal IDs and categories such as case ID, user ID, subscription ID, plan code, provider, model, task type, route type, and fallback reason. Do not add prompts, answers, document text, filenames, party names, citations, emails, phone numbers, addresses, or other legal-case facts as metric labels.
+- Shared AI model panels must stay aggregate-only. Allowed labels include categories such as plan code, provider, model, task type, route type, route class, status, fallback reason, and window. Do not add raw case IDs, user IDs, subscription IDs, prompts, answers, document text, filenames, party names, citations, emails, phone numbers, addresses, or other legal-case facts as metric labels. The top-case Grafana panel uses masked `case_ref` values only.
 
 ## AI Model Token And Cost Monitoring
 
-Task #365 model routing must emit or export Prometheus-compatible metrics for input and output token usage per case and per model. The source of truth should be the API usage ledger; Prometheus/Grafana should read aggregate counters/gauges derived from that ledger rather than raw prompts or documents.
+Model routing must emit or export Prometheus-compatible metrics for input and
+output token usage per model/route, plus a masked top-case operational view. The
+source of truth is the API usage ledger; Prometheus/Grafana reads aggregate
+counters/gauges derived from that ledger rather than raw prompts, documents, or
+raw user/case identifiers.
 
 Required ledger fields for every model call:
 
@@ -77,17 +82,17 @@ Required ledger fields for every model call:
 - `fallback_reason`
 - `confidentiality_warning_ack_id`
 
-Recommended metric names:
+Current metric names:
 
-- `jurisdigta_ai_model_input_tokens_total`
-- `jurisdigta_ai_model_cached_input_tokens_total`
-- `jurisdigta_ai_model_output_tokens_total`
-- `jurisdigta_ai_model_tokens_total`
-- `jurisdigta_ai_model_cost_eur_total`
-- `jurisdigta_ai_model_requests_total`
-- `jurisdigta_ai_model_budget_remaining_eur`
-- `jurisdigta_ai_model_fallbacks_total`
-- `jurisdigta_ai_model_latency_seconds`
+- `jurisdigta_ai_model_requests_window`
+- `jurisdigta_ai_model_input_tokens_window`
+- `jurisdigta_ai_model_cached_input_tokens_window`
+- `jurisdigta_ai_model_output_tokens_window`
+- `jurisdigta_ai_model_total_tokens_window`
+- `jurisdigta_ai_model_estimated_cost_eur_window`
+- `jurisdigta_ai_model_top_case_requests_window`
+- `jurisdigta_ai_model_top_case_total_tokens_window`
+- `jurisdigta_ai_model_top_case_estimated_cost_eur_window`
 
 Recommended labels:
 
@@ -95,26 +100,26 @@ Recommended labels:
 - `model`
 - `task_type`
 - `route_type`
+- `route_class`
 - `plan_code`
-- `model_group_id`
-- `case_id`
-- `user_id`
-- `subscription_id`
+- `case_ref` only on masked top-case metrics
 - `status`
 - `fallback_reason`
+- `window_minutes`
 
 Provisioned Grafana panels:
 
 - AI model usage status
 - AI model cost in the current status window
-- AI model requests by task, provider, model, route type, and status
-- input and output tokens by model
+- AI model requests by task, provider, model, route type, route class, and status
+- local/Ollama and paid-model total tokens by provider/model/route
+- masked top 10 cases by token volume and estimated cost
+- input, cached input, output, and total tokens by model
 - top AI model cost by plan, task, provider, model, and route type
 
-Optional drill-down panels for a protected admin-only dashboard:
-
-- input tokens by model for a selected case
-- output tokens by model for a selected case
+Case-level drill-down remains limited to masked top-case Grafana rows. Raw
+case/user/subscription identifiers stay in the API usage ledger and case audit
+APIs, not in shared Prometheus labels.
 - total tokens by model and task type
 - estimated EUR cost by model for the selected case
 - model cost per user over hour/day/month windows
@@ -498,7 +503,7 @@ Grafana loads JurisDigta dashboards from `grafana/dashboards` into the
 
 - `JurisDigta Server Performance`: CPU, RAM, disk, load, network, disk I/O, and container memory.
 - `JurisDigta Application Performance`: API/MCP/web/Grafana HTTP probes, component status, email queue/sent/time, document queue/processed/time, laws processing cursor and runtime, and application error counts.
-- `JurisDigta Ollama And AI Models`: Ollama API health, configured model presence, installed/running model counts, model size, loaded model VRAM, probe latency, input/output tokens, requests, estimated cost, and top cases by token volume.
+- `JurisDigta Ollama And AI Models`: Ollama API health, configured model presence, installed/running model counts, model size, loaded model VRAM, probe latency, local/Ollama tokens, paid-model tokens, requests, estimated cost, and masked top cases by token volume.
 - `JurisDigta Laws Collector`: execution time, imported laws per latest run, processed entries/documents, and recent sanitized collector errors.
 - `JurisDigta Errors`: total errors, error telemetry status, error counts by source, HTTP probe status codes, and scrape target health.
 - `JurisDigta System Logs`: Loki log stream with source, severity, stream, and regex search filters for Docker container logs and server job log files.
@@ -564,11 +569,13 @@ Useful starter queries:
 - `jurisdigta_document_processing_duration_seconds_avg{window="24h"}`
 - `jurisdigta_document_processing_duration_seconds_max{window="24h"}`
 - `jurisdigta_document_processor_last_run_duration_seconds`
-- `jurisdigta_ai_model_input_tokens_total{model="...",case_id="..."}`
-- `jurisdigta_ai_model_output_tokens_total{model="...",case_id="..."}`
-- `jurisdigta_ai_model_cost_eur_total{model="...",case_id="..."}`
-- `jurisdigta_ai_model_budget_remaining_eur{case_id="..."}`
-- `jurisdigta_ai_model_fallbacks_total{model="...",fallback_reason="..."}`
+- `jurisdigta_ai_model_input_tokens_window{provider="...",model="...",route_class="...",window_minutes="..."}`
+- `jurisdigta_ai_model_cached_input_tokens_window{provider="...",model="...",route_class="...",window_minutes="..."}`
+- `jurisdigta_ai_model_output_tokens_window{provider="...",model="...",route_class="...",window_minutes="..."}`
+- `jurisdigta_ai_model_total_tokens_window{provider="...",model="...",route_class="...",window_minutes="..."}`
+- `jurisdigta_ai_model_estimated_cost_eur_window{provider="...",model="...",route_class="...",window_minutes="..."}`
+- `jurisdigta_ai_model_top_case_total_tokens_window{case_ref="case-....",route_class="...",window_minutes="..."}`
+- `jurisdigta_ai_model_top_case_estimated_cost_eur_window{case_ref="case-....",route_class="...",window_minutes="..."}`
 - `up{job="node-exporter"}`
 - `up{job="cadvisor"}`
 
@@ -578,7 +585,10 @@ Suggested alert rules:
 - API blackbox probe failure for more than 2 minutes.
 - Any `jurisdigta_errors_window` above `0` for 10 minutes.
 - Paid case model budget remaining below 10%.
-- Model output-token spend spike above normal threshold for any provider/model.
+- Ollama exporter/API down for more than 2 minutes.
+- Configured Ollama model missing for more than 5 minutes.
+- Paid-model token usage above 200,000 tokens in the 1h API-ledger window for more than 10 minutes.
+- Paid-model estimated cost above 10 EUR in the 1h API-ledger window for more than 10 minutes.
 - Disk used above 80%.
 - Memory used above 85%.
 - Laws collector last run older than 36 hours.

--- a/Deployment/monitoring/docker-compose.yml
+++ b/Deployment/monitoring/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus-rules:/etc/prometheus/rules:ro
       - prometheus-data:/prometheus
     depends_on:
       - status-exporter

--- a/Deployment/monitoring/grafana/dashboards/jurisdigta-application-performance.json
+++ b/Deployment/monitoring/grafana/dashboards/jurisdigta-application-performance.json
@@ -2243,7 +2243,46 @@
     "application"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "1h",
+          "value": "60"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Usage window",
+        "multi": false,
+        "name": "usage_window",
+        "options": [
+          {
+            "selected": true,
+            "text": "1h",
+            "value": "60"
+          },
+          {
+            "selected": false,
+            "text": "24h",
+            "value": "1440"
+          },
+          {
+            "selected": false,
+            "text": "7d",
+            "value": "10080"
+          },
+          {
+            "selected": false,
+            "text": "30d",
+            "value": "43200"
+          }
+        ],
+        "query": "60,1440,10080,43200",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/Deployment/monitoring/grafana/dashboards/jurisdigta-ollama-models.json
+++ b/Deployment/monitoring/grafana/dashboards/jurisdigta-ollama-models.json
@@ -426,17 +426,27 @@
       },
       "targets": [
         {
-          "expr": "sum by (provider, model, route_type) (jurisdigta_ai_model_input_tokens_window)",
-          "legendFormat": "input {{provider}} {{model}} {{route_type}}",
+          "expr": "sum by (provider, model, route_class, route_type) (jurisdigta_ai_model_input_tokens_window{window_minutes=\"$usage_window\"})",
+          "legendFormat": "input {{route_class}} {{provider}} {{model}} {{route_type}}",
           "refId": "A"
         },
         {
-          "expr": "sum by (provider, model, route_type) (jurisdigta_ai_model_output_tokens_window)",
-          "legendFormat": "output {{provider}} {{model}} {{route_type}}",
+          "expr": "sum by (provider, model, route_class, route_type) (jurisdigta_ai_model_cached_input_tokens_window{window_minutes=\"$usage_window\"})",
+          "legendFormat": "cached {{route_class}} {{provider}} {{model}} {{route_type}}",
           "refId": "B"
+        },
+        {
+          "expr": "sum by (provider, model, route_class, route_type) (jurisdigta_ai_model_output_tokens_window{window_minutes=\"$usage_window\"})",
+          "legendFormat": "output {{route_class}} {{provider}} {{model}} {{route_type}}",
+          "refId": "C"
+        },
+        {
+          "expr": "sum by (provider, model, route_class, route_type) (jurisdigta_ai_model_total_tokens_window{window_minutes=\"$usage_window\"})",
+          "legendFormat": "total {{route_class}} {{provider}} {{model}} {{route_type}}",
+          "refId": "D"
         }
       ],
-      "title": "Input And Output Tokens By Model",
+      "title": "AI Tokens By Model And Route",
       "type": "timeseries"
     },
     {
@@ -476,12 +486,12 @@
       },
       "targets": [
         {
-          "expr": "sum by (provider, model, route_type) (jurisdigta_ai_model_estimated_cost_eur_window)",
+          "expr": "sum by (provider, model, route_type) (jurisdigta_ai_model_estimated_cost_eur_window{route_class=\"paid\",window_minutes=\"$usage_window\"})",
           "legendFormat": "{{provider}} {{model}} {{route_type}}",
           "refId": "A"
         }
       ],
-      "title": "Estimated Model Cost",
+      "title": "Paid Model Estimated Cost",
       "type": "timeseries"
     },
     {
@@ -521,8 +531,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (task_type, provider, model) (jurisdigta_ai_model_requests_window)",
-          "legendFormat": "{{task_type}} {{provider}} {{model}}",
+          "expr": "sum by (task_type, provider, model, route_class) (jurisdigta_ai_model_requests_window{window_minutes=\"$usage_window\"})",
+          "legendFormat": "{{task_type}} {{route_class}} {{provider}} {{model}}",
           "refId": "A"
         }
       ],
@@ -563,15 +573,112 @@
       },
       "targets": [
         {
-          "expr": "topk(20, sum by (case_id, provider, model, task_type) (jurisdigta_ai_model_total_tokens_window))",
+          "expr": "topk(10, sum by (case_ref, route_class, plan_code) (jurisdigta_ai_model_top_case_total_tokens_window{window_minutes=\"$usage_window\"}))",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
           "refId": "A"
+        },
+        {
+          "expr": "topk(10, sum by (case_ref, route_class, plan_code) (jurisdigta_ai_model_top_case_estimated_cost_eur_window{window_minutes=\"$usage_window\"}))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "B"
         }
       ],
-      "title": "Top Cases By Tokens",
+      "title": "Top 10 Cases By Tokens (Masked)",
       "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "jurisdigta-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "type": "timeseries",
+      "id": 11,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "targets": [
+        {
+          "expr": "sum by (provider, model, route_type) (jurisdigta_ai_model_total_tokens_window{route_class=\"local\",window_minutes=\"$usage_window\"})",
+          "legendFormat": "{{provider}} {{model}} {{route_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Local/Ollama Total Tokens"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "jurisdigta-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "type": "timeseries",
+      "id": 12,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "targets": [
+        {
+          "expr": "sum by (provider, model, route_type) (jurisdigta_ai_model_total_tokens_window{route_class=\"paid\",window_minutes=\"$usage_window\"})",
+          "legendFormat": "{{provider}} {{model}} {{route_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Paid Model Total Tokens"
     }
   ],
   "refresh": "30s",
@@ -582,7 +689,46 @@
     "ai-models"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "1h",
+          "value": "60"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Usage window",
+        "multi": false,
+        "name": "usage_window",
+        "options": [
+          {
+            "selected": true,
+            "text": "1h",
+            "value": "60"
+          },
+          {
+            "selected": false,
+            "text": "24h",
+            "value": "1440"
+          },
+          {
+            "selected": false,
+            "text": "7d",
+            "value": "10080"
+          },
+          {
+            "selected": false,
+            "text": "30d",
+            "value": "43200"
+          }
+        ],
+        "query": "60,1440,10080,43200",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/Deployment/monitoring/prometheus-rules/jurisdigta-ai-models.yml
+++ b/Deployment/monitoring/prometheus-rules/jurisdigta-ai-models.yml
@@ -1,0 +1,42 @@
+groups:
+  - name: jurisdigta-ai-models
+    rules:
+      - alert: JurisDigtaOllamaExporterDown
+        expr: up{job="jurisdigta-ollama"} == 0 or max(jurisdigta_ollama_up) == 0
+        for: 2m
+        labels:
+          severity: critical
+          component: ollama
+        annotations:
+          summary: "JurisDigta Ollama metrics are red"
+          description: "Prometheus cannot scrape Ollama metrics or the Ollama exporter reports the Ollama API as down."
+
+      - alert: JurisDigtaOllamaConfiguredModelMissing
+        expr: max(jurisdigta_ollama_configured_model_present) == 0
+        for: 5m
+        labels:
+          severity: warning
+          component: ollama
+        annotations:
+          summary: "Configured Ollama model is missing"
+          description: "LOCAL_LLM_MODEL is not present in the Ollama model inventory exported to Prometheus."
+
+      - alert: JurisDigtaPaidModelTokenSpike
+        expr: sum(jurisdigta_ai_model_total_tokens_window{route_class="paid",window_minutes="60"}) > 200000
+        for: 10m
+        labels:
+          severity: warning
+          component: ai-model-usage
+        annotations:
+          summary: "Paid-model token usage spike"
+          description: "Paid-model token usage in the 1h API-ledger window exceeded 200,000 tokens."
+
+      - alert: JurisDigtaPaidModelCostSpike
+        expr: sum(jurisdigta_ai_model_estimated_cost_eur_window{route_class="paid",window_minutes="60"}) > 10
+        for: 10m
+        labels:
+          severity: warning
+          component: ai-model-usage
+        annotations:
+          summary: "Paid-model estimated cost spike"
+          description: "Paid-model estimated cost in the 1h API-ledger window exceeded 10 EUR."

--- a/Deployment/monitoring/prometheus.yml
+++ b/Deployment/monitoring/prometheus.yml
@@ -2,6 +2,9 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
 scrape_configs:
   - job_name: prometheus
     static_configs:

--- a/Deployment/self-managed-server-deployment.md
+++ b/Deployment/self-managed-server-deployment.md
@@ -1180,9 +1180,10 @@ Components:
 - cAdvisor: Docker container CPU, memory, filesystem, and restart metrics.
 - Blackbox Exporter: API availability probes.
 - Monitoring containers join `MONITORING_APP_DOCKER_NETWORK`, defaulting to `aijuristiction-api_default`, so API and MCP are probed by container name while their host ports stay bound to `127.0.0.1`.
-- `scripts/server/export_system_status_metrics.py`: converts `GET /v1/system/status?minutes=60` into Prometheus text metrics.
+- `scripts/server/export_system_status_metrics.py`: converts `GET /v1/system/status?minutes=60` into Prometheus text metrics, including API-ledger token/cost windows for 1h, 24h, 7d, and 30d.
 - `scripts/server/export_ollama_metrics.py`: exports localhost-only Ollama health, model inventory, loaded model, and VRAM gauges.
 - `scripts/server/write_system_status.py`: records aggregate API/MCP request counts, average/max request latency, total users, new users, total cases, and new cases without exposing personal data or legal case content in Prometheus labels.
+- `Deployment/monitoring/prometheus-rules/jurisdigta-ai-models.yml`: evaluates Ollama red-state alerts and paid-model token/cost spike alerts.
 
 Start the JurisDigta status exporter:
 
@@ -1217,6 +1218,9 @@ docker compose ps
 cd /srv/jurisdigta/app && PROMETHEUS_BASE_URL=http://127.0.0.1:9091 python3 examples/monitoring_scrape_demo.py
 curl -fsS 'http://127.0.0.1:9091/api/v1/query?query=jurisdigta_users_total'
 curl -fsS 'http://127.0.0.1:9091/api/v1/query?query=jurisdigta_http_requests_total_window'
+curl -fsS 'http://127.0.0.1:9091/api/v1/query?query=jurisdigta_ai_model_total_tokens_window'
+curl -fsS 'http://127.0.0.1:9091/api/v1/query?query=jurisdigta_ai_model_top_case_total_tokens_window'
+curl -fsS 'http://127.0.0.1:9091/api/v1/rules'
 ```
 
 Access Grafana by SSH tunnel first:

--- a/api/aijuristiction-api/app/system_status_api.py
+++ b/api/aijuristiction-api/app/system_status_api.py
@@ -25,6 +25,7 @@ router = APIRouter(
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _APPLICATIONS: tuple[ApplicationName, ...] = ("api", "laws_collector", "document_processor")
+_AI_USAGE_WINDOWS_MINUTES = (60, 24 * 60, 7 * 24 * 60, 30 * 24 * 60)
 
 
 @router.get("/status")
@@ -218,28 +219,42 @@ def _ai_model_usage_payload(*, minutes: int) -> dict[str, Any]:
         from aijurisdictionagents.api_db import ApiDatabaseStore
 
         store = ApiDatabaseStore.from_env()
-        summaries = store.summarize_ai_model_usage(minutes=minutes)
+        windows = _ai_usage_windows(minutes)
+        summaries = [
+            (window, item)
+            for window in windows
+            for item in store.summarize_ai_model_usage(minutes=window)
+        ]
+        top_cases = [
+            (window, item)
+            for window in windows
+            for item in store.summarize_top_ai_model_cases(minutes=window, limit=10)
+        ]
     except Exception as exc:
         return {
             "status": "error",
             "window_minutes": minutes,
             "message": str(exc),
             "summaries": [],
+            "top_cases": [],
         }
 
     return {
         "status": "ok",
         "window_minutes": minutes,
+        "available_windows_minutes": windows,
         "summaries": [
             {
-                "case_id": item.case_id,
-                "user_id": item.user_id,
-                "subscription_id": item.subscription_id,
+                "window_minutes": window,
                 "plan_code": item.plan_code,
                 "task_type": item.task_type,
                 "provider": item.provider,
                 "model": item.model,
                 "route_type": item.route_type,
+                "route_class": _ai_usage_route_class(
+                    provider=item.provider,
+                    route_type=item.route_type,
+                ),
                 "status": item.status,
                 "fallback_reason": item.fallback_reason,
                 "input_tokens": item.input_tokens,
@@ -249,9 +264,57 @@ def _ai_model_usage_payload(*, minutes: int) -> dict[str, Any]:
                 "estimated_cost_eur": item.estimated_cost_eur,
                 "request_count": item.request_count,
             }
-            for item in summaries
+            for window, item in summaries
+        ],
+        "top_cases": [
+            {
+                "window_minutes": window,
+                "case_ref": _masked_case_ref(item.case_id),
+                "plan_code": item.plan_code,
+                "provider": item.provider,
+                "model": item.model,
+                "route_type": item.route_type,
+                "route_class": _ai_usage_route_class(
+                    provider=item.provider,
+                    route_type=item.route_type,
+                ),
+                "input_tokens": item.input_tokens,
+                "cached_input_tokens": item.cached_input_tokens,
+                "output_tokens": item.output_tokens,
+                "total_tokens": item.total_tokens,
+                "estimated_cost_eur": item.estimated_cost_eur,
+                "request_count": item.request_count,
+            }
+            for window, item in top_cases
         ],
     }
+
+
+def _ai_usage_windows(requested_minutes: int) -> list[int]:
+    windows = list(_AI_USAGE_WINDOWS_MINUTES)
+    if requested_minutes not in windows:
+        windows.insert(0, requested_minutes)
+    return windows
+
+
+def _ai_usage_route_class(*, provider: str, route_type: str) -> str:
+    normalized_provider = provider.strip().lower()
+    normalized_route = route_type.strip().lower()
+    if normalized_route in {"local", "local_only"} or "ollama" in normalized_provider:
+        return "local"
+    if normalized_route in {"external", "external_ack_required"}:
+        return "paid"
+    return normalized_route or "unknown"
+
+
+def _masked_case_ref(case_id: str) -> str:
+    normalized = case_id.strip()
+    if not normalized:
+        return "case-unknown"
+    compact = normalized.replace("-", "")
+    if len(compact) >= 8:
+        return f"case-{compact[:4]}...{compact[-4:]}"
+    return f"case-...{compact[-4:]}"
 
 
 def _laws_collector_runtime_from_server_file() -> dict[str, Any] | None:

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260478"
+version = "1.0.260479"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_ai_model_routing.py
+++ b/api/aijuristiction-api/tests/test_ai_model_routing.py
@@ -319,7 +319,9 @@ def test_paid_external_route_requires_acknowledgement(tmp_path: Path) -> None:
     assert allowed.model_profile.model_code == "gpt-4.1"
 
 
-def test_usage_ledger_summarizes_tokens_and_cost_by_case_model(tmp_path: Path) -> None:
+def test_usage_ledger_summarizes_tokens_and_cost_by_model_without_identifiers(
+    tmp_path: Path,
+) -> None:
     store = _store(tmp_path)
     store.record_ai_model_usage(
         provider="azure_foundry",
@@ -354,11 +356,44 @@ def test_usage_ledger_summarizes_tokens_and_cost_by_case_model(tmp_path: Path) -
     assert len(summaries) == 1
     summary = summaries[0]
     assert summary.request_count == 2
+    assert summary.case_id == ""
+    assert summary.user_id == ""
+    assert summary.subscription_id == ""
     assert summary.input_tokens == 1200
     assert summary.cached_input_tokens == 250
     assert summary.output_tokens == 600
     assert summary.total_tokens == 1800
     assert summary.estimated_cost_eur == 0.012
+
+
+def test_usage_ledger_lists_top_cases_by_tokens(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.record_ai_model_usage(
+        provider="local_ollama",
+        model="qwen3.6:27b",
+        route_type="local",
+        input_tokens=500,
+        output_tokens=250,
+        case_id="case-local",
+        plan_code="free",
+    )
+    store.record_ai_model_usage(
+        provider="azure_foundry",
+        model="gpt-4.1",
+        route_type="external",
+        input_tokens=3000,
+        output_tokens=1000,
+        estimated_cost_eur=0.05,
+        case_id="case-paid",
+        plan_code="case",
+    )
+
+    top_cases = store.summarize_top_ai_model_cases(minutes=60, limit=1)
+
+    assert len(top_cases) == 1
+    assert top_cases[0].case_id == "case-paid"
+    assert top_cases[0].total_tokens == 4000
+    assert top_cases[0].estimated_cost_eur == 0.05
 
 
 def test_usage_ledger_lists_question_model_audit_entries(tmp_path: Path) -> None:
@@ -410,13 +445,32 @@ def test_status_exporter_renders_ai_model_usage_metrics() -> None:
                         "case_id": "case-1",
                         "user_id": "user-1",
                         "subscription_id": "sub-1",
+                        "window_minutes": 60,
                         "plan_code": "case",
                         "task_type": "document_generation",
                         "provider": "azure_foundry",
                         "model": "gpt-4.1",
                         "route_type": "external",
+                        "route_class": "paid",
                         "status": "ok",
                         "fallback_reason": "",
+                        "request_count": 2,
+                        "input_tokens": 1200,
+                        "cached_input_tokens": 250,
+                        "output_tokens": 600,
+                        "total_tokens": 2050,
+                        "estimated_cost_eur": 0.012,
+                    },
+                ],
+                "top_cases": [
+                    {
+                        "case_ref": "case-...se-1",
+                        "window_minutes": 60,
+                        "plan_code": "case",
+                        "provider": "azure_foundry",
+                        "model": "gpt-4.1",
+                        "route_type": "external",
+                        "route_class": "paid",
                         "request_count": 2,
                         "input_tokens": 1200,
                         "cached_input_tokens": 250,
@@ -430,7 +484,11 @@ def test_status_exporter_renders_ai_model_usage_metrics() -> None:
     )
 
     assert "jurisdigta_ai_model_output_tokens_window" in rendered
-    assert 'case_id="case-1"' in rendered
+    assert 'case_id="case-1"' not in rendered
+    assert 'user_id="user-1"' not in rendered
+    assert 'subscription_id="sub-1"' not in rendered
+    assert 'case_ref="case-...se-1"' in rendered
+    assert "jurisdigta_ai_model_top_case_total_tokens_window" in rendered
     assert 'model="gpt-4.1"' in rendered
     assert " 600.0" in rendered
     assert "jurisdigta_ai_model_estimated_cost_eur_window" in rendered

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -416,6 +416,10 @@ Optional server-local monitoring setting in `/srv/jurisdigta/app/Deployment/moni
 | `GRAFANA_DEFAULT_HOME_DASHBOARD_PATH` | `/var/lib/grafana/dashboards/jurisdigta-application-performance.json` | Grafana dashboard JSON shown as the default home dashboard after login |
 | `OLLAMA_METRICS_PORT` | `9109` | Host-local Ollama Prometheus exporter port scraped by Prometheus through `host.docker.internal` |
 
+The monitoring stack also loads `Deployment/monitoring/prometheus-rules/jurisdigta-ai-models.yml`
+for Ollama red-state and high paid-model token/cost alerts. No extra GitHub
+Environment secret is required for those default thresholds.
+
 Minimal workflow validation after setup:
 
 1. Run `Self-Managed Prod Deploy` with `repo_ref=main`.

--- a/docs/SYSTEM_STATUS_MONITORING.md
+++ b/docs/SYSTEM_STATUS_MONITORING.md
@@ -263,20 +263,32 @@ Useful Grafana panels:
 - `jurisdigta_ollama_running_model_vram_bytes`
 - `jurisdigta_ai_model_requests_window`
 - `jurisdigta_ai_model_input_tokens_window`
+- `jurisdigta_ai_model_cached_input_tokens_window`
 - `jurisdigta_ai_model_output_tokens_window`
+- `jurisdigta_ai_model_total_tokens_window`
 - `jurisdigta_ai_model_estimated_cost_eur_window`
+- `jurisdigta_ai_model_top_case_total_tokens_window`
+- `jurisdigta_ai_model_top_case_estimated_cost_eur_window`
 
 The provisioned `JurisDigta Application Performance` dashboard includes
-aggregate AI model panels for usage status, current-window EUR cost, requests by
-route, tokens by provider/model/route, and top cost by plan/task/provider/model
-route. Keep these dashboard queries aggregate-only. Case IDs, user IDs, prompts,
-answers, generated documents, filenames, emails, phone numbers, addresses, or
-legal-case facts must not be added to the shared application dashboard labels or
-legends. If an incident requires case/user drill-down, create a separate
-admin-only dashboard protected by Cloudflare Access and Grafana permissions.
+aggregate AI model panels for usage status, EUR cost, requests by route, and
+tokens by provider/model/route for 1h, 24h, 7d, and 30d windows. The provisioned
+`JurisDigta Ollama And AI Models` dashboard also includes local/Ollama tokens,
+paid-model tokens, and a masked top-10 case consumption table. Keep shared
+dashboard queries aggregate-only. Raw case IDs, user IDs, subscription IDs,
+prompts, answers, generated documents, filenames, emails, phone numbers,
+addresses, or legal-case facts must not be added to Prometheus labels or
+legends. Case-level Grafana triage must use the masked `case_ref` label only.
 - `jurisdigta_ai_model_input_tokens_window`
 - `jurisdigta_ai_model_output_tokens_window`
 - `jurisdigta_ai_model_estimated_cost_eur_window`
+
+Prometheus loads `Deployment/monitoring/prometheus-rules/jurisdigta-ai-models.yml`
+for Ollama red-state and paid-model usage alerts. The initial thresholds are:
+Ollama exporter/API down for 2 minutes, configured Ollama model missing for 5
+minutes, paid-model tokens above 200,000 in the 1h API-ledger window for 10
+minutes, and paid-model estimated cost above 10 EUR in the 1h API-ledger window
+for 10 minutes.
 
 Email notification setup:
 

--- a/examples/monitoring_scrape_demo.py
+++ b/examples/monitoring_scrape_demo.py
@@ -44,8 +44,25 @@ def main() -> int:
         if isinstance(result.get("metric"), dict)
         and result["metric"].get("instance") in active_probe_instances
     ]
+    missing_queries = [
+        expression
+        for expression in (
+            "jurisdigta_ollama_up",
+            "jurisdigta_ai_model_total_tokens_window",
+            "jurisdigta_ai_model_top_case_total_tokens_window",
+        )
+        if not _query(expression)
+    ]
+    missing_alerts = _missing_alert_rules(
+        {
+            "JurisDigtaOllamaExporterDown",
+            "JurisDigtaOllamaConfiguredModelMissing",
+            "JurisDigtaPaidModelTokenSpike",
+            "JurisDigtaPaidModelCostSpike",
+        }
+    )
 
-    if failed_scrapes or failed_probes:
+    if failed_scrapes or failed_probes or missing_queries or missing_alerts:
         print("Monitoring validation failed.")
         if failed_scrapes:
             print("Failed scrape targets:")
@@ -55,9 +72,20 @@ def main() -> int:
             print("Failed HTTP probes:")
             for result in failed_probes:
                 print(json.dumps(result.get("metric", {}), sort_keys=True))
+        if missing_queries:
+            print("Missing expected Prometheus metrics:")
+            for expression in missing_queries:
+                print(expression)
+        if missing_alerts:
+            print("Missing expected Prometheus alert rules:")
+            for alert_name in sorted(missing_alerts):
+                print(alert_name)
         return 1
 
-    print("Monitoring validation passed: all Prometheus scrapes and JurisDigta HTTP probes are healthy.")
+    print(
+        "Monitoring validation passed: Prometheus scrapes, JurisDigta HTTP probes, "
+        "AI token metrics, and AI model alert rules are healthy."
+    )
     return 0
 
 
@@ -81,6 +109,27 @@ def _failed_results(results: list[dict[str, object]]) -> list[dict[str, object]]
         if isinstance(value, list) and len(value) >= 2 and value[1] != "1":
             failed.append(result)
     return failed
+
+
+def _missing_alert_rules(expected: set[str]) -> set[str]:
+    url = f"{PROMETHEUS_BASE_URL}/api/v1/rules"
+    with urlopen(url, timeout=10) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if payload.get("status") != "success":
+        raise RuntimeError(f"Prometheus rules lookup failed: {payload}")
+    groups = payload.get("data", {}).get("groups", [])
+    found: set[str] = set()
+    if isinstance(groups, list):
+        for group in groups:
+            if not isinstance(group, dict):
+                continue
+            rules = group.get("rules", [])
+            if not isinstance(rules, list):
+                continue
+            for rule in rules:
+                if isinstance(rule, dict) and isinstance(rule.get("name"), str):
+                    found.add(rule["name"])
+    return expected - found
 
 
 if __name__ == "__main__":

--- a/scripts/server/export_system_status_metrics.py
+++ b/scripts/server/export_system_status_metrics.py
@@ -427,43 +427,92 @@ def _append_business_metrics(lines: list[str], business: dict[str, Any]) -> None
 
 def _append_ai_model_usage_metrics(lines: list[str], ai_model_usage: dict[str, Any]) -> None:
     summaries = ai_model_usage.get("summaries")
-    if not isinstance(summaries, list):
-        return
-    window_minutes = int(_number(ai_model_usage.get("window_minutes"), 60))
     _append_help(lines, "jurisdigta_ai_model_requests_window", "AI model request count in the status query window.", "gauge")
     _append_help(lines, "jurisdigta_ai_model_input_tokens_window", "AI input tokens in the status query window.", "gauge")
     _append_help(lines, "jurisdigta_ai_model_cached_input_tokens_window", "AI cached input tokens in the status query window.", "gauge")
     _append_help(lines, "jurisdigta_ai_model_output_tokens_window", "AI output tokens in the status query window.", "gauge")
     _append_help(lines, "jurisdigta_ai_model_total_tokens_window", "AI total tokens in the status query window.", "gauge")
     _append_help(lines, "jurisdigta_ai_model_estimated_cost_eur_window", "Estimated AI model cost in EUR in the status query window.", "gauge")
-    for summary in summaries:
-        if not isinstance(summary, dict):
-            continue
-        labels = (
-            f'provider="{_label(str(summary.get("provider") or ""))}",'
-            f'model="{_label(str(summary.get("model") or ""))}",'
-            f'task_type="{_label(str(summary.get("task_type") or ""))}",'
-            f'route_type="{_label(str(summary.get("route_type") or ""))}",'
-            f'plan_code="{_label(str(summary.get("plan_code") or ""))}",'
-            f'case_id="{_label(str(summary.get("case_id") or ""))}",'
-            f'user_id="{_label(str(summary.get("user_id") or ""))}",'
-            f'subscription_id="{_label(str(summary.get("subscription_id") or ""))}",'
-            f'status="{_label(str(summary.get("status") or ""))}",'
-            f'fallback_reason="{_label(str(summary.get("fallback_reason") or ""))}",'
-            f'window_minutes="{window_minutes}"'
-        )
-        lines.append(f"jurisdigta_ai_model_requests_window{{{labels}}} {_number(summary.get('request_count'), 0)}")
-        lines.append(f"jurisdigta_ai_model_input_tokens_window{{{labels}}} {_number(summary.get('input_tokens'), 0)}")
-        lines.append(
-            "jurisdigta_ai_model_cached_input_tokens_window"
-            f"{{{labels}}} {_number(summary.get('cached_input_tokens'), 0)}"
-        )
-        lines.append(f"jurisdigta_ai_model_output_tokens_window{{{labels}}} {_number(summary.get('output_tokens'), 0)}")
-        lines.append(f"jurisdigta_ai_model_total_tokens_window{{{labels}}} {_number(summary.get('total_tokens'), 0)}")
-        lines.append(
-            "jurisdigta_ai_model_estimated_cost_eur_window"
-            f"{{{labels}}} {_number(summary.get('estimated_cost_eur'), 0)}"
-        )
+    if isinstance(summaries, list):
+        for summary in summaries:
+            if not isinstance(summary, dict):
+                continue
+            labels = _ai_model_usage_labels(
+                summary,
+                default_window_minutes=int(_number(ai_model_usage.get("window_minutes"), 60)),
+            )
+            lines.append(f"jurisdigta_ai_model_requests_window{{{labels}}} {_number(summary.get('request_count'), 0)}")
+            lines.append(f"jurisdigta_ai_model_input_tokens_window{{{labels}}} {_number(summary.get('input_tokens'), 0)}")
+            lines.append(
+                "jurisdigta_ai_model_cached_input_tokens_window"
+                f"{{{labels}}} {_number(summary.get('cached_input_tokens'), 0)}"
+            )
+            lines.append(f"jurisdigta_ai_model_output_tokens_window{{{labels}}} {_number(summary.get('output_tokens'), 0)}")
+            lines.append(f"jurisdigta_ai_model_total_tokens_window{{{labels}}} {_number(summary.get('total_tokens'), 0)}")
+            lines.append(
+                "jurisdigta_ai_model_estimated_cost_eur_window"
+                f"{{{labels}}} {_number(summary.get('estimated_cost_eur'), 0)}"
+            )
+
+    top_cases = ai_model_usage.get("top_cases")
+    _append_help(lines, "jurisdigta_ai_model_top_case_requests_window", "Top case AI request count in the status query window.", "gauge")
+    _append_help(lines, "jurisdigta_ai_model_top_case_total_tokens_window", "Top case AI total tokens in the status query window.", "gauge")
+    _append_help(lines, "jurisdigta_ai_model_top_case_input_tokens_window", "Top case AI input tokens in the status query window.", "gauge")
+    _append_help(lines, "jurisdigta_ai_model_top_case_output_tokens_window", "Top case AI output tokens in the status query window.", "gauge")
+    _append_help(lines, "jurisdigta_ai_model_top_case_estimated_cost_eur_window", "Top case estimated AI model cost in EUR in the status query window.", "gauge")
+    if isinstance(top_cases, list):
+        for item in top_cases:
+            if not isinstance(item, dict):
+                continue
+            labels = _ai_model_usage_labels(
+                item,
+                default_window_minutes=int(_number(ai_model_usage.get("window_minutes"), 60)),
+                case_ref=str(item.get("case_ref") or "case-unknown"),
+            )
+            lines.append(
+                "jurisdigta_ai_model_top_case_requests_window"
+                f"{{{labels}}} {_number(item.get('request_count'), 0)}"
+            )
+            lines.append(
+                "jurisdigta_ai_model_top_case_total_tokens_window"
+                f"{{{labels}}} {_number(item.get('total_tokens'), 0)}"
+            )
+            lines.append(
+                "jurisdigta_ai_model_top_case_input_tokens_window"
+                f"{{{labels}}} {_number(item.get('input_tokens'), 0)}"
+            )
+            lines.append(
+                "jurisdigta_ai_model_top_case_output_tokens_window"
+                f"{{{labels}}} {_number(item.get('output_tokens'), 0)}"
+            )
+            lines.append(
+                "jurisdigta_ai_model_top_case_estimated_cost_eur_window"
+                f"{{{labels}}} {_number(item.get('estimated_cost_eur'), 0)}"
+            )
+
+
+def _ai_model_usage_labels(
+    item: dict[str, Any],
+    *,
+    default_window_minutes: int,
+    case_ref: str | None = None,
+) -> str:
+    labels = [
+        f'provider="{_label(str(item.get("provider") or ""))}"',
+        f'model="{_label(str(item.get("model") or ""))}"',
+        f'route_type="{_label(str(item.get("route_type") or ""))}"',
+        f'route_class="{_label(str(item.get("route_class") or ""))}"',
+        f'plan_code="{_label(str(item.get("plan_code") or ""))}"',
+        f'status="{_label(str(item.get("status") or "ok"))}"',
+        f'fallback_reason="{_label(str(item.get("fallback_reason") or ""))}"',
+        f'window_minutes="{int(_number(item.get("window_minutes"), default_window_minutes))}"',
+    ]
+    task_type = item.get("task_type")
+    if task_type is not None:
+        labels.insert(2, f'task_type="{_label(str(task_type or ""))}"')
+    if case_ref is not None:
+        labels.insert(0, f'case_ref="{_label(case_ref)}"')
+    return ",".join(labels)
 
 
 def _render_exporter_error(exc: Exception) -> str:

--- a/src/aijurisdictionagents/api_db/store.py
+++ b/src/aijurisdictionagents/api_db/store.py
@@ -311,6 +311,21 @@ class AIModelUsageSummary:
 
 
 @dataclass(frozen=True)
+class AIModelTopCaseUsage:
+    case_id: str
+    plan_code: str
+    provider: str
+    model: str
+    route_type: str
+    input_tokens: int
+    cached_input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    estimated_cost_eur: float
+    request_count: int
+
+
+@dataclass(frozen=True)
 class AIModelUsageAuditEntry:
     usage_id: str
     case_id: str
@@ -1646,19 +1661,61 @@ class ApiDatabaseStore:
             rows = self._execute(
                 conn,
                 f"""
-                SELECT case_id, user_id, subscription_id, plan_code, task_type, provider,
+                SELECT '' AS case_id, '' AS user_id, '' AS subscription_id,
+                       plan_code, task_type, provider,
                        model, route_type, status, fallback_reason,
                        SUM(input_tokens), SUM(cached_input_tokens), SUM(output_tokens),
                        SUM(total_tokens), SUM(estimated_cost_eur), COUNT(*)
                 FROM ai_model_usage_ledger
                 WHERE request_completed_at >= ?{case_filter}
-                GROUP BY case_id, user_id, subscription_id, plan_code, task_type, provider,
-                         model, route_type, status, fallback_reason
+                GROUP BY plan_code, task_type, provider, model, route_type, status,
+                         fallback_reason
                 ORDER BY SUM(estimated_cost_eur) DESC, SUM(total_tokens) DESC
                 """,
                 tuple(params),
             ).fetchall()
         return [_row_to_ai_model_usage_summary(row) for row in rows]
+
+    def summarize_top_ai_model_cases(
+        self,
+        *,
+        minutes: int = 60,
+        limit: int = 10,
+    ) -> list[AIModelTopCaseUsage]:
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(minutes=max(minutes, 1))
+        ).isoformat().replace("+00:00", "Z")
+        bounded_limit = min(max(limit, 1), 50)
+        with self._connect() as conn:
+            rows = self._execute(
+                conn,
+                """
+                SELECT case_id, plan_code, 'all' AS provider, 'all' AS model,
+                       CASE
+                           WHEN route_type IN ('local', 'local_only') OR provider LIKE '%ollama%'
+                           THEN 'local'
+                           WHEN route_type IN ('external', 'external_ack_required')
+                           THEN 'paid'
+                           ELSE COALESCE(NULLIF(route_type, ''), 'unknown')
+                       END AS route_type,
+                       SUM(input_tokens), SUM(cached_input_tokens), SUM(output_tokens),
+                       SUM(total_tokens), SUM(estimated_cost_eur), COUNT(*)
+                FROM ai_model_usage_ledger
+                WHERE request_completed_at >= ? AND case_id <> ''
+                GROUP BY case_id, plan_code,
+                         CASE
+                             WHEN route_type IN ('local', 'local_only') OR provider LIKE '%ollama%'
+                             THEN 'local'
+                             WHEN route_type IN ('external', 'external_ack_required')
+                             THEN 'paid'
+                             ELSE COALESCE(NULLIF(route_type, ''), 'unknown')
+                         END
+                ORDER BY SUM(total_tokens) DESC, SUM(estimated_cost_eur) DESC
+                LIMIT ?
+                """,
+                (cutoff, bounded_limit),
+            ).fetchall()
+        return [_row_to_ai_model_top_case_usage(row) for row in rows]
 
     def list_ai_model_usage_audit(
         self,
@@ -4410,6 +4467,22 @@ def _row_to_ai_model_usage_summary(row: tuple[object, ...]) -> AIModelUsageSumma
         total_tokens=int(row[13] or 0),
         estimated_cost_eur=float(row[14] or 0),
         request_count=int(row[15] or 0),
+    )
+
+
+def _row_to_ai_model_top_case_usage(row: tuple[object, ...]) -> AIModelTopCaseUsage:
+    return AIModelTopCaseUsage(
+        case_id=str(row[0]),
+        plan_code=str(row[1]),
+        provider=str(row[2]),
+        model=str(row[3]),
+        route_type=str(row[4]),
+        input_tokens=int(row[5] or 0),
+        cached_input_tokens=int(row[6] or 0),
+        output_tokens=int(row[7] or 0),
+        total_tokens=int(row[8] or 0),
+        estimated_cost_eur=float(row[9] or 0),
+        request_count=int(row[10] or 0),
     )
 
 

--- a/tests/test_server_monitoring.py
+++ b/tests/test_server_monitoring.py
@@ -61,8 +61,25 @@ def test_monitoring_dashboards_include_ollama_ai_models_dashboard() -> None:
     assert dashboard["uid"] == "jurisdigta-ollama-models"
     assert "Ollama API" in panel_titles
     assert "Loaded Model VRAM" in panel_titles
-    assert "Input And Output Tokens By Model" in panel_titles
-    assert "Top Cases By Tokens" in panel_titles
+    assert "AI Tokens By Model And Route" in panel_titles
+    assert "Local/Ollama Total Tokens" in panel_titles
+    assert "Paid Model Total Tokens" in panel_titles
+    assert "Top 10 Cases By Tokens (Masked)" in panel_titles
+    assert any(item["name"] == "usage_window" for item in dashboard["templating"]["list"])
+
+
+def test_monitoring_stack_loads_ai_model_alert_rules() -> None:
+    compose = (MONITORING_DIR / "docker-compose.yml").read_text(encoding="utf-8")
+    prometheus_config = (MONITORING_DIR / "prometheus.yml").read_text(encoding="utf-8")
+    alert_rules = (
+        MONITORING_DIR / "prometheus-rules" / "jurisdigta-ai-models.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "./prometheus-rules:/etc/prometheus/rules:ro" in compose
+    assert "rule_files:" in prometheus_config
+    assert "JurisDigtaOllamaExporterDown" in alert_rules
+    assert "JurisDigtaPaidModelTokenSpike" in alert_rules
+    assert "JurisDigtaPaidModelCostSpike" in alert_rules
 
 
 def test_monitoring_env_defaults_include_log_retention() -> None:


### PR DESCRIPTION
## Summary

Implements #425.

- Adds API-ledger based AI model usage windows for 1h, 24h, 7d, and 30d.
- Keeps shared Prometheus/Grafana labels aggregate-only and removes raw case/user/subscription identifiers from exported usage metrics.
- Adds masked top-10 case token/cost metrics for Grafana-only operational triage.
- Updates Ollama/AI model dashboards with usage-window selection, local/Ollama token panels, paid-model token panels, paid cost panels, and masked top cases.
- Adds Prometheus alert rules for Ollama red state, missing configured Ollama model, paid-model token spike, and paid-model cost spike.
- Updates monitoring docs, deployment validation, GitHub environment docs, and monitoring demo validation.

## Validation

- `ruff check app tests` from `api/aijuristiction-api` using bundled Python runtime.
- `mypy app` from `api/aijuristiction-api` using bundled Python runtime.
- Full API tests: `pythonw.exe -m pytest tests` from `api/aijuristiction-api` using the task env runtime.
- `pytest tests/test_server_monitoring.py` using bundled Python runtime.
- Dashboard JSON parse check for all provisioned dashboards.
- Prometheus config/rule YAML parse check.

Note: `scripts/validate_api.ps1` could not run directly in this worktree because the helper-created `conda` env is missing `python.exe` and falls through to the Windows Store Python alias. The pre-commit hook passed after prepending the bundled Python runtime to `PATH`, and the equivalent lint/type checks above pass.