### PR TITLE
Fix free-plan assistant model routing hydration

### DIFF
--- a/api/aijuristiction-api/e2e-playwright/e2e-test-catalog.json
+++ b/api/aijuristiction-api/e2e-playwright/e2e-test-catalog.json
@@ -90,6 +90,16 @@
     "scheduled": true
   },
   {
+    "id": "free-plan-ollama-splnomocnenie-pdf",
+    "file": "tests/free-plan-ollama-document-pdf.spec.ts",
+    "title": "free plan Ollama flow prepares clean Slovak and English splnomocnenie PDFs",
+    "name": "Free-plan Ollama splnomocnenie PDFs",
+    "description": "Creates a free-plan case, verifies the local Ollama route, runs a Slovak/English vehicle authorization document conversation, requests generated PDF exports, and checks that exported PDFs contain only legal-document content without assistant chatter or duplicate-question regressions.",
+    "area": "Free-plan local model documents",
+    "scheduled": false,
+    "prerequisite": "Requires a live API with local_ollama/qwen3:1.7b reachable and a Python runtime with pypdf for PDF text extraction."
+  },
+  {
     "id": "frontend-auth-case-document",
     "file": "tests/frontend-auth-case-document.spec.ts",
     "title": "registration and login can create, reopen, and preview a generated potvrdenie PDF",

--- a/api/aijuristiction-api/e2e-playwright/package.json
+++ b/api/aijuristiction-api/e2e-playwright/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "test": "playwright test",
     "test:free-plan-api": "playwright test tests/free-plan-api-connectivity.spec.ts",
+    "test:free-plan-document": "playwright test tests/free-plan-ollama-document-pdf.spec.ts",
     "test:payment": "playwright test tests/payment-process.spec.ts"
   },
   "devDependencies": {

--- a/api/aijuristiction-api/e2e-playwright/tests/free-plan-ollama-document-pdf.spec.ts
+++ b/api/aijuristiction-api/e2e-playwright/tests/free-plan-ollama-document-pdf.spec.ts
@@ -1,0 +1,345 @@
+import { APIRequestContext, expect, test } from '@playwright/test';
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { ensureLiveApiOrFail } from './helpers/liveApi';
+
+const execFileAsync = promisify(execFile);
+const apiKey = process.env.API_KEY ?? 'aijuris';
+const e2eRoot = path.resolve(__dirname, '..');
+const apiRoot = path.resolve(e2eRoot, '..');
+const repoRoot = path.resolve(apiRoot, '..', '..');
+const currentWorktreePythonPath = [path.join(repoRoot, 'src'), apiRoot].join(path.delimiter);
+
+const documentRequest =
+  'Priprav mi splnomocnenie na prevadzku motoroveho vozidla firmy ESolutions SK s.r.o. ' +
+  'pre Janka Hraska, bytom testova 10, Poprad, slovensko od 1.7.2026 na neurcito. ' +
+  'Priprav document v slovenskom a anglickom jazyku.';
+
+const liveTimeoutMs = Number(process.env.FREE_PLAN_DOCUMENT_E2E_TIMEOUT_MS ?? 300_000);
+
+type CreatedUser = {
+  user_id: string;
+};
+
+type CreatedCase = {
+  case_id: string;
+};
+
+type ChatSession = {
+  id: string;
+  user_id: string;
+  case_id?: string;
+};
+
+type EffectiveRoute = {
+  plan_code: string;
+  route_type: string;
+  provider: string;
+  model: string;
+  is_local: boolean;
+  is_external: boolean;
+};
+
+type ChatMessage = {
+  role: string;
+  content: string;
+};
+
+type DocumentExportOptions = {
+  documents: {
+    index: number;
+    filename: string;
+    title: string;
+  }[];
+};
+
+test.beforeEach(async ({ request, baseURL }) => {
+  await ensureLiveApiOrFail(request, baseURL);
+});
+
+test('free plan Ollama flow prepares clean Slovak and English splnomocnenie PDFs', async ({
+  request,
+  baseURL,
+}) => {
+  test.setTimeout(liveTimeoutMs);
+
+  const runId = Date.now();
+  const user = await createUser(request, baseURL, runId);
+  const createdCase = await createCase(request, baseURL, user.user_id, `E2E free Ollama splnomocnenie ${runId}`);
+
+  const route = await getEffectiveRoute(request, baseURL, user.user_id);
+  expect(route).toMatchObject({
+    plan_code: 'free',
+    route_type: 'free_local',
+    provider: 'local_ollama',
+    model: 'qwen3:1.7b',
+    is_local: true,
+    is_external: false,
+  });
+
+  const session = await createSession(request, baseURL, user.user_id, createdCase.case_id);
+  const assistantMessages: ChatMessage[] = [];
+
+  assistantMessages.push(await sendReply(request, baseURL, session.id, documentRequest));
+  expectConversationIsProfessional(assistantMessages);
+  expectNoDuplicateAssistantQuestions(assistantMessages);
+
+  const exports = await listDocumentExports(request, baseURL, session.id);
+  if (exports.documents.length < 2) {
+    assistantMessages.push(
+      await sendReply(
+        request,
+        baseURL,
+        session.id,
+        'Na konci konverzacie teraz poziadam o PDF: vygeneruj prosim finalne PDF dokumenty v slovenskom aj anglickom jazyku.'
+      )
+    );
+  }
+
+  expectConversationIsProfessional(assistantMessages);
+  expectNoDuplicateAssistantQuestions(assistantMessages);
+
+  const readyExports = await listDocumentExports(request, baseURL, session.id);
+  expect(readyExports.documents.length).toBeGreaterThanOrEqual(2);
+
+  const pdfTexts = await Promise.all(
+    readyExports.documents.slice(0, 2).map(async (document) => {
+      const pdf = await request.get(`${baseURL}/v1/chat/sessions/${session.id}/export/documents/${document.index}`, {
+        headers: { 'x-api-key': apiKey },
+        timeout: liveTimeoutMs,
+      });
+      expect(pdf.status()).toBe(200);
+      expect(pdf.headers()['content-type']).toContain('application/pdf');
+      return extractPdfText(Buffer.from(await pdf.body()));
+    })
+  );
+
+  const normalizedTexts = pdfTexts.map((text) => canonical(text));
+  const combined = normalizedTexts.join('\n---document---\n');
+
+  expect(combined).toContain('esolutions sk');
+  expect(combined).toContain('janka hraska');
+  expect(combined).toContain('testova 10');
+  expect(combined).toContain('poprad');
+  expect(combined).toContain('1.7.2026');
+
+  expect(normalizedTexts.some((text) => text.includes('splnomocnenie'))).toBeTruthy();
+  expect(normalizedTexts.some((text) => text.includes('power of attorney'))).toBeTruthy();
+
+  for (const text of normalizedTexts) {
+    expectLegalDocumentOnly(text);
+  }
+});
+
+async function createUser(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  runId: number
+): Promise<CreatedUser> {
+  const response = await request.post(`${baseURL}/v1/users/sign-up`, {
+    headers: { 'x-api-key': apiKey },
+    data: {
+      phone_number: `+421902${String(runId).slice(-6)}`,
+      email: `free-ollama-document-e2e.${runId}@example.test`,
+      password: 'secret',
+    },
+  });
+  expect(response.status()).toBe(201);
+  return (await response.json()) as CreatedUser;
+}
+
+async function createCase(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  userId: string,
+  title: string
+): Promise<CreatedCase> {
+  const response = await request.post(`${baseURL}/v1/cases`, {
+    headers: { 'x-api-key': apiKey },
+    data: {
+      user_id: userId,
+      title,
+    },
+  });
+  expect(response.status()).toBe(201);
+  return (await response.json()) as CreatedCase;
+}
+
+async function createSession(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  userId: string,
+  caseId: string
+): Promise<ChatSession> {
+  const response = await request.post(`${baseURL}/v1/chat/sessions`, {
+    headers: { 'x-api-key': apiKey },
+    data: {
+      user_id: userId,
+      case_id: caseId,
+      country: 'SK',
+      language: 'sk',
+      discussion_type: 'advice',
+    },
+  });
+  expect(response.status()).toBe(200);
+  return (await response.json()) as ChatSession;
+}
+
+async function getEffectiveRoute(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  userId: string
+): Promise<EffectiveRoute> {
+  const response = await request.get(`${baseURL}/v1/model-routing/effective?task_type=chat_reply&user_id=${userId}`, {
+    headers: { 'x-api-key': apiKey },
+  });
+  expect(response.status()).toBe(200);
+  return (await response.json()) as EffectiveRoute;
+}
+
+async function sendReply(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  sessionId: string,
+  content: string
+): Promise<ChatMessage> {
+  const response = await request.post(`${baseURL}/v1/chat/sessions/${sessionId}/reply`, {
+    headers: { 'x-api-key': apiKey },
+    data: { content },
+    timeout: liveTimeoutMs,
+  });
+  expect(response.status()).toBe(200);
+  const message = (await response.json()) as ChatMessage;
+  expect(message.role).toBe('assistant');
+  expect(
+    message.content.trim().length,
+    `Assistant reply should not be empty for prompt: ${content}`
+  ).toBeGreaterThan(40);
+  return message;
+}
+
+async function listDocumentExports(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  sessionId: string
+): Promise<DocumentExportOptions> {
+  const response = await request.get(`${baseURL}/v1/chat/sessions/${sessionId}/export/documents`, {
+    headers: { 'x-api-key': apiKey },
+    timeout: liveTimeoutMs,
+  });
+  expect(response.status()).toBe(200);
+  return (await response.json()) as DocumentExportOptions;
+}
+
+function expectConversationIsProfessional(messages: ChatMessage[]): void {
+  for (const message of messages) {
+    const visible = canonical(stripTechnicalPayload(message.content));
+    expect(visible).not.toMatch(/connection error|internal_server_error|network|traceback|exception|undefined|null/);
+    expect(visible).not.toMatch(/\bwtf\b|blbost|hlupost|idiot|stupid/);
+    expect(visible).toMatch(/splnomocnen|dokument|pdf|prav|prosim|priprav|vozidl|attorney|document/);
+  }
+}
+
+function expectNoDuplicateAssistantQuestions(messages: ChatMessage[]): void {
+  const seen = new Set<string>();
+  for (const message of messages) {
+    for (const question of extractQuestions(stripTechnicalPayload(message.content))) {
+      const normalized = canonical(question).replace(/[^a-z0-9 ]/g, '').replace(/\s+/g, ' ').trim();
+      if (!normalized) {
+        continue;
+      }
+      expect(seen.has(normalized), `Duplicate assistant question: ${question}`).toBeFalsy();
+      seen.add(normalized);
+    }
+  }
+}
+
+function expectLegalDocumentOnly(text: string): void {
+  expect(text).not.toMatch(/case_update_json|facts_summary|open_questions|client_goal/);
+  expect(text).not.toMatch(/assistant|lawyerslovakia|jurisdigta assistant|system|user:/);
+  expect(text).not.toMatch(/pripravil som|rozumiem|prosim doplnte|chybajuce informacie|zhrnutie pripadu/);
+  expect(text).not.toMatch(/navrhovany postup|rizika|stiahnutie|ready for download|draft package/);
+  expect(text).not.toMatch(/\*\*|---|```/);
+}
+
+function stripTechnicalPayload(content: string): string {
+  return content.replace(/CASE_UPDATE_JSON\s*:?\s*[\s\S]*$/i, '').trim();
+}
+
+function extractQuestions(content: string): string[] {
+  return content
+    .split('?')
+    .slice(0, -1)
+    .map((part) => {
+      const sentenceStart = Math.max(part.lastIndexOf('\n'), part.lastIndexOf('.'), part.lastIndexOf('!'));
+      return `${part.slice(sentenceStart + 1).trim()}?`;
+    })
+    .filter((question) => question.length > 1);
+}
+
+async function extractPdfText(pdf: Buffer): Promise<string> {
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'jurisdigta-free-ollama-doc-'));
+  const pdfPath = path.join(tempDir, 'document.pdf');
+  await writeFile(pdfPath, pdf);
+  const script = [
+    'from pypdf import PdfReader',
+    'import sys',
+    'reader = PdfReader(sys.argv[1])',
+    'print("\\n".join(page.extract_text() or "" for page in reader.pages))',
+  ].join('\n');
+
+  try {
+    return await runPython(script, {}, [pdfPath]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function runPython(
+  script: string,
+  extraEnv: Record<string, string>,
+  args: string[] = []
+): Promise<string> {
+  const candidates = [
+    process.env.PYTHON,
+    process.env.API_PYTHON,
+    path.resolve(process.cwd(), '..', '..', '..', 'conda', 'python.exe'),
+    'python',
+  ].filter(Boolean) as string[];
+  const failures: string[] = [];
+
+  for (const candidate of candidates) {
+    try {
+      const { stdout } = await execFileAsync(candidate, ['-c', script, ...args], {
+        encoding: 'utf8',
+        cwd: apiRoot,
+        env: {
+          ...process.env,
+          ...extraEnv,
+          PYTHONPATH: process.env.PYTHONPATH
+            ? `${currentWorktreePythonPath}${path.delimiter}${process.env.PYTHONPATH}`
+            : currentWorktreePythonPath,
+          PYTHONIOENCODING: 'utf-8',
+        },
+        maxBuffer: 2_000_000,
+      });
+      return stdout;
+    } catch (error) {
+      failures.push(`${candidate}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  throw new Error(`No Python runtime was available for PDF e2e extraction. Failures:\n${failures.join('\n')}`);
+}
+
+function canonical(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/docs/E2E_CONTRACT_TESTS.md
+++ b/docs/E2E_CONTRACT_TESTS.md
@@ -20,10 +20,16 @@ This repository now includes deterministic end-to-end simulations for two docume
    - Confirms the simulated payment and verifies that the subscription becomes `paid`.
    - Verifies guard rails: disabled plans stay unavailable, and unknown payment IDs do not activate subscriptions.
 
-3. `api/aijuristiction-api/e2e-playwright/tests/free-plan-api-connectivity.spec.ts`
+4. `api/aijuristiction-api/e2e-playwright/tests/free-plan-api-connectivity.spec.ts`
    - Creates a synthetic free-plan chat user.
    - Verifies the effective route is `free_local` through `local_ollama`.
    - Sends a legal chat prompt through `/v1/chat/sessions/{session_id}/reply` and fails if the API returns a network/model connection error.
+
+5. `api/aijuristiction-api/e2e-playwright/tests/free-plan-ollama-document-pdf.spec.ts`
+   - Creates a synthetic free-plan user and case.
+   - Verifies the effective route is `free_local` through `local_ollama` with `qwen3:1.7b`.
+   - Runs a Slovak request for `Splnomocnenie` for operation of a company vehicle for `ESolutions SK s.r.o.` and asks for Slovak and English generated PDFs.
+   - Fails when the assistant conversation is unprofessional, repeats the same question, or exported PDFs contain assistant/system commentary instead of only legal-document content.
 
 ## Files
 
@@ -43,6 +49,13 @@ Run the Playwright payment-process simulation:
 ```bash
 cd api/aijuristiction-api/e2e-playwright
 npm run test:payment
+```
+
+Run the live free-plan Ollama document/PDF simulation:
+
+```bash
+cd api/aijuristiction-api/e2e-playwright
+npm run test:free-plan-document
 ```
 
 The payment-process E2E is GDPR/privacy-by-design safe for local and scheduled runs: it uses generated identities, local test storage, log-only email transport in CI, and the API sandbox checkout contract instead of a real payment-provider charge.

--- a/frontend/aijurisdictionfronend/src/__tests__/assistantWorkspace.test.tsx
+++ b/frontend/aijurisdictionfronend/src/__tests__/assistantWorkspace.test.tsx
@@ -34,6 +34,7 @@ const labels: Record<string, string> = {
   assistantMetadataReviewValue: "Required before final use",
   assistantModelDisclosureAria: "AI model used for this chat",
   assistantModelDisclosureLabel: "Model",
+  assistantModelDisclosurePending: "Checking model route...",
   assistantComposerLabel: "Assistant message",
   assistantComposerPlaceholder: "Ask for legal research or document preparation...",
   assistantSend: "Send message",
@@ -41,6 +42,7 @@ const labels: Record<string, string> = {
   assistantUserRole: "You",
   assistantInitialMessage: "JurisDigta Assistant is ready with JurisDigta API and MCP locked on.",
   assistantEmptyMessageResponse: "Please enter a question or drafting instruction.",
+  assistantAuthLoadingResponse: "I am checking your account before starting the legal assistant. Please try again in a moment.",
   assistantApiErrorResponse: "The assistant could not reach the JurisDigta API. Status: {status}. Detail: {detail}",
   workspaceConfigurations: "Configurations",
   workspaceSystemLabel: "System",
@@ -70,10 +72,14 @@ vi.mock("../components/LanguageProvider", () => ({
   })
 }));
 
+const authState = vi.hoisted(() => ({
+  isAuthenticated: true,
+  isAuthLoading: false,
+  user: { userId: "user-1" } as { userId: string } | null
+}));
+
 vi.mock("../auth/webAuth", () => ({
-  useAuth: () => ({
-    user: { userId: "user-1" }
-  })
+  useAuth: () => authState
 }));
 
 const caseActions = vi.hoisted(() => ({
@@ -172,6 +178,9 @@ vi.mock("@assistant-ui/react", () => ({
 
 describe("AssistantWorkspace", () => {
   beforeEach(() => {
+    authState.isAuthenticated = true;
+    authState.isAuthLoading = false;
+    authState.user = { userId: "user-1" };
     vi.mocked(fetchEffectiveModelRoute).mockResolvedValue({
       plan_code: "free",
       route_type: "free_local",
@@ -222,7 +231,60 @@ describe("AssistantWorkspace", () => {
     expect(screen.queryByText("Production access uses JurisDigta account login")).toBeNull();
   });
 
+  it("waits for the signed-in user id before showing the effective model route", async () => {
+    authState.isAuthenticated = true;
+    authState.isAuthLoading = true;
+    authState.user = null;
+    const { rerender } = render(<AssistantWorkspace />);
+
+    expect(screen.getByLabelText("AI model used for this chat").textContent).toContain("Checking model route...");
+    expect(vi.mocked(fetchEffectiveModelRoute)).not.toHaveBeenCalled();
+
+    authState.isAuthLoading = false;
+    authState.user = { userId: "user-1" };
+    rerender(<AssistantWorkspace />);
+
+    expect(await screen.findByText("Local Ollama - qwen3:1.7b")).toBeDefined();
+    expect(vi.mocked(fetchEffectiveModelRoute)).toHaveBeenCalledWith("user-1");
+    expect(vi.mocked(fetchEffectiveModelRoute)).not.toHaveBeenCalledWith(undefined);
+  });
+
+  it("does not create a chat session until a signed-in user id is available", async () => {
+    authState.isAuthenticated = true;
+    authState.isAuthLoading = true;
+    authState.user = null;
+
+    render(<AssistantWorkspace />);
+
+    const result = capturedAdapter?.run({
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Priprav splnomocnenie." }]
+        }
+      ],
+      abortSignal: new AbortController().signal
+    });
+
+    let lastResult: CapturedRunResult | undefined;
+    if (result && Symbol.asyncIterator in result) {
+      for await (const update of result) {
+        lastResult = update;
+      }
+    } else {
+      lastResult = await result;
+    }
+
+    expect(createChatSession).not.toHaveBeenCalled();
+    expect(streamSession).not.toHaveBeenCalled();
+    expect(lastResult?.content?.[0]?.text).toBe(
+      "I am checking your account before starting the legal assistant. Please try again in a moment."
+    );
+  });
+
   it("falls back to the configured model label when route disclosure is unavailable", () => {
+    authState.isAuthenticated = false;
+    authState.user = null;
     vi.mocked(fetchEffectiveModelRoute).mockRejectedValue(new Error("offline"));
 
     render(<AssistantWorkspace />);

--- a/frontend/aijurisdictionfronend/src/data/translations.ts
+++ b/frontend/aijurisdictionfronend/src/data/translations.ts
@@ -197,6 +197,7 @@ export const translations = {
     assistantApiAuthAccess: "Production access uses JurisDigta account login",
     assistantModelDisclosureAria: "AI model used for this chat",
     assistantModelDisclosureLabel: "Model",
+    assistantModelDisclosurePending: "Checking model route...",
     assistantComposerLabel: "Assistant message",
     assistantComposerPlaceholder: "Ask for legal research or document preparation...",
     assistantSend: "Send message",
@@ -205,6 +206,8 @@ export const translations = {
     assistantInitialMessage:
       "JurisDigta Assistant is ready with JurisDigta API and MCP locked on. Drafts are AI-assisted and require human legal review before use.",
     assistantEmptyMessageResponse: "Please enter a question or drafting instruction.",
+    assistantAuthLoadingResponse:
+      "I am checking your account before starting the legal assistant. Please try again in a moment.",
     assistantApiErrorResponse:
       "The assistant could not reach the JurisDigta API. Status: {status}. Detail: {detail}",
     caseTitle: "Create a case",
@@ -747,6 +750,7 @@ export const translations = {
     assistantApiAuthAccess: "Produkčný prístup používa prihlásenie účtom JurisDigta",
     assistantModelDisclosureAria: "AI model použitý pre tento chat",
     assistantModelDisclosureLabel: "Model",
+    assistantModelDisclosurePending: "Overujem trasu modelu...",
     assistantComposerLabel: "Správa asistentovi",
     assistantComposerPlaceholder: "Požiadajte o právny výskum alebo prípravu dokumentu...",
     assistantSend: "Odoslať správu",
@@ -755,6 +759,8 @@ export const translations = {
     assistantInitialMessage:
       "JurisDigta Asistent je pripravený s povinne zapnutým JurisDigta API a MCP. Návrhy sú asistované AI a pred použitím vyžadujú ľudskú právnu kontrolu.",
     assistantEmptyMessageResponse: "Zadajte otázku alebo pokyn na prípravu dokumentu.",
+    assistantAuthLoadingResponse:
+      "Overujem vaše konto pred spustením právneho asistenta. Skúste to, prosím, o chvíľu znova.",
     assistantApiErrorResponse:
       "Asistent sa nevie spojiť s JurisDigta API. Stav: {status}. Detail: {detail}",
     caseTitle: "Vytvoriť prípad",
@@ -1297,6 +1303,7 @@ export const translations = {
     assistantApiAuthAccess: "Produktionszugang nutzt JurisDigta-Kontoanmeldung",
     assistantModelDisclosureAria: "Für diesen Chat verwendetes KI-Modell",
     assistantModelDisclosureLabel: "Modell",
+    assistantModelDisclosurePending: "Modellroute wird geprüft...",
     assistantComposerLabel: "Nachricht an den Assistenten",
     assistantComposerPlaceholder: "Fragen Sie nach Rechtsrecherche oder Dokumentvorbereitung...",
     assistantSend: "Nachricht senden",
@@ -1305,6 +1312,8 @@ export const translations = {
     assistantInitialMessage:
       "JurisDigta Assistent ist mit verpflichtendem JurisDigta API und MCP bereit. Entwürfe sind KI-unterstützt und benötigen vor der Nutzung menschliche rechtliche Prüfung.",
     assistantEmptyMessageResponse: "Bitte geben Sie eine Frage oder eine Anweisung zur Dokumenterstellung ein.",
+    assistantAuthLoadingResponse:
+      "Ich pruefe Ihr Konto, bevor der Rechtsassistent startet. Bitte versuchen Sie es gleich erneut.",
     assistantApiErrorResponse:
       "Der Assistent konnte die JurisDigta API nicht erreichen. Status: {status}. Detail: {detail}",
     caseTitle: "Fall erstellen",

--- a/frontend/aijurisdictionfronend/src/pages/AssistantWorkspace.tsx
+++ b/frontend/aijurisdictionfronend/src/pages/AssistantWorkspace.tsx
@@ -420,7 +420,7 @@ const AssistantTextPart: React.FC = () => {
 
 const AssistantThread: React.FC = () => {
   const { language, t } = useLanguage();
-  const { user } = useAuth();
+  const { isAuthenticated, isAuthLoading, user } = useAuth();
   const { activeCase, loadCaseData } = useCases();
   const activeCaseId = activeCase?.id;
   const sessionRef = React.useRef<{ language: string; userId?: string; caseId?: string; sessionId: string } | null>(
@@ -463,6 +463,14 @@ const AssistantThread: React.FC = () => {
 
         try {
           const userId = user?.userId;
+          if (isAuthenticated && (isAuthLoading || !userId)) {
+            yield {
+              content: [{ type: "text", text: t("assistantAuthLoadingResponse") }],
+              status: { type: "complete", reason: "stop" }
+            };
+            return;
+          }
+
           const existingSession = sessionRef.current;
           const session =
             existingSession?.language === language &&
@@ -544,7 +552,7 @@ const AssistantThread: React.FC = () => {
         }
       }
     }),
-    [activeCaseId, language, loadCaseData, t, user?.userId]
+    [activeCaseId, isAuthenticated, isAuthLoading, language, loadCaseData, t, user?.userId]
   );
 
   const runtime = useLocalRuntime(assistantAdapter, {
@@ -722,13 +730,21 @@ const AssistantConfigurations: React.FC = () => {
 
 const AssistantWorkspace: React.FC = () => {
   const { t } = useLanguage();
-  const { user } = useAuth();
+  const { isAuthenticated, isAuthLoading, user } = useAuth();
   const { activeCase } = useCases();
   const threadKey = React.useMemo(() => caseThreadKey(activeCase), [activeCase]);
   const fallbackModelLabel = React.useMemo(() => chatApiRuntimeConfig().chatModelLabel, []);
-  const [modelLabel, setModelLabel] = React.useState(fallbackModelLabel);
+  const pendingModelLabel = t("assistantModelDisclosurePending");
+  const [modelLabel, setModelLabel] = React.useState(
+    isAuthenticated ? pendingModelLabel : fallbackModelLabel
+  );
 
   React.useEffect(() => {
+    if (isAuthenticated && !user?.userId) {
+      setModelLabel(pendingModelLabel);
+      return;
+    }
+
     let isCurrent = true;
     void fetchEffectiveModelRoute(user?.userId)
       .then((route) => {
@@ -744,7 +760,7 @@ const AssistantWorkspace: React.FC = () => {
     return () => {
       isCurrent = false;
     };
-  }, [fallbackModelLabel, user?.userId]);
+  }, [fallbackModelLabel, isAuthenticated, isAuthLoading, pendingModelLabel, user?.userId]);
 
   return (
     <div className="page assistant-workspace-page">


### PR DESCRIPTION
## Summary
- Fix first-login assistant hydration so signed-in free users wait for `userId` before model-route lookup or chat session creation.
- Add regression coverage proving model routing and chat sessions are not called without a signed-in user id.
- Add the free-plan Local Ollama Splnomocnenie PDF E2E contract and catalog/npm script entry.

## Verification
- `npm run test:free-plan-api` passed against prod (`free_local`, `local_ollama`, `qwen3:1.7b`).
- `npm test -- --run src/__tests__/assistantWorkspace.test.tsx` passed, 13 tests.
- `npm run build` passed.
- Browser check verified first render requests model route with `user_id=free-e2e-ui-user` and renders `Local Ollama - qwen3:1.7b` when the verified prod route payload is returned.

## Follow-up bug
- #428 tracks the remaining Splnomocnenie document E2E failure: prod reply returns HTTP 200 but empty assistant content.