### PR TITLE
Fix Ollama Grafana metrics routing

### DIFF
--- a/Deployment/monitoring/README.md
+++ b/Deployment/monitoring/README.md
@@ -227,7 +227,9 @@ curl -fsS http://127.0.0.1:9108/metrics | head
 
 ## Ollama Metrics Exporter
 
-Self-managed production also starts `ollama-exporter` when the monitoring stack is enabled. It runs with host networking so it can read the localhost-only Ollama API at `LOCAL_LLM_BASE_URL`, which defaults to:
+Self-managed production also starts `ollama-exporter` when the monitoring stack is enabled. It runs with host networking and reads Ollama through `LOCAL_LLM_BASE_URL` in `Deployment/monitoring/.env`. `configure_monitoring.py` derives that value from `OLLAMA_HOST_BIND`, an already non-loopback `LOCAL_LLM_BASE_URL`, or the `MONITORING_APP_DOCKER_NETWORK` gateway. This keeps the exporter aligned with Docker production, where Ollama is bound to the private API Docker gateway instead of `127.0.0.1`.
+
+When Docker gateway detection is unavailable, the fallback remains:
 
 ```text
 http://127.0.0.1:11434
@@ -237,6 +239,15 @@ Prometheus scrapes it at:
 
 ```text
 http://host.docker.internal:9109/metrics
+```
+
+Validate the exporter target on the server:
+
+```bash
+grep '^LOCAL_LLM_BASE_URL=' /srv/jurisdigta/app/Deployment/monitoring/.env
+curl -fsS "$(grep '^LOCAL_LLM_BASE_URL=' /srv/jurisdigta/app/Deployment/monitoring/.env | cut -d= -f2-)/api/tags" >/dev/null
+curl -fsS http://127.0.0.1:9109/metrics | grep jurisdigta_ollama_up
+curl -fsS 'http://127.0.0.1:9091/api/v1/query?query=jurisdigta_ollama_up'
 ```
 
 Keep host port `9109` blocked from public ingress the same way as Prometheus, Grafana, and the status exporter. It is only for the private Prometheus scrape path.

--- a/Deployment/monitoring/configure_monitoring.py
+++ b/Deployment/monitoring/configure_monitoring.py
@@ -26,6 +26,8 @@ DEFAULT_GRAFANA_ROOT_URL = "https://admin.jurisdigta.eu/grafana/"
 DEFAULT_ALERT_EMAIL_TO = "info@jurisdigta.eu"
 DEFAULT_APP_DOCKER_NETWORK = "aijuristiction-api_default"
 DEFAULT_HOME_DASHBOARD_PATH = "/var/lib/grafana/dashboards/jurisdigta-application-performance.json"
+DEFAULT_LOCAL_LLM_MODEL = "qwen3:1.7b"
+DEFAULT_LOCAL_LLM_BASE_URL = "http://127.0.0.1:11434"
 
 
 def main() -> int:
@@ -142,6 +144,15 @@ def _build_monitoring_env(
         _first(project_values, existing_values, "GRAFANA_ADMIN_PASSWORD")
         or secrets.token_urlsafe(32)
     )
+    app_network = (
+        _first(project_values, existing_values, "MONITORING_APP_DOCKER_NETWORK")
+        or DEFAULT_APP_DOCKER_NETWORK
+    )
+    local_llm_base_url = _monitoring_local_llm_base_url(
+        project_values=project_values,
+        existing_values=existing_values,
+        app_network=app_network,
+    )
 
     return {
         "PROMETHEUS_HOST_PORT": (
@@ -176,8 +187,11 @@ def _build_monitoring_env(
             or DEFAULT_DOCKER_LOG_MAX_FILE
         ),
         "MONITORING_APP_DOCKER_NETWORK": (
-            _first(project_values, existing_values, "MONITORING_APP_DOCKER_NETWORK")
-            or DEFAULT_APP_DOCKER_NETWORK
+            app_network
+        ),
+        "LOCAL_LLM_BASE_URL": local_llm_base_url,
+        "LOCAL_LLM_MODEL": (
+            _first(project_values, existing_values, "LOCAL_LLM_MODEL") or DEFAULT_LOCAL_LLM_MODEL
         ),
         "JURISDIGTA_API_KEY": _first(project_values, existing_values, "JURISDIGTA_API_KEY", "API_KEY"),
         "GRAFANA_SERVER_DOMAIN": (
@@ -218,6 +232,60 @@ def _build_monitoring_env(
             or DEFAULT_ALERT_EMAIL_TO
         ),
     }
+
+
+def _monitoring_local_llm_base_url(
+    *,
+    project_values: dict[str, str],
+    existing_values: dict[str, str],
+    app_network: str,
+) -> str:
+    explicit_bind = _first(project_values, existing_values, "OLLAMA_HOST_BIND")
+    if explicit_bind:
+        return _ollama_bind_to_base_url(explicit_bind)
+
+    configured = _first(project_values, existing_values, "LOCAL_LLM_BASE_URL")
+    if configured and not _is_loopback_url(configured):
+        return configured.rstrip("/")
+
+    gateway = _docker_network_gateway(app_network)
+    if gateway:
+        return f"http://{gateway}:11434"
+
+    return (configured or DEFAULT_LOCAL_LLM_BASE_URL).rstrip("/")
+
+
+def _ollama_bind_to_base_url(bind: str) -> str:
+    normalized = bind.strip()
+    if not normalized:
+        return DEFAULT_LOCAL_LLM_BASE_URL
+    if normalized.startswith(("http://", "https://")):
+        return normalized.rstrip("/")
+    return f"http://{normalized.rstrip('/')}"
+
+
+def _is_loopback_url(value: str) -> bool:
+    normalized = value.strip().lower()
+    return (
+        normalized.startswith("http://127.0.0.1:")
+        or normalized.startswith("http://localhost:")
+        or normalized.startswith("https://127.0.0.1:")
+        or normalized.startswith("https://localhost:")
+    )
+
+
+def _docker_network_gateway(network: str) -> str:
+    try:
+        result = subprocess.run(
+            ["docker", "network", "inspect", network, "--format", "{{(index .IPAM.Config 0).Gateway}}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return ""
+    gateway = result.stdout.strip()
+    return "" if not gateway or gateway == "<no value>" else gateway
 
 
 def _first(

--- a/Deployment/self-managed-server-deployment.md
+++ b/Deployment/self-managed-server-deployment.md
@@ -184,13 +184,15 @@ less /tmp/install-ollama.sh
 sh /tmp/install-ollama.sh
 ```
 
-Bind Ollama to localhost only:
+Bind Ollama to a private host interface only. The deployment script computes the
+API Docker network gateway and writes it as `OLLAMA_HOST`; manual setups can use
+`127.0.0.1:11434` only when every local caller runs on the host network:
 
 ```bash
 sudo mkdir -p /etc/systemd/system/ollama.service.d
 cat <<'EOF' | sudo tee /etc/systemd/system/ollama.service.d/jurisdigta-localhost.conf >/dev/null
 [Service]
-Environment="OLLAMA_HOST=127.0.0.1:11434"
+Environment="OLLAMA_HOST=<private-host-or-docker-gateway-ip>:11434"
 EOF
 sudo systemctl daemon-reload
 sudo systemctl enable --now ollama
@@ -211,8 +213,8 @@ Validate the service:
 
 ```bash
 systemctl is-active --quiet ollama
-curl -fsS http://127.0.0.1:11434/api/tags
-curl -fsS http://127.0.0.1:11434/v1/models
+curl -fsS http://<private-host-or-docker-gateway-ip>:11434/api/tags
+curl -fsS http://<private-host-or-docker-gateway-ip>:11434/v1/models
 ```
 
 Security rule: do not expose port `11434` through Cloudflare Tunnel, nginx, router NAT, or public firewall rules. Only the API/model-router should call Ollama on localhost or the private Docker server network.

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260481"
+version = "1.0.260482"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_ai_model_routing.py
+++ b/api/aijuristiction-api/tests/test_ai_model_routing.py
@@ -161,6 +161,31 @@ def test_effective_model_route_endpoint_reports_free_user_local_model(
     assert payload["label"] == "Local Ollama - qwen3:1.7b"
 
 
+def test_effective_model_route_endpoint_reports_default_free_route_without_user(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "api.sqlite3"
+    blob_root = tmp_path / "blob"
+    monkeypatch.setenv("DB_OPTION", "local")
+    monkeypatch.setenv("DB_LOCAL", str(db_path))
+    monkeypatch.setenv("STORAGE_OPTION", "local")
+    monkeypatch.setenv("STORE_LOCAL", str(blob_root))
+
+    response = client.get(
+        "/v1/model-routing/effective?task_type=chat_reply",
+        headers={"x-api-key": "aijuris"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["plan_code"] == "free"
+    assert payload["route_type"] == "free_local"
+    assert payload["provider"] == "local_ollama"
+    assert payload["model"] == "qwen3:1.7b"
+    assert payload["is_local"] is True
+
+
 def test_model_credentials_are_encrypted_and_revealed_only_when_requested(
     monkeypatch: Any,
     tmp_path: Path,

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260400"
+__version__ = "1.0.260401"

--- a/src/aijurisdictionagents/api_db/store.py
+++ b/src/aijurisdictionagents/api_db/store.py
@@ -1692,7 +1692,7 @@ class ApiDatabaseStore:
                 """
                 SELECT case_id, plan_code, 'all' AS provider, 'all' AS model,
                        CASE
-                           WHEN route_type IN ('local', 'local_only') OR provider LIKE '%ollama%'
+                           WHEN route_type IN ('local', 'local_only') OR provider LIKE '%%ollama%%'
                            THEN 'local'
                            WHEN route_type IN ('external', 'external_ack_required')
                            THEN 'paid'
@@ -1704,7 +1704,7 @@ class ApiDatabaseStore:
                 WHERE request_completed_at >= ? AND case_id <> ''
                 GROUP BY case_id, plan_code,
                          CASE
-                             WHEN route_type IN ('local', 'local_only') OR provider LIKE '%ollama%'
+                             WHEN route_type IN ('local', 'local_only') OR provider LIKE '%%ollama%%'
                              THEN 'local'
                              WHEN route_type IN ('external', 'external_ack_required')
                              THEN 'paid'
@@ -2351,6 +2351,22 @@ class ApiDatabaseStore:
                 """,
             ).fetchall()
         return [_row_to_subscription_plan(row) for row in rows]
+
+    def get_subscription_plan(self, *, plan_code: str) -> SubscriptionPlan:
+        normalized_plan = plan_code.strip().lower()
+        with self._connect() as conn:
+            row = self._fetchone(
+                conn,
+                """
+                SELECT plan_code, display_name, subscription_type, price_eur, max_cases, max_documents_per_case, case_ttl_days
+                FROM subscription_plans
+                WHERE plan_code = ?
+                """,
+                (normalized_plan,),
+            )
+        if row is None:
+            raise KeyError(f"Subscription plan {normalized_plan or plan_code} not found")
+        return _row_to_subscription_plan(row)
 
     def list_user_subscriptions(self, *, user_id: str) -> list[UserSubscription]:
         with self._connect() as conn:

--- a/tests/test_server_monitoring.py
+++ b/tests/test_server_monitoring.py
@@ -85,6 +85,7 @@ def test_monitoring_stack_loads_ai_model_alert_rules() -> None:
 def test_monitoring_env_defaults_include_log_retention() -> None:
     module = _load_configure_monitoring_module()
 
+    module._docker_network_gateway = lambda network: ""
     values = module._build_monitoring_env(
         project_values={},
         existing_values={},
@@ -96,6 +97,34 @@ def test_monitoring_env_defaults_include_log_retention() -> None:
     assert values["PROMETHEUS_RETENTION_DAYS"] == "30"
     assert values["DOCKER_LOG_MAX_SIZE"] == "50m"
     assert values["DOCKER_LOG_MAX_FILE"] == "5"
+    assert values["LOCAL_LLM_BASE_URL"] == "http://127.0.0.1:11434"
+    assert values["LOCAL_LLM_MODEL"] == "qwen3:1.7b"
+
+
+def test_monitoring_env_uses_docker_gateway_for_loopback_ollama_url() -> None:
+    module = _load_configure_monitoring_module()
+
+    module._docker_network_gateway = lambda network: "172.18.0.1"
+    values = module._build_monitoring_env(
+        project_values={"LOCAL_LLM_BASE_URL": "http://127.0.0.1:11434"},
+        existing_values={},
+        prometheus_host_port=None,
+    )
+
+    assert values["LOCAL_LLM_BASE_URL"] == "http://172.18.0.1:11434"
+
+
+def test_monitoring_env_prefers_explicit_ollama_host_bind() -> None:
+    module = _load_configure_monitoring_module()
+
+    module._docker_network_gateway = lambda network: "172.18.0.1"
+    values = module._build_monitoring_env(
+        project_values={"OLLAMA_HOST_BIND": "10.0.0.5:11434"},
+        existing_values={"LOCAL_LLM_BASE_URL": "http://127.0.0.1:11434"},
+        prometheus_host_port=None,
+    )
+
+    assert values["LOCAL_LLM_BASE_URL"] == "http://10.0.0.5:11434"
 
 
 def test_prod_api_container_receives_prometheus_url() -> None:


### PR DESCRIPTION
## Summary
- Fixes #431.
- Adds the missing `ApiDatabaseStore.get_subscription_plan()` path used by `/v1/model-routing/effective` when no user id is supplied.
- Fixes PostgreSQL AI model top-case usage summarization by escaping the `%ollama%` LIKE pattern for the DB adapter.
- Makes monitoring env generation pass a reachable Ollama URL to `jurisdigta-ollama-exporter`, preferring `OLLAMA_HOST_BIND`, then non-loopback `LOCAL_LLM_BASE_URL`, then the Docker network gateway.
- Updates monitoring/self-managed docs and bumps API/core revision versions.

## Compliance
- Observability remains aggregate/model-runtime only.
- No prompts, answers, full case IDs, user PII, or secrets are added to Prometheus/Grafana metrics.
- Existing masked case references are preserved for top-case usage metrics.

## Validation
- `scripts/validate_api.ps1` passed.
- `ruff check Deployment/monitoring/configure_monitoring.py tests/test_server_monitoring.py src/aijurisdictionagents/api_db/store.py api/aijuristiction-api/tests/test_ai_model_routing.py` passed.
- `mypy app` passed.
- Focused regression tests passed: `tests/test_server_monitoring.py`, default free effective route, top-case usage summary, and status exporter AI model metrics.

## Known local test limitation
- Full `python -m pytest api/aijuristiction-api/tests` still hard-exits after progress dots on this Windows runner. Isolated failure boundary is the pre-existing `test_expired_paid_subscription_routes_as_free_local_model`, which exits without a Python traceback.