### PR TITLE
Fix issue 437 MCP TLS interception diagnostics

### DIFF
--- a/Deployment/local-dynamic-dns-domain-setup.md
+++ b/Deployment/local-dynamic-dns-domain-setup.md
@@ -279,6 +279,15 @@ If a hostname returns a Cloudflare tunnel error, check:
 4. The public hostname's local service URL and port.
 5. The setup.sk `CNAME` value and DNS propagation.
 
+If HTTPS fails before an HTTP status is returned, inspect the certificate issuer
+shown to the client. Antivirus or enterprise proxy TLS inspection can re-sign
+the Cloudflare certificate with a local issuer such as `Avast Web/Mail Shield
+Root`; strict clients may then fail with OpenSSL, Node.js, or Schannel
+certificate errors even though the tunnel route is healthy. Exclude JurisDigta
+hostnames from HTTPS scanning or configure the client runtime to use the
+operating-system trust store where appropriate. Do not treat `--ssl-no-revoke`,
+`-k`, or disabled certificate verification as a production MCP/Claude fix.
+
 ### 9. Add Cloudflare Access before exposing admin
 
 Before using `admin.jurisdigta.eu` for anything real:

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -165,6 +165,26 @@ system certificate store. If Claude logs `Claude Code requires a Pro or Max
 subscription`, the MCP server may be configured correctly but the active Claude
 account lacks the required Claude Desktop/Code entitlement.
 
+If Claude, `mcp-remote`, `curl`, or `scripts/prod_mcp_claude_smoke.py` reports
+a TLS/certificate failure before OAuth discovery is reached, inspect the
+certificate issuer first. Some antivirus and corporate proxy products re-sign
+HTTPS traffic with a local root certificate, for example `Avast Web/Mail Shield
+Root`. That client-side TLS interception can cause strict OpenSSL clients to
+fail with errors such as `certificate verify failed`,
+`UNABLE_TO_VERIFY_LEAF_SIGNATURE`, or Windows Schannel revocation errors even
+when the public Cloudflare tunnel and MCP app are healthy.
+
+For production connector validation, do not use `--ssl-no-revoke`, `-k`, or
+disabled certificate verification as the fix. Exclude `mcp.jurisdigta.eu` from
+HTTPS scanning, disable TLS interception for Claude/MCP traffic, or configure
+the client runtime to trust the operating-system store when that is acceptable
+for the local workstation. Then re-run:
+
+```powershell
+python scripts/prod_mcp_claude_smoke.py --retries 1 --retry-delay 1
+curl.exe -Iv https://mcp.jurisdigta.eu/health
+```
+
 Discovery endpoints:
 
 - `https://mcp.jurisdigta.eu/.well-known/oauth-protected-resource/MCP`

--- a/docs/manual_infrastucture_setup.md
+++ b/docs/manual_infrastucture_setup.md
@@ -216,6 +216,7 @@ Purpose: point `web.jurisdigta.eu`, `agent.jurisdigta.eu`, `api.jurisdigta.eu`, 
 7. Configure local nginx or service listeners for `web`, `api`, `mcp`, and `admin`.
 8. Validate HTTPS externally from outside the LAN after DNS propagation.
 9. Protect `agent.jurisdigta.eu` with JurisDigta account login against the API users table for the current release, and protect `admin.jurisdigta.eu` plus MCP endpoints with Cloudflare Access, authentication, rate limits, audit logging, and preferably VPN/IP allow-list before production use.
+10. If external HTTPS validation fails before an HTTP response, inspect the served certificate issuer. A local antivirus or enterprise proxy issuer such as `Avast Web/Mail Shield Root` means the failure is on the client TLS-inspection path, not on the Cloudflare Tunnel app route. Disable or exclude HTTPS scanning for JurisDigta MCP/API validation clients, or configure the client runtime to use the operating-system trust store where appropriate.
 
 ### Secrets And Access Values
 
@@ -231,6 +232,7 @@ Purpose: point `web.jurisdigta.eu`, `agent.jurisdigta.eu`, `api.jurisdigta.eu`, 
 - Router forwards for public TCP `80` and `443` remain disabled unless a separate documented exception exists.
 - `cloudflared --version`, `systemctl status cloudflared --no-pager`, and `journalctl -u cloudflared -n 100 --no-pager` succeed on the server.
 - External checks such as `curl -fsS https://api.jurisdigta.eu/health` succeed from outside the LAN.
+- Strict client checks such as `curl.exe -Iv https://mcp.jurisdigta.eu/health` and `python scripts/prod_mcp_claude_smoke.py --retries 1 --retry-delay 1` succeed without `--ssl-no-revoke`, `-k`, or disabled verification. If they fail and the peer issuer is an antivirus/proxy root rather than Cloudflare or a public CA, fix the local TLS-inspection configuration before testing Claude again.
 
 ### Rollback Notes
 

--- a/scripts/prod_mcp_claude_smoke.py
+++ b/scripts/prod_mcp_claude_smoke.py
@@ -2,10 +2,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import socket
+import ssl
 import sys
+import tempfile
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
@@ -268,7 +273,11 @@ def request(
         data = exc.read()
         response_headers = {key.lower(): value for key, value in exc.headers.items()}
     except URLError as exc:
-        raise AssertionError(f"HTTP request failed for {method} {url}: {exc}") from exc
+        detail = f"HTTP request failed for {method} {url}: {exc}"
+        tls_detail = tls_certificate_diagnostic(url, exc)
+        if tls_detail:
+            detail = f"{detail}\n{tls_detail}"
+        raise AssertionError(detail) from exc
 
     expected_statuses = expected_status if isinstance(expected_status, set) else {expected_status}
     if status not in expected_statuses:
@@ -283,6 +292,82 @@ def mcp_headers() -> dict[str, str]:
         "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
         "User-Agent": "python-httpx/0.28.1 Claude MCP smoke test",
     }
+
+
+def tls_certificate_diagnostic(url: str, error: URLError) -> str:
+    reason = getattr(error, "reason", error)
+    if not isinstance(reason, ssl.SSLError):
+        return ""
+
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or not parsed.hostname:
+        return ""
+
+    port = parsed.port or 443
+    try:
+        cert = fetch_peer_certificate(parsed.hostname, port)
+    except OSError as exc:  # pragma: no cover - diagnostic path
+        return f"TLS certificate diagnostic unavailable for {parsed.hostname}:{port}: {exc}"
+
+    subject = name_to_text(cert.get("subject", ()))
+    issuer = name_to_text(cert.get("issuer", ()))
+    san = cert.get("subjectAltName", ())
+    san_text = (
+        ", ".join(f"{name}:{value}" for name, value in san)
+        if isinstance(san, tuple)
+        else str(san)
+    )
+    mitigation = (
+        "Strict TLS verification failed before the MCP/OAuth flow reached the server. "
+        "If the issuer is an antivirus, proxy, or enterprise TLS inspection root "
+        "(for example Avast Web/Mail Shield), fix that local/client trust path or "
+        "exclude mcp.jurisdigta.eu from HTTPS scanning. Do not use --ssl-no-revoke, "
+        "-k, or disabled verification as a production connector workaround."
+    )
+    return (
+        "TLS certificate diagnostic:\n"
+        f"- peer subject: {subject or 'unknown'}\n"
+        f"- peer issuer: {issuer or 'unknown'}\n"
+        f"- peer SAN: {san_text or 'unknown'}\n"
+        f"- guidance: {mitigation}"
+    )
+
+
+def fetch_peer_certificate(hostname: str, port: int) -> dict[str, Any]:
+    context = ssl._create_unverified_context()
+    with socket.create_connection((hostname, port), timeout=TIMEOUT_SECONDS) as raw_socket:
+        with context.wrap_socket(raw_socket, server_hostname=hostname) as tls_socket:
+            der_cert = tls_socket.getpeercert(binary_form=True)
+    if not der_cert:
+        return {}
+
+    pem_cert = ssl.DER_cert_to_PEM_cert(der_cert)
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".pem", delete=False, encoding="ascii"
+    ) as cert_file:
+        cert_path = Path(cert_file.name)
+        cert_file.write(pem_cert)
+    try:
+        return ssl._ssl._test_decode_cert(str(cert_path))  # type: ignore[attr-defined]
+    finally:
+        cert_path.unlink(missing_ok=True)
+
+
+def name_to_text(name: object) -> str:
+    if not isinstance(name, tuple):
+        return ""
+    parts: list[str] = []
+    for group in name:
+        if not isinstance(group, tuple):
+            continue
+        for attribute in group:
+            if (
+                isinstance(attribute, tuple)
+                and len(attribute) == 2
+                and isinstance(attribute[0], str)
+            ):
+                parts.append(f"{attribute[0]}={attribute[1]}")
+    return ", ".join(parts)
 
 
 def assert_equal(actual: Any, expected: Any, name: str) -> None:


### PR DESCRIPTION
## Summary\n- add strict TLS failure diagnostics to the production MCP Claude smoke script\n- document antivirus/proxy TLS interception as a client-side blocker for Claude/mcp-remote\n- update Cloudflare Tunnel/manual infrastructure validation steps to avoid --ssl-no-revoke or disabled verification as production fixes\n- updated this workstation's Claude Desktop config with the JurisDigta mcp-remote entry and NODE_OPTIONS=--use-system-ca\n\n## Validation\n- parsed Claude Desktop JSON config after adding the JurisDigta MCP server\n- verified Node reaches https://mcp.jurisdigta.eu/health with NODE_OPTIONS=--use-system-ca: HTTP 200\n- verified curl.exe --ssl-no-revoke reaches https://mcp.jurisdigta.eu/health: status ok\n- verified default Node/curl on this workstation see Avast Web/Mail Shield Root TLS interception\n- ran py_compile for scripts/prod_mcp_claude_smoke.py\n- git diff --check passed\n\n## Notes\n- Could not run the Python smoke end-to-end locally because available Windows Python runtimes fail in the local OpenSSL/Avast path with OPENSSL_Applink before script execution. The script remains strict and should still fail when TLS verification is genuinely broken.\n\nCloses #437