### PR TITLE
Add outdated Slovak rental agreement E2E scenario

### DIFF
--- a/api/aijuristiction-api/e2e-playwright/package.json
+++ b/api/aijuristiction-api/e2e-playwright/package.json
@@ -6,6 +6,7 @@
     "test": "playwright test",
     "test:free-plan-api": "playwright test tests/free-plan-api-connectivity.spec.ts",
     "test:free-plan-document": "playwright test tests/free-plan-ollama-document-pdf.spec.ts",
+    "test:outdated-rental": "playwright test tests/outdated-rental-agreement.spec.ts",
     "test:payment": "playwright test tests/payment-process.spec.ts"
   },
   "devDependencies": {

--- a/api/aijuristiction-api/e2e-playwright/tests/outdated-rental-agreement.spec.ts
+++ b/api/aijuristiction-api/e2e-playwright/tests/outdated-rental-agreement.spec.ts
@@ -1,0 +1,589 @@
+import { APIRequestContext, expect, test } from '@playwright/test';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { ensureLiveApiOrFail } from './helpers/liveApi';
+
+const execFileAsync = promisify(execFile);
+const apiKey = process.env.API_KEY ?? 'aijuris';
+const e2eRoot = path.resolve(__dirname, '..');
+const apiRoot = path.resolve(e2eRoot, '..');
+const repoRoot = path.resolve(apiRoot, '..', '..');
+const currentWorktreePythonPath = [path.join(repoRoot, 'src'), apiRoot].join(path.delimiter);
+const fixturePath = path.join(
+  repoRoot,
+  'api',
+  'chat-simulator-app',
+  'testcases',
+  'outdated-najomna-zmluva-2026.txt'
+);
+const expectedPath = path.join(
+  repoRoot,
+  'api',
+  'chat-simulator-app',
+  'testcases',
+  'outdated-najomna-zmluva-2026.expected.json'
+);
+const liveTimeoutMs = Number(process.env.OUTDATED_RENTAL_E2E_TIMEOUT_MS ?? 360_000);
+
+type CreatedUser = {
+  user_id: string;
+  email: string;
+};
+
+type CreatedCase = {
+  case_id: string;
+};
+
+type ChatSession = {
+  id: string;
+  user_id: string;
+  case_id?: string;
+};
+
+type EffectiveRoute = {
+  plan_code: string;
+  route_type: string;
+  provider: string;
+  model: string;
+  is_local: boolean;
+  is_external: boolean;
+};
+
+type CheckoutResponse = {
+  subscription_id: string;
+  payment_id: string;
+};
+
+type ChatMessage = {
+  role: string;
+  content: string;
+};
+
+type CaseHistory = {
+  messages: Array<{ role: string; content: string; agent_name: string | null }>;
+  documents: Array<{ doc_id: string; kind: string; original_filename: string; processing_status: string }>;
+};
+
+type DocumentDebug = {
+  stored_documents: Array<{ original_filename: string; processing_status: string; extracted_characters: number }>;
+  selected_prompt_chunks: Array<{ content: string; path: string }>;
+  prompt_preview: string;
+};
+
+type DocumentExportOptions = {
+  documents: {
+    index: number;
+    filename: string;
+    title: string;
+  }[];
+};
+
+type ExpectedFixture = {
+  expectedExtractedFields: Record<string, string>;
+  knownOutdatedThemes: Array<{
+    id: string;
+    keywords: string[];
+    expectedLawHints: string[];
+  }>;
+  forbiddenMissingDataQuestions: string[];
+  lawGroundingHints: string[];
+};
+
+type TestVariant = {
+  name: 'free' | 'paid';
+  title: string;
+};
+
+const variants: TestVariant[] = [
+  { name: 'free', title: 'Free local model route' },
+  { name: 'paid', title: 'Paid Case-plan route' },
+];
+
+test.beforeEach(async ({ request, baseURL }) => {
+  await ensureLiveApiOrFail(request, baseURL);
+});
+
+for (const variant of variants) {
+  test(`${variant.title} updates an outdated Slovak rental agreement with law-grounded changes`, async ({
+    request,
+    baseURL,
+  }) => {
+    test.setTimeout(liveTimeoutMs);
+
+    const expected = await loadExpectedFixture();
+    await expectLiveLawsCorpus(request, baseURL);
+
+    const runId = Date.now() + Math.floor(Math.random() * 1000);
+    const user = await createSyntheticUser(request, baseURL, runId, variant.name);
+    if (variant.name === 'paid') {
+      await activateCasePlan(request, baseURL, user.user_id);
+    }
+
+    const route = await getEffectiveRoute(request, baseURL, user.user_id);
+    expectRouteMatchesVariant(route, variant);
+
+    const createdCase = await createCase(
+      request,
+      baseURL,
+      user.user_id,
+      `E2E outdated rental ${variant.name} ${runId}`
+    );
+    await uploadOutdatedRentalAgreement(request, baseURL, user.user_id, createdCase.case_id);
+
+    const debug = await getDocumentDebug(request, baseURL, user.user_id, createdCase.case_id);
+    expect(debug.stored_documents[0]).toMatchObject({
+      original_filename: 'outdated-najomna-zmluva-2026.txt',
+      processing_status: 'processed',
+    });
+    expect(debug.stored_documents[0].extracted_characters).toBeGreaterThan(2500);
+    expect(canonical(debug.prompt_preview)).toContain('marek testovany');
+    expect(canonical(debug.prompt_preview)).toContain('eva najomna');
+
+    const session = await createSession(request, baseURL, user.user_id, createdCase.case_id);
+    const assistantMessages: ChatMessage[] = [];
+
+    assistantMessages.push(
+      await sendReply(
+        request,
+        baseURL,
+        session.id,
+        [
+          'Analyzuj vsetky nahrane dokumenty v tomto pripade.',
+          'Over zastaranu najomnu zmluvu podla aktualnych slovenskych zakonov z JurisDigta laws/RAG databazy.',
+          'Zobraz udaje, ktore si nasiel v starej zmluve.',
+          'Navrhni zmeny a kazdu materialnu zmenu odovodni zakonom.',
+          'Priprav opraveny navrh najomnej zmluvy.',
+          'Nepytaj sa na prenajimatela, najomcu, byt, najomne, zabezpeku ani dobu najmu, ak su citatelne v dokumente.',
+        ].join(' ')
+      )
+    );
+
+    const firstReply = visibleText(assistantMessages[0].content);
+    expectExtractedFields(firstReply, expected);
+    expectDoesNotAskForKnownData(firstReply, expected);
+
+    assistantMessages.push(
+      await sendReply(
+        request,
+        baseURL,
+        session.id,
+        [
+          'Suhlasim, pouzi udaje najdene v starej zmluve.',
+          'Neziadaj znovu udaje, ktore boli v dokumente.',
+          'Vygeneruj finalny opraveny navrh najomnej zmluvy vo formate PDF na stiahnutie.',
+          'V odpovedi ponechaj aj strucny zoznam navrhovanych zmien s odkazom na zakon.',
+        ].join(' ')
+      )
+    );
+
+    const combinedAssistantText = visibleText(assistantMessages.map((message) => message.content).join('\n\n'));
+    expectExtractedFields(combinedAssistantText, expected);
+    expectDoesNotAskForKnownData(combinedAssistantText, expected);
+    expectSuggestedChangesAreGrounded(combinedAssistantText, expected);
+
+    const exports = await pollDocumentExports(request, baseURL, session.id);
+    expect(exports.documents.length).toBeGreaterThanOrEqual(1);
+
+    const pdf = await request.get(`${baseURL}/v1/chat/sessions/${session.id}/export/documents/${exports.documents[0].index}`, {
+      headers: { 'x-api-key': apiKey },
+      timeout: liveTimeoutMs,
+    });
+    expect(pdf.status()).toBe(200);
+    expect(pdf.headers()['content-type']).toContain('application/pdf');
+    const pdfText = await extractPdfText(Buffer.from(await pdf.body()));
+    const normalizedPdf = canonical(pdfText);
+
+    expect(normalizedPdf).toContain('marek testovany');
+    expect(normalizedPdf).toContain('eva najomna');
+    expect(normalizedPdf).toContain('dunajska 45');
+    expect(normalizedPdf).toContain('850 eur');
+    expect(normalizedPdf).toContain('1 700 eur');
+    expect(normalizedPdf).toContain('1. jula 2026');
+    expect(normalizedPdf).toContain('30. juna 2027');
+    expectNoUnresolvedPlaceholders(normalizedPdf);
+
+    const history = await getCaseHistory(request, baseURL, user.user_id, createdCase.case_id);
+    const historyText = visibleText(history.messages.map((message) => message.content).join('\n\n'));
+    expectExtractedFields(historyText, expected);
+    expect(history.documents.some((document) => document.original_filename === 'outdated-najomna-zmluva-2026.txt')).toBeTruthy();
+  });
+}
+
+async function loadExpectedFixture(): Promise<ExpectedFixture> {
+  return JSON.parse(await readFile(expectedPath, 'utf8')) as ExpectedFixture;
+}
+
+async function expectLiveLawsCorpus(request: APIRequestContext, baseURL: string | undefined): Promise<void> {
+  const response = await request.get(`${baseURL}/version`, {
+    headers: { 'x-api-key': apiKey },
+    timeout: 10_000,
+  });
+  expect(response.status()).toBe(200);
+  const payload = (await response.json()) as {
+    laws_by_country?: {
+      sk?: {
+        last_law_update_source?: string | null;
+        last_processed_law?: string | null;
+      };
+    };
+  };
+  const sk = payload.laws_by_country?.sk;
+  expect(sk, `Expected /version to expose SK laws corpus metadata. Payload: ${JSON.stringify(payload)}`).toBeTruthy();
+  expect(sk?.last_law_update_source || sk?.last_processed_law).toBeTruthy();
+  const corpusStatus = canonical(`${sk?.last_law_update_source ?? ''} ${sk?.last_processed_law ?? ''}`);
+  if (corpusStatus.includes('unavailable')) {
+    throw new Error(
+      'Live SK laws corpus is unavailable to the API. Start the API with LAWS_DB_BACKEND=postgres ' +
+        'and LAWS_DB_CLOUD=postgresql://postgres:postgres@127.0.0.1:5433/laws_sk, or point it to an equivalent ' +
+        `live laws collector database. /version SK payload: ${JSON.stringify(sk)}`
+    );
+  }
+}
+
+async function createSyntheticUser(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  runId: number,
+  variant: string
+): Promise<CreatedUser> {
+  const response = await request.post(`${baseURL}/v1/users/sign-up`, {
+    headers: { 'x-api-key': apiKey },
+    data: {
+      phone_number: `+421905${String(runId).slice(-6)}`,
+      email: `outdated-rental-${variant}.${runId}@example.test`,
+      password: 'secret',
+      first_name: 'E2E',
+      last_name: `Rental ${variant}`,
+      data_processing_consent_accepted: true,
+      data_processing_consent_version: 'e2e-outdated-rental-2026-06-28',
+    },
+  });
+  expect(response.status()).toBe(201);
+  return (await response.json()) as CreatedUser;
+}
+
+async function activateCasePlan(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  userId: string
+): Promise<void> {
+  const checkoutResponse = await request.post(`${baseURL}/v1/users/${userId}/subscriptions/checkout`, {
+    headers: { 'x-api-key': apiKey },
+    data: { plan_code: 'case', payment_provider: 'paypal' },
+    timeout: 30_000,
+  });
+  if (checkoutResponse.status() !== 201) {
+    throw new Error(
+      `Case-plan checkout must be enabled for the paid outdated-rental E2E. ` +
+        `Status: ${checkoutResponse.status()}. Body: ${await checkoutResponse.text()}`
+    );
+  }
+  const checkout = (await checkoutResponse.json()) as CheckoutResponse;
+
+  const confirmResponse = await request.post(
+    `${baseURL}/v1/users/subscriptions/${checkout.subscription_id}/confirm-payment`,
+    {
+      headers: { 'x-api-key': apiKey },
+      data: { payment_id: checkout.payment_id },
+      timeout: 30_000,
+    }
+  );
+  expect(confirmResponse.status()).toBe(200);
+  await expect(confirmResponse.json()).resolves.toMatchObject({
+    plan_code: 'case',
+    status: 'paid',
+  });
+}
+
+async function createCase(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  userId: string,
+  title: string
+): Promise<CreatedCase> {
+  const response = await request.post(`${baseURL}/v1/cases`, {
+    headers: { 'x-api-key': apiKey },
+    data: {
+      user_id: userId,
+      title,
+    },
+  });
+  expect(response.status()).toBe(201);
+  return (await response.json()) as CreatedCase;
+}
+
+async function uploadOutdatedRentalAgreement(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  userId: string,
+  caseId: string
+): Promise<void> {
+  const buffer = await readFile(fixturePath);
+  const response = await request.post(`${baseURL}/v1/cases/${caseId}/documents?user_id=${userId}`, {
+    headers: { 'x-api-key': apiKey },
+    multipart: {
+      files: {
+        name: 'outdated-najomna-zmluva-2026.txt',
+        mimeType: 'text/plain',
+        buffer,
+      },
+    },
+    timeout: 60_000,
+  });
+  expect(response.status()).toBe(201);
+  const payload = (await response.json()) as { uploaded: Array<{ processing_status: string }> };
+  expect(payload.uploaded[0].processing_status).toBe('processed');
+}
+
+async function getDocumentDebug(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  userId: string,
+  caseId: string
+): Promise<DocumentDebug> {
+  const response = await request.get(
+    `${baseURL}/v1/cases/${caseId}/documents/debug?user_id=${userId}&query=${encodeURIComponent(
+      'analyze all uploaded documents and extract all rental agreement facts'
+    )}`,
+    {
+      headers: { 'x-api-key': apiKey },
+      timeout: 30_000,
+    }
+  );
+  expect(response.status()).toBe(200);
+  return (await response.json()) as DocumentDebug;
+}
+
+async function getEffectiveRoute(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  userId: string
+): Promise<EffectiveRoute> {
+  const response = await request.get(`${baseURL}/v1/model-routing/effective?task_type=chat_reply&user_id=${userId}`, {
+    headers: { 'x-api-key': apiKey },
+    timeout: 30_000,
+  });
+  if (response.status() !== 200) {
+    throw new Error(`Effective route failed. Status: ${response.status()}. Body: ${await response.text()}`);
+  }
+  return (await response.json()) as EffectiveRoute;
+}
+
+function expectRouteMatchesVariant(route: EffectiveRoute, variant: TestVariant): void {
+  if (variant.name === 'free') {
+    expect(route).toMatchObject({
+      plan_code: 'free',
+      route_type: 'free_local',
+      is_local: true,
+      is_external: false,
+    });
+    expect(canonical(route.provider)).toContain('local');
+    return;
+  }
+
+  expect(route.plan_code).toBe('case');
+  expect(route.route_type, `Paid Case plan should not be reported as the Free local route: ${JSON.stringify(route)}`).not.toBe(
+    'free_local'
+  );
+}
+
+async function createSession(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  userId: string,
+  caseId: string
+): Promise<ChatSession> {
+  const response = await request.post(`${baseURL}/v1/chat/sessions`, {
+    headers: { 'x-api-key': apiKey },
+    data: {
+      user_id: userId,
+      case_id: caseId,
+      country: 'SK',
+      language: 'sk',
+      discussion_type: 'advice',
+    },
+  });
+  expect(response.status()).toBe(200);
+  return (await response.json()) as ChatSession;
+}
+
+async function sendReply(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  sessionId: string,
+  content: string
+): Promise<ChatMessage> {
+  const response = await request.post(`${baseURL}/v1/chat/sessions/${sessionId}/reply`, {
+    headers: { 'x-api-key': apiKey },
+    data: { content },
+    timeout: liveTimeoutMs,
+  });
+  if (response.status() !== 200) {
+    throw new Error(
+      `Reply failed for prompt "${content}". Status: ${response.status()}. Body: ${await response.text()}`
+    );
+  }
+  const message = (await response.json()) as ChatMessage;
+  expect(message.role).toBe('assistant');
+  expect(message.content.trim().length).toBeGreaterThan(80);
+  return message;
+}
+
+async function pollDocumentExports(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  sessionId: string
+): Promise<DocumentExportOptions> {
+  const deadline = Date.now() + 90_000;
+  let lastExports: DocumentExportOptions | null = null;
+  while (Date.now() < deadline) {
+    const response = await request.get(`${baseURL}/v1/chat/sessions/${sessionId}/export/documents`, {
+      headers: { 'x-api-key': apiKey },
+      timeout: 30_000,
+    });
+    expect(response.status()).toBe(200);
+    lastExports = (await response.json()) as DocumentExportOptions;
+    if (lastExports.documents.length > 0) {
+      return lastExports;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+  throw new Error(`No corrected rental agreement export was produced. Last export payload: ${JSON.stringify(lastExports)}`);
+}
+
+async function getCaseHistory(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  userId: string,
+  caseId: string
+): Promise<CaseHistory> {
+  const response = await request.get(`${baseURL}/v1/cases/${caseId}/history?user_id=${userId}&limit=20`, {
+    headers: { 'x-api-key': apiKey },
+    timeout: 30_000,
+  });
+  expect(response.status()).toBe(200);
+  return (await response.json()) as CaseHistory;
+}
+
+function expectExtractedFields(content: string, expected: ExpectedFixture): void {
+  const normalized = canonical(content);
+  const requiredFields = [
+    'landlord',
+    'tenant',
+    'propertyAddress',
+    'rent',
+    'servicesAdvance',
+    'deposit',
+    'leaseStart',
+    'leaseEnd',
+    'iban',
+  ];
+  for (const key of requiredFields) {
+    const value = expected.expectedExtractedFields[key];
+    expect(normalized, `Expected extracted field ${key}=${value} in assistant output`).toContain(canonical(value));
+  }
+}
+
+function expectDoesNotAskForKnownData(content: string, expected: ExpectedFixture): void {
+  const normalized = canonical(content);
+  for (const forbiddenQuestion of expected.forbiddenMissingDataQuestions) {
+    expect(normalized, `Assistant asked for already-known field: ${forbiddenQuestion}`).not.toContain(
+      canonical(forbiddenQuestion)
+    );
+  }
+}
+
+function expectSuggestedChangesAreGrounded(content: string, expected: ExpectedFixture): void {
+  const normalized = canonical(content);
+  for (const theme of expected.knownOutdatedThemes) {
+    expect(
+      theme.keywords.some((keyword) => normalized.includes(canonical(keyword))),
+      `Assistant did not discuss outdated theme ${theme.id}`
+    ).toBeTruthy();
+  }
+
+  expect(
+    expected.lawGroundingHints.some((hint) => normalized.includes(canonical(hint))),
+    `Assistant output did not include any expected law grounding hint: ${expected.lawGroundingHints.join(', ')}`
+  ).toBeTruthy();
+  expect(normalized).toMatch(/zakon|obciansk|paragraf|§|z\.\s*z|zb/);
+}
+
+function expectNoUnresolvedPlaceholders(normalizedText: string): void {
+  expect(normalizedText).not.toMatch(/\[[^\]]+\]/);
+  expect(normalizedText).not.toContain('doplnte');
+  expect(normalizedText).not.toContain('chyba');
+  expect(normalizedText).not.toContain('nezname');
+  expect(normalizedText).not.toContain('xxx');
+}
+
+function visibleText(content: string): string {
+  return content.replace(/CASE_UPDATE_JSON\s*:?\s*[\s\S]*$/i, '').trim();
+}
+
+async function extractPdfText(pdf: Buffer): Promise<string> {
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'jurisdigta-outdated-rental-'));
+  const pdfPath = path.join(tempDir, 'document.pdf');
+  await writeFile(pdfPath, pdf);
+  const script = [
+    'from pypdf import PdfReader',
+    'import sys',
+    'reader = PdfReader(sys.argv[1])',
+    'print("\\n".join(page.extract_text() or "" for page in reader.pages))',
+  ].join('\n');
+
+  try {
+    return await runPython(script, {}, [pdfPath]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function runPython(
+  script: string,
+  extraEnv: Record<string, string>,
+  args: string[] = []
+): Promise<string> {
+  const candidates = [
+    process.env.PYTHON,
+    process.env.API_PYTHON,
+    path.resolve(process.cwd(), '..', '..', '..', 'conda', 'python.exe'),
+    'python',
+  ].filter(Boolean) as string[];
+  const failures: string[] = [];
+
+  for (const candidate of candidates) {
+    try {
+      const { stdout } = await execFileAsync(candidate, ['-c', script, ...args], {
+        encoding: 'utf8',
+        cwd: apiRoot,
+        env: {
+          ...process.env,
+          ...extraEnv,
+          PYTHONPATH: process.env.PYTHONPATH
+            ? `${currentWorktreePythonPath}${path.delimiter}${process.env.PYTHONPATH}`
+            : currentWorktreePythonPath,
+          PYTHONIOENCODING: 'utf-8',
+        },
+        maxBuffer: 2_000_000,
+      });
+      return stdout;
+    } catch (error) {
+      failures.push(`${candidate}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  throw new Error(`No Python runtime was available for PDF e2e extraction. Failures:\n${failures.join('\n')}`);
+}
+
+function canonical(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/api/chat-simulator-app/testcases/outdated-najomna-zmluva-2026.corrected-reference.txt
+++ b/api/chat-simulator-app/testcases/outdated-najomna-zmluva-2026.corrected-reference.txt
@@ -1,0 +1,78 @@
+OPRAVENY REFERENCNY NAVRH NAJOMNEJ ZMLUVY
+synteticky testovaci dokument pre JurisDigta E2E
+
+Tento referencny navrh sluzi iba ako benchmark pre test. Live E2E ma overit,
+ze system pripravi vlastny aktualizovany navrh z aktualnych zakonov v laws/RAG
+korpuse a zachova udaje zo stareho dokumentu.
+
+Prenajimatel:
+Marek Testovany
+Trvale bydlisko: Kvetna 12, 040 01 Kosice
+Datum narodenia: 10. marec 1980
+Cislo OP: TT123456
+
+Najomca:
+Eva Najomna
+Trvale bydlisko: Hlavna 8, 058 01 Poprad
+Datum narodenia: 5. maj 1992
+Cislo OP: EN654321
+
+Predmet najmu:
+Prenajimatel prenechava najomcovi do uzivania byt c. 12 na 3. poschodi
+bytoveho domu na adrese Dunajska 45, 811 08 Bratislava, Slovenska republika,
+vratane pivnicnej kobky c. 12B. Stav bytu, vybavenia, klucov a meracov bude
+zachyteny v odovzdavacom protokole podpisanom oboma stranami.
+
+Doba najmu:
+Najom sa dojednava od 1. jula 2026 do 30. juna 2027.
+
+Najomne a platby:
+Najomne je 850 EUR mesacne a je splatne vzdy do 5. dna prislusneho mesiaca
+na ucet prenajimatela IBAN: SK12 1100 0000 0026 2947 1123.
+Zalohy za sluzby spojene s uzivanim bytu su 180 EUR mesacne. Vyuctovanie sluzieb
+sa vykona podla skutocnych nakladov a pravidiel dohodnutych v tejto zmluve a
+podla povinne uplatnitelnych pravnych predpisov.
+
+Penazna zabezpeka:
+Najomca sklada pri podpise zmluvy penaznu zabezpeku vo vyske 1 700 EUR. Zabezpeka
+sluzi na zabezpecenie splatnych narokov prenajimatela z tejto zmluvy, najma
+nezaplateneho najomneho, sluzieb a preukazanej skody sposobenej najomcom.
+Prenajimatel moze zo zabezpeky zapocitat iba riadne vycislene a odovodnene
+naroky a zvysok vrati najomcovi po skonceni najmu v primeranej lehote po
+odovzdani bytu a vysporiadani narokov.
+
+Odovzdanie a vratenie bytu:
+O odovzdani a vrateni bytu zmluvne strany spisu protokol. Protokol uvedie stav
+bytu, zariadenia, klucov, pivnicnej kobky, meracov a zjavnych vad. Protokol moze
+obsahovat fotodokumentaciu.
+
+Opravy, vady a skody:
+Najomca hradi beznu drobnu udrzbu a skody, ktore sposobi on alebo osoby, ktorym
+umozni vstup do bytu. Prenajimatel zodpoveda za vady a opravy, ktore podla
+pravnych predpisov alebo povahy veci nepatria najomcovi. Najomca je povinny
+bez zbytocneho odkladu oznamit vady a hroziacu skodu.
+
+Vypoved a skoncenie najmu:
+Najom mozno skoncit pisomnou dohodou, uplynutim dohodnutej doby alebo pisomnou
+vypovedou v sulade s povinne uplatnitelnymi ustanoveniami slovenskeho prava.
+Vypoved musi byt pisomna, dorucena druhej strane preukazatelnym sposobom a musi
+obsahovat dovod, ak ho vyzaduje prislusny pravny predpis alebo zvoleny rezim najmu.
+
+Dorucovanie:
+Pisemnosti sa dorucuju osobne proti podpisu, postou na adresy uvedene v tejto
+zmluve alebo elektronicky iba sposobom, pri ktorom je mozne preukazat dorucenie
+alebo potvrdenie prijatia. Telefonicka sprava alebo SMS sama osebe nenahradza
+pisomnu vypoved, ak pravny predpis alebo tato zmluva vyzaduje pisomnu formu.
+
+Rozhodne pravo a kontrola:
+Zmluva sa riadi pravom Slovenskej republiky ucinne aplikovatelnym na najomny
+vztah. Tento dokument je synteticky navrh na kontrolu; pred realnym pouzitim ho
+ma skontrolovat kvalifikovana osoba.
+
+V Bratislave dna 15. juna 2026
+
+Prenajimatel: Marek Testovany
+Podpis: ______________________
+
+Najomca: Eva Najomna
+Podpis: ______________________

--- a/api/chat-simulator-app/testcases/outdated-najomna-zmluva-2026.expected.json
+++ b/api/chat-simulator-app/testcases/outdated-najomna-zmluva-2026.expected.json
@@ -1,0 +1,68 @@
+{
+  "fixture": "outdated-najomna-zmluva-2026.txt",
+  "documentType": "synthetic_slovak_rental_agreement",
+  "expectedExtractedFields": {
+    "landlord": "Marek Testovany",
+    "landlordAddress": "Kvetna 12, 040 01 Kosice",
+    "tenant": "Eva Najomna",
+    "tenantAddress": "Hlavna 8, 058 01 Poprad",
+    "propertyAddress": "Dunajska 45, 811 08 Bratislava",
+    "apartment": "byt c. 12",
+    "cellar": "pivnicna kobka c. 12B",
+    "leaseStart": "1. jula 2026",
+    "leaseEnd": "30. juna 2027",
+    "rent": "850 EUR",
+    "servicesAdvance": "180 EUR",
+    "deposit": "1 700 EUR",
+    "paymentDueDay": "5. dna",
+    "iban": "SK12 1100 0000 0026 2947 1123",
+    "signaturePlace": "Bratislava",
+    "signatureDate": "15. juna 2026"
+  },
+  "knownOutdatedThemes": [
+    {
+      "id": "deposit-return",
+      "keywords": ["zabezpeka", "vratenie", "zapoctenie"],
+      "expectedLawHints": ["40/1964", "Obciansky zakonnik", "98/2014"]
+    },
+    {
+      "id": "handover-protocol",
+      "keywords": ["odovzdavaci protokol", "stav meracov", "odovzdanie bytu"],
+      "expectedLawHints": ["40/1964", "Obciansky zakonnik", "98/2014"]
+    },
+    {
+      "id": "termination-notice",
+      "keywords": ["vypoved", "vypovedna lehota", "dorucenie"],
+      "expectedLawHints": ["40/1964", "Obciansky zakonnik", "98/2014"]
+    },
+    {
+      "id": "repairs-and-defects",
+      "keywords": ["opravy", "vady", "skody"],
+      "expectedLawHints": ["40/1964", "Obciansky zakonnik"]
+    },
+    {
+      "id": "delivery-proof",
+      "keywords": ["dorucovanie", "pisomnosti", "potvrdenie prijatia"],
+      "expectedLawHints": ["40/1964", "Obciansky zakonnik"]
+    }
+  ],
+  "forbiddenMissingDataQuestions": [
+    "kto je prenajimatel",
+    "meno prenajimatela",
+    "kto je najomca",
+    "meno najomcu",
+    "aka je adresa bytu",
+    "adresa nehnutelnosti",
+    "aka je vyska najomneho",
+    "kolko je najomne",
+    "aka je vyska zabezpeky",
+    "od kedy trva najom",
+    "do kedy trva najom"
+  ],
+  "lawGroundingHints": [
+    "40/1964",
+    "Obciansky zakonnik",
+    "98/2014",
+    "kratkodoby najom"
+  ]
+}

--- a/api/chat-simulator-app/testcases/outdated-najomna-zmluva-2026.suggested-changes.md
+++ b/api/chat-simulator-app/testcases/outdated-najomna-zmluva-2026.suggested-changes.md
@@ -1,0 +1,49 @@
+# Suggested Changes For The Synthetic Rental Agreement
+
+This is a reference checklist for issue #426. The live E2E still verifies the
+assistant output against the current laws collector/RAG corpus.
+
+1. Monetary security/deposit
+   - Old clause: landlord can set off the deposit at personal discretion and
+     return the rest "sometime" after lease end.
+   - Suggested change: state what the deposit secures, when deductions are
+     allowed, how they are documented, and when the remaining amount is returned.
+   - Law grounding to verify live: Slovak Civil Code rental provisions and, if
+     the agreement is treated as short-term apartment lease, Act No. 98/2014 Z. z.
+
+2. Handover protocol and meter readings
+   - Old clause: no handover protocol or meter state is needed.
+   - Suggested change: require a written handover protocol with apartment
+     condition, keys, equipment, meter readings, and photo/documentation annexes.
+   - Law grounding to verify live: Slovak Civil Code duties around lease object
+     handover/use and short-term apartment lease transparency requirements where applicable.
+
+3. Repairs, defects, and damage
+   - Old clause: tenant pays all repairs regardless of cause or amount.
+   - Suggested change: separate ordinary minor maintenance, tenant-caused damage,
+     landlord duties for defects not caused by the tenant, and notice duties.
+   - Law grounding to verify live: Slovak Civil Code lease provisions on use,
+     defects, maintenance, and liability.
+
+4. Termination and notice delivery
+   - Old clause: landlord can terminate anytime without reason, seven-day notice,
+     including oral/SMS notice.
+   - Suggested change: define written termination, lawful grounds, notice period,
+     delivery method, and evidence of delivery.
+   - Law grounding to verify live: Slovak Civil Code apartment-rental termination
+     provisions and Act No. 98/2014 Z. z. if the short-term lease regime applies.
+
+5. Delivery of documents
+   - Old clause: documents are deemed delivered merely by sending to phone/email.
+   - Suggested change: use written/electronic delivery with provable receipt or
+     legally supportable substitute delivery wording.
+   - Law grounding to verify live: Slovak Civil Code legal-act/delivery principles
+     plus the selected lease regime.
+
+6. Current-law clause
+   - Old clause: agreement is governed by law as of 1 January 2000.
+   - Suggested change: agreement is governed by the law of the Slovak Republic
+     effective at signing/performance, with mandatory provisions prevailing.
+
+Human oversight: This checklist is for synthetic test validation. The generated
+agreement must remain a draft for human/legal review before real use.

--- a/api/chat-simulator-app/testcases/outdated-najomna-zmluva-2026.txt
+++ b/api/chat-simulator-app/testcases/outdated-najomna-zmluva-2026.txt
@@ -1,0 +1,60 @@
+NAJOMNA ZMLUVA O PRENAJME BYTU
+synteticky testovaci dokument pre JurisDigta E2E
+
+Prenajimatel:
+Marek Testovany
+Trvale bydlisko: Kvetna 12, 040 01 Kosice
+Datum narodenia: 10. marec 1980
+Cislo OP: TT123456
+
+Najomca:
+Eva Najomna
+Trvale bydlisko: Hlavna 8, 058 01 Poprad
+Datum narodenia: 5. maj 1992
+Cislo OP: EN654321
+
+Predmet najmu:
+Prenajimatel prenechava najomcovi do uzivania byt c. 12 na 3. poschodi bytoveho domu
+na adrese Dunajska 45, 811 08 Bratislava, Slovenska republika. Byt ma dve izby,
+kuchynu, kupelnu, WC a pivnicnu kobku c. 12B.
+
+Doba najmu:
+Najom sa dojednava od 1. jula 2026 do 30. juna 2027.
+
+Najomne a platby:
+Najomne je 850 EUR mesacne a je splatne vzdy do 5. dna prislusneho mesiaca
+na ucet prenajimatela IBAN: SK12 1100 0000 0026 2947 1123.
+Zalohy za sluzby spojene s uzivanim bytu su 180 EUR mesacne.
+
+Penazna zabezpeka:
+Najomca sklada pri podpise zmluvy penaznu zabezpeku vo vyske 1 700 EUR.
+Prenajimatel moze zabezpeku zapocitat na akekolvek svoje naroky podla vlastneho uvazenia
+a zvysok vrati najomcovi niekedy po skonceni najmu.
+
+Odovzdanie bytu:
+Byt sa povazuje za odovzdany podpisom tejto zmluvy. Zmluvne strany nemusia spisat
+samostatny odovzdavaci protokol ani stav meracov.
+
+Opravy a skody:
+Najomca hradi vsetky opravy v byte bez ohladu na pricinu a vysku nakladov.
+Prenajimatel nie je povinny riesit vady, ktore vzniknu pocas trvania najmu.
+
+Vypoved:
+Prenajimatel moze najom kedykolvek vypovedat bez uvedenia dovodu s vypovednou
+lehotou sedem dni. Vypoved je ucinna aj ustnym oznamom alebo SMS spravou.
+
+Dorucovanie:
+Pisemnosti sa povazuju za dorucene odoslanim na posledne zname telefonne cislo alebo
+e-mailovu adresu bez potreby potvrdenia prijatia.
+
+Osobitne ustanovenie:
+Zmluva sa riadi pravnymi predpismi platnymi ku dnu 1. januara 2000.
+Strany vyhlasuju, ze nepotrebuju ziadne dalsie poucenie o pravach a povinnostiach.
+
+V Bratislave dna 15. juna 2026
+
+Prenajimatel: Marek Testovany
+Podpis: ______________________
+
+Najomca: Eva Najomna
+Podpis: ______________________

--- a/api/chat-simulator-app/testcases/sample_outdated_najomna_zmluva_2026.txt
+++ b/api/chat-simulator-app/testcases/sample_outdated_najomna_zmluva_2026.txt
@@ -1,0 +1,16 @@
+{
+  "CaseTitle": "E2E zastarana najomna zmluva",
+  "CaseDescription": "
+    Analyzuj vsetky nahrane dokumenty v tomto pripade. Over zastaranu najomnu zmluvu
+    podla aktualnych slovenskych zakonov z JurisDigta laws/RAG databazy. Najprv zobraz
+    udaje, ktore si nasiel v starej zmluve, potom navrhni zmeny s odovodnenim v zakone
+    a priprav opraveny navrh najomnej zmluvy. Nepytaj sa na prenajimatela, najomcu,
+    byt, najomne, zabezpeku ani dobu najmu, ak su tieto udaje citatelne v dokumente.
+  ",
+  "Documents": [
+    {
+      "filePath": "./outdated-najomna-zmluva-2026.txt",
+      "fileName": "Zastarana najomna zmluva 2026"
+    }
+  ]
+}

--- a/docs/OUTDATED_RENTAL_AGREEMENT_E2E.md
+++ b/docs/OUTDATED_RENTAL_AGREEMENT_E2E.md
@@ -1,0 +1,58 @@
+# Outdated Slovak Rental Agreement E2E
+
+This scenario covers issue #426. It verifies that JurisDigta can review an
+uploaded synthetic Slovak rental agreement, compare it with the current live
+laws collector/RAG corpus, show extracted facts, suggest law-grounded changes,
+and generate a corrected agreement for both Free and Paid users.
+
+## Fixtures
+
+- Original synthetic agreement:
+  `api/chat-simulator-app/testcases/outdated-najomna-zmluva-2026.txt`
+- Expected extracted fields and outdated themes:
+  `api/chat-simulator-app/testcases/outdated-najomna-zmluva-2026.expected.json`
+- Chat simulator prepared case:
+  `api/chat-simulator-app/testcases/sample_outdated_najomna_zmluva_2026.txt`
+- Human-readable suggested changes:
+  `api/chat-simulator-app/testcases/outdated-najomna-zmluva-2026.suggested-changes.md`
+- Human-readable corrected reference draft:
+  `api/chat-simulator-app/testcases/outdated-najomna-zmluva-2026.corrected-reference.txt`
+
+The fixture uses only synthetic people, addresses, identity-card numbers, and
+bank-account data. Do not replace it with real lease-party data.
+
+## E2E Command
+
+Start the local API with live laws collector data available, then run:
+
+```powershell
+cd api/aijuristiction-api/e2e-playwright
+npm run test:outdated-rental
+```
+
+The test checks:
+
+- Free user route is local/free.
+- Paid user route has an active Case-plan policy.
+- The uploaded fixture is processed and appears in document debug context.
+- The assistant message shows the extracted parties, property, rent, deposit,
+  dates, and payment data from the old document.
+- The assistant does not ask for those already-known fields.
+- Suggested changes reference current Slovak law sources from the live corpus.
+- The exported corrected agreement PDF contains the extracted facts and avoids
+  unresolved placeholders.
+
+## Compliance Notes
+
+- GDPR: synthetic fixture only, no real personal data.
+- GDPR minimization: the test asserts selected field values and diagnostics
+  without dumping full generated documents into shared logs.
+- EU AI Act: legal-risk output must remain transparent and subject to human
+  review. The generated agreement is a draft for review, not guaranteed legal
+  representation or filing.
+
+The repository default minimal runnable example remains:
+
+```powershell
+python examples/minimal_demo.py
+```


### PR DESCRIPTION
﻿## Summary
- adds a synthetic outdated Slovak rental agreement fixture for issue #426
- adds expected extracted fields, outdated-clause themes, suggested changes, and corrected reference draft
- adds API Playwright E2E coverage for Free/local and Paid/Case-plan routes using live laws corpus preconditions
- documents the scenario and run command

## Validation
- PASS: `npm run test:outdated-rental -- --list`
- PASS: `python -m pytest api/aijuristiction-api/tests/test_case_documents_processing.py::test_case_document_upload_processes_immediately_in_api_mode -q`
- PASS: `python -m pytest tests/test_app.py::test_read_testcase_supports_case_descripton_typo_and_embeds_documents -q` from `api/chat-simulator-app`
- PASS: pre-commit hook during commit (`All checks passed!`, `Success: no issues found in 59 source files`)
- EXPECTED INFRA FAIL locally: `npm run test:outdated-rental` fails before model execution because the running API reports `/version laws_by_country.sk.last_law_update_source=unavailable`. The test now fails with an explicit message requiring `LAWS_DB_BACKEND=postgres` and `LAWS_DB_CLOUD=postgresql://postgres:postgres@127.0.0.1:5433/laws_sk` or equivalent live laws DB. Ollama is also not installed/running on this workstation, so the Free local model route cannot complete until local model infra is available.

## Issue
Closes #426
