### PR TITLE
Accept 201 for MCP dynamic registration smoke

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -55,8 +55,10 @@ curl http://127.0.0.1:8070/
 The OAuth flow uses authorization code with PKCE S256, plus refresh tokens for
 remote clients that request `offline_access`. Remote clients can either use
 dynamic client registration at `/oauth/register` or provide a preconfigured
-public OAuth Client ID. ChatGPT and Claude should pass the protected resource
-value `https://mcp.jurisdigta.eu/MCP` on the authorization, token, and refresh
+public OAuth Client ID. New dynamic registrations may return either `200 OK` or
+`201 Created` with the issued public client metadata. ChatGPT and Claude should
+pass the protected resource value `https://mcp.jurisdigta.eu/MCP` on the
+authorization, token, and refresh
 requests. Protected-resource metadata includes a human-readable
 `resource_name`, and authorization-server metadata advertises the protected MCP
 resource plus `authorization_response_iss_parameter_supported=true`. The

--- a/scripts/prod_mcp_claude_smoke.py
+++ b/scripts/prod_mcp_claude_smoke.py
@@ -124,6 +124,7 @@ def check_claude_registration(base_url: str) -> str:
             "token_endpoint_auth_method": "none",
             "scope": "mcp:laws offline_access",
         },
+        expected_status={200, 201},
     )
     client_id = str(payload.get("client_id") or "")
     if not client_id.startswith("jurisdigta-"):
@@ -232,9 +233,10 @@ def request_json(
     url: str,
     payload: dict[str, Any] | None = None,
     *,
+    expected_status: int | set[int] = 200,
     extra_headers: dict[str, str] | None = None,
 ) -> dict[str, Any]:
-    return request(method, url, payload, extra_headers=extra_headers).json()
+    return request(method, url, payload, expected_status=expected_status, extra_headers=extra_headers).json()
 
 
 def request(
@@ -242,7 +244,7 @@ def request(
     url: str,
     payload: dict[str, Any] | None = None,
     *,
-    expected_status: int = 200,
+    expected_status: int | set[int] = 200,
     extra_headers: dict[str, str] | None = None,
 ) -> HttpResponse:
     body = None
@@ -268,9 +270,11 @@ def request(
     except URLError as exc:
         raise AssertionError(f"HTTP request failed for {method} {url}: {exc}") from exc
 
-    if status != expected_status:
+    expected_statuses = expected_status if isinstance(expected_status, set) else {expected_status}
+    if status not in expected_statuses:
         preview = data.decode("utf-8", errors="replace")[:500]
-        raise AssertionError(f"Expected {expected_status} for {method} {url}, got {status}: {preview}")
+        expected_label = " or ".join(str(item) for item in sorted(expected_statuses))
+        raise AssertionError(f"Expected {expected_label} for {method} {url}, got {status}: {preview}")
     return HttpResponse(status=status, headers=response_headers, body=data)
 
 


### PR DESCRIPTION
Fixes the self-managed production deploy smoke check to accept OAuth dynamic client registration responses that return 201 Created with valid public client metadata. Production currently returns 201 for /oauth/register, which is valid for newly created registrations.

Validation:
- Ran patched scripts/prod_mcp_claude_smoke.py against https://mcp.jurisdigta.eu via jurisdigta-server Python; all checks passed.
- git diff --check