### PR TITLE
Fix free-plan vehicle authorization direct reply

### DIFF
--- a/api/aijuristiction-api/app/chat/country_services/slovakia.py
+++ b/api/aijuristiction-api/app/chat/country_services/slovakia.py
@@ -1530,7 +1530,17 @@ def _looks_like_vehicle_authorization_final_request(content: str) -> bool:
     if not any(token in normalized for token in ("vozidlo", "vozidla", "auto", "auta", "motorov")):
         return False
     final_markers = ("priprav", "vygeneruj", "vytvor", "document", "dokument")
-    language_markers = ("slovencine", "slovencina", "slovak", "anglictine", "anglicky", "english")
+    language_markers = (
+        "slovencine",
+        "slovencina",
+        "slovenskom",
+        "slovensky",
+        "slovak",
+        "anglictine",
+        "anglickom",
+        "anglicky",
+        "english",
+    )
     return any(marker in normalized for marker in final_markers) and any(
         marker in normalized for marker in language_markers
     )
@@ -1603,6 +1613,14 @@ def _extract_vehicle_authorized_person(content: str) -> str:
     if explicit_address_match is not None:
         return " ".join(explicit_address_match.group(1).strip().split())
 
+    bytom_match = re.search(
+        r"\bpre\s+([^,.;]+?)\s*,\s*bytom\b",
+        content,
+        flags=re.IGNORECASE,
+    )
+    if bytom_match is not None:
+        return " ".join(bytom_match.group(1).strip().split())
+
     match = re.search(
         r"\bpre\s+(?:dceru|dc[ée]ru|syna|manzelku|manzela|osobu)\s+([^,.;]+?)(?=\s+na\s+|\s+od\s+|[,.;]|$)",
         content,
@@ -1621,7 +1639,7 @@ def _extract_vehicle_authorized_person(content: str) -> str:
 
 def _extract_vehicle_authorized_person_address(content: str) -> str:
     match = re.search(
-        r"\badresa\s+([^.;]+?)(?=\s+(?:priprav|vygeneruj|vytvor)\b|[.;]|$)",
+        r"\b(?:adresa|bytom)\s+([^.;]+?)(?=\s+(?:od\s+\d{1,2}\.\d{1,2}\.\d{4}|priprav|vygeneruj|vytvor)\b|[.;]|$)",
         content,
         flags=re.IGNORECASE,
     )

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260480"
+version = "1.0.260481"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -3077,6 +3077,60 @@ def test_prepare_slovakia_vehicle_authorization_captures_user_facts_and_company_
     slovakia_service._ORSR_CACHE.clear()
 
 
+def test_prepare_slovakia_vehicle_authorization_issue_428_uses_direct_document_reply(monkeypatch) -> None:
+    from app.chat.country_services import slovakia as slovakia_service
+    from app.chat.country_services.slovakia import prepare_slovakia_direct_reply
+    from app.chat.models import Message, MessageRole, Session
+
+    class _FakeRegistry:
+        def run(self, name: str, **kwargs):
+            assert name == "obchodny_register_company_check"
+            assert kwargs["company_name_or_registration"] == "ESolutions SK s.r.o."
+            return SimpleNamespace(
+                ok=True,
+                records=(
+                    {
+                        "name": "ESolutions SK s.r.o.",
+                        "registration_number": "46491261",
+                        "seat": "Partizanska 665, 059 18 Spisske Bystre",
+                        "status": "Aktivna",
+                    },
+                ),
+            )
+
+    slovakia_service._ORSR_CACHE.clear()
+    monkeypatch.setattr(slovakia_service, "build_default_tool_registry", lambda: _FakeRegistry())
+    session = Session(country="SK", language="sk")
+    current_content = (
+        "Priprav mi splnomocnenie na prevadzku motoroveho vozidla firmy ESolutions SK s.r.o. "
+        "pre Janka Hraska, bytom testova 10, Poprad, slovensko od 1.7.2026 na neurcito. "
+        "Priprav document v slovenskom a anglickom jazyku."
+    )
+    messages = [Message(session_id=session.id, role=MessageRole.USER, content=current_content)]
+    events: list[dict[str, object]] = []
+
+    preparation = prepare_slovakia_direct_reply(
+        session=session,
+        messages=messages,
+        current_content=current_content,
+        prior_messages=[],
+        normalize_document_lines=lambda text: [text],
+        extract_document_facts=lambda lines: {},
+        current_turn_confirms_document_generation=lambda content, previous_messages: False,
+        build_share_transfer_lines=lambda facts: [],
+        processing_event_callback=events.append,
+    )
+
+    assert preparation.direct_reply is not None
+    assert "Janka Hraska, adresa: testova 10, Poprad, slovensko" in preparation.direct_reply
+    assert "ESolutions SK s.r.o., ICO 46491261, Partizanska 665" in preparation.direct_reply
+    assert "1.7.2026" in preparation.direct_reply
+    assert "Splnomocnenie (slovenska verzia)" in preparation.direct_reply
+    assert "Power of Attorney (English version)" in preparation.direct_reply
+    assert any(event.get("stage") == "document_ready" for event in events)
+    slovakia_service._ORSR_CACHE.clear()
+
+
 def test_prepare_slovakia_direct_reply_runs_orsr_for_plain_company_name(monkeypatch) -> None:
     from app.chat.country_services import slovakia as slovakia_service
     from app.chat.country_services.slovakia import prepare_slovakia_direct_reply

--- a/docs/E2E_CONTRACT_TESTS.md
+++ b/docs/E2E_CONTRACT_TESTS.md
@@ -29,6 +29,7 @@ This repository now includes deterministic end-to-end simulations for two docume
    - Creates a synthetic free-plan user and case.
    - Verifies the effective route is `free_local` through `local_ollama` with `qwen3:1.7b`.
    - Runs a Slovak request for `Splnomocnenie` for operation of a company vehicle for `ESolutions SK s.r.o.` and asks for Slovak and English generated PDFs.
+   - The Slovak vehicle-authorization direct-reply path handles the exact request before local model fallback so the assistant reply cannot be empty when the user already supplied the drafting facts.
    - Fails when the assistant conversation is unprofessional, repeats the same question, or exported PDFs contain assistant/system commentary instead of only legal-document content.
 
 ## Files


### PR DESCRIPTION
﻿## Summary
- routes issue #428's exact Slovak vehicle Splnomocnenie request through the deterministic Slovak direct-reply document path before local Ollama fallback
- captures `pre <person>, bytom <address>` facts and Slovak/English language wording used by the live E2E prompt
- adds a regression test for the issue prompt, documents the contract, and bumps the API revision

## Validation
- `./conda/python.exe -m pytest api/aijuristiction-api/tests/test_chat.py -k "issue_428 or vehicle_authorization_captures"`
- `../../conda/python.exe -m ruff check app tests` from `api/aijuristiction-api`
- `../../conda/python.exe -m mypy app` from `api/aijuristiction-api`
- `./scripts/validate_api.ps1`
- `./conda/python.exe -m pytest api/aijuristiction-api/tests`

Fixes #428
