### PR TITLE
Add court decision MCP statistics

### DIFF
--- a/api/aijuristiction-api/app/mcp_api.py
+++ b/api/aijuristiction-api/app/mcp_api.py
@@ -1150,13 +1150,22 @@ def _call_tool(name: str, arguments: dict[str, Any]) -> Any:
     return handler(arguments)
 
 
-def _tool_get_version(_arguments: dict[str, Any]) -> dict[str, str]:
+def _tool_get_version(_arguments: dict[str, Any]) -> dict[str, Any]:
+    court_decisions = _court_decision_statistics()
+    court_decision_collector_version = get_core_version()
     return {
         "api_version": get_api_version(),
         "mcp_server_version": get_mcp_server_version(),
         "system_version": get_core_version(),
         "mobile_app_version": get_mobile_app_version(),
         "web_app_version": get_web_app_version(),
+        "court_decision_collector_version": court_decision_collector_version,
+        "court_decision_collector": {
+            "version": court_decision_collector_version,
+            "status": court_decisions.get("collector_status"),
+            "last_imported_decision": court_decisions.get("last_imported_decision"),
+            "last_imported_at": court_decisions.get("last_imported_at"),
+        },
     }
 
 
@@ -1165,18 +1174,29 @@ def _tool_get_statistics(arguments: dict[str, Any]) -> dict[str, Any]:
     logger.info("mcp_tool_get_statistics_query country_code=%s", country_code)
     payload = _read_laws_statistics(config=_laws_db_config(), country_code=country_code)
     collector = payload.get("collector", {})
+    court_decisions = _court_decision_statistics()
     result = {
         "country_code": payload.get("country_code"),
         "processed_laws": payload.get("totals", {}).get("laws_imported", 0),
         "last_processed_law": collector.get("last_processed_law"),
         "last_processed_day": collector.get("last_processed_at"),
+        "court_decision_collector_version": get_core_version(),
+        "total_court_decisions": court_decisions.get("total_decisions", 0),
+        "last_imported_decision": court_decisions.get("last_imported_decision"),
+        "last_imported_decision_at": court_decisions.get("last_imported_at"),
+        "court_decisions": court_decisions,
         "details": payload,
     }
     logger.info(
-        "mcp_tool_get_statistics_result country_code=%s processed_laws=%s last_processed_law=%s",
+        (
+            "mcp_tool_get_statistics_result country_code=%s processed_laws=%s "
+            "last_processed_law=%s total_court_decisions=%s last_imported_decision=%s"
+        ),
         result["country_code"],
         result["processed_laws"],
         result["last_processed_law"],
+        result["total_court_decisions"],
+        result["last_imported_decision"],
     )
     return result
 
@@ -1556,16 +1576,65 @@ def _court_decision_store() -> Any:
     return store
 
 
+def _court_decision_statistics() -> dict[str, Any]:
+    try:
+        stats = _court_decision_store().statistics()
+    except Exception as exc:
+        logger.warning("mcp_court_decision_statistics_unavailable reason=%s", exc.__class__.__name__)
+        return {
+            "status": "unavailable",
+            "collector_status": "unavailable",
+            "total_decisions": 0,
+            "published_decisions": 0,
+            "total_versions": 0,
+            "last_imported_decision": None,
+            "last_imported_decision_id": None,
+            "last_imported_source_guid": None,
+            "last_imported_at": None,
+            "last_imported_court_name": None,
+            "last_imported_court_type": None,
+            "last_imported_issue_date": None,
+            "last_imported_ecli": None,
+            "last_imported_file_number": None,
+            "collector_last_processed_at": None,
+            "collector_last_source_guid": None,
+        }
+    return {
+        "status": "ok",
+        "collector_status": stats.collector_status,
+        "total_decisions": stats.total_decisions,
+        "published_decisions": stats.published_decisions,
+        "total_versions": stats.total_versions,
+        "last_imported_decision": stats.last_imported_source_guid or stats.last_imported_decision_id or None,
+        "last_imported_decision_id": stats.last_imported_decision_id or None,
+        "last_imported_source_guid": stats.last_imported_source_guid or None,
+        "last_imported_at": stats.last_imported_at or None,
+        "last_imported_court_name": stats.last_imported_court_name or None,
+        "last_imported_court_type": stats.last_imported_court_type or None,
+        "last_imported_issue_date": stats.last_imported_issue_date or None,
+        "last_imported_ecli": stats.last_imported_ecli or None,
+        "last_imported_file_number": stats.last_imported_file_number or None,
+        "collector_last_processed_at": stats.collector_last_processed_at or None,
+        "collector_last_source_guid": stats.collector_last_source_guid or None,
+    }
+
+
 def _mcp_tools() -> list[dict[str, Any]]:
     return [
         {
             "name": "getVersion",
-            "description": "Public version information for the mobile, system, API, and web apps.",
+            "description": (
+                "Public version information for the mobile, system, API, and web apps, "
+                "plus court-decision collector status and latest imported decision metadata."
+            ),
             "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
         },
         {
             "name": "getStatistics",
-            "description": "Public laws collector processing statistics.",
+            "description": (
+                "Public laws collector and court-decision collector processing statistics, including totals and "
+                "latest imported source identifiers."
+            ),
             "inputSchema": {
                 "type": "object",
                 "properties": {"country_code": {"type": "string", "default": "SK"}},
@@ -2118,12 +2187,15 @@ def _tool_result_summary(*, tool_name: str, result: Any) -> str:
     if not isinstance(result, dict):
         return f"type={type(result).__name__}"
     if tool_name == "getVersion":
-        return "fields=api_version,system_version,mobile_app_version,web_app_version"
+        court_decisions = result.get("court_decision_collector")
+        court_status = court_decisions.get("status") if isinstance(court_decisions, dict) else "missing"
+        return f"fields=api_version,system_version,mobile_app_version,web_app_version court_status={court_status}"
     if tool_name == "getStatistics":
         return (
             f"country_code={result.get('country_code')} "
             f"processed_laws={result.get('processed_laws')} "
-            f"last_processed_law={result.get('last_processed_law')}"
+            f"last_processed_law={result.get('last_processed_law')} "
+            f"total_court_decisions={result.get('total_court_decisions')}"
         )
     if tool_name == "searchLaws":
         results = result.get("results")

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260486"
+version = "1.0.260487"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_mcp_api.py
+++ b/api/aijuristiction-api/tests/test_mcp_api.py
@@ -12,6 +12,7 @@ from urllib.parse import parse_qs, urlparse
 from fastapi.testclient import TestClient
 
 from app.main import app as api_app
+from app import mcp_api
 from app.mcp_main import app as mcp_app
 from app.mcp_main import _redact_header_value
 from app.mcp_main import _redact_payload
@@ -138,12 +139,38 @@ def test_mcp_public_tools_and_authenticated_law_search(monkeypatch, tmp_path: Pa
     _configure_env(monkeypatch, tmp_path)
     _create_laws_db(tmp_path / "laws.sqlite3")
     mcp_key = _create_mcp_key(tmp_path)
+    court_stats = {
+        "status": "ok",
+        "collector_status": "running",
+        "total_decisions": 2,
+        "published_decisions": 2,
+        "total_versions": 3,
+        "last_imported_decision": "fixture-sk-decision-2",
+        "last_imported_decision_id": "decision-2",
+        "last_imported_source_guid": "fixture-sk-decision-2",
+        "last_imported_at": "2026-06-30T10:00:00+00:00",
+        "last_imported_court_name": "Okresny sud Zilina",
+        "last_imported_court_type": "Okresny sud",
+        "last_imported_issue_date": "2026-06-29",
+        "last_imported_ecli": "ECLI:SK:OSZA:2026:2",
+        "last_imported_file_number": "12C/34/2026",
+        "collector_last_processed_at": "2026-06-30T10:00:00+00:00",
+        "collector_last_source_guid": "fixture-sk-decision-2",
+    }
+    monkeypatch.setattr(mcp_api, "_court_decision_statistics", lambda: court_stats)
 
     version_response = _mcp_call("getVersion")
     assert version_response.status_code == 200
     version_payload = _tool_payload(version_response)
     assert version_payload["api_version"]
     assert version_payload["mcp_server_version"] == version_payload["api_version"]
+    assert version_payload["court_decision_collector_version"]
+    assert version_payload["court_decision_collector"] == {
+        "version": version_payload["court_decision_collector_version"],
+        "status": "running",
+        "last_imported_decision": "fixture-sk-decision-2",
+        "last_imported_at": "2026-06-30T10:00:00+00:00",
+    }
 
     statistics_response = _mcp_call("getStatistics")
     assert statistics_response.status_code == 200
@@ -151,6 +178,12 @@ def test_mcp_public_tools_and_authenticated_law_search(monkeypatch, tmp_path: Pa
     assert statistics["processed_laws"] == 1
     assert statistics["last_processed_law"] == "1/1993"
     assert statistics["last_processed_day"] == "2026-06-01T12:00:00Z"
+    assert statistics["court_decision_collector_version"] == version_payload["court_decision_collector_version"]
+    assert statistics["total_court_decisions"] == 2
+    assert statistics["last_imported_decision"] == "fixture-sk-decision-2"
+    assert statistics["last_imported_decision_at"] == "2026-06-30T10:00:00+00:00"
+    assert statistics["court_decisions"]["published_decisions"] == 2
+    assert statistics["court_decisions"]["last_imported_file_number"] == "12C/34/2026"
 
     unauthenticated_search = _mcp_call("searchLaws", {"query": "civil"})
     assert unauthenticated_search.status_code == 200

--- a/docs/COURT_DECISION_COLLECTOR.md
+++ b/docs/COURT_DECISION_COLLECTOR.md
@@ -82,6 +82,8 @@ $env:COURT_DECISIONS_IMPORT_LIMIT="5"
 
 The MCP server exposes:
 
+- `getVersion()` includes court-decision collector version, status, latest imported decision/source GUID, and latest import time.
+- `getStatistics(country_code)` includes court-decision collector version, total court decisions, published decisions, total versions, latest imported decision/source GUID, latest import time, court metadata, ECLI/file number, issue date, and collector cursor status.
 - `searchCourtDecisions(query, limit)` for pseudonymized metadata/snippet search.
 - `getCourtDecision(decision_id, outputMode)` where `outputMode=public` is the default and returns pseudonymized text.
 

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -202,8 +202,8 @@ Client documentation:
 
 These tools do not require an MCP API key:
 
-- `getVersion`: returns API, system/core, mobile app, and web app versions.
-- `getStatistics`: returns processed laws count, last processed law, last processed day, and collector details.
+- `getVersion`: returns API, system/core, mobile app, web app versions, court-decision collector version, and court-decision collector status with latest imported decision metadata.
+- `getStatistics`: returns processed laws count, last processed law, last processed day, laws collector details, court-decision collector version, and court-decision statistics such as total decisions, published decisions, total versions, last imported decision/source GUID, last import time, court, court type, ECLI, file number, issue date, and collector cursor status.
 
 ## Protected Tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aijurisdictionagents"
-version = "1.0.260406"
+version = "1.0.260407"
 description = "Multi-agent legal discussion scaffold."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260406"
+__version__ = "1.0.260407"

--- a/src/services/court_decision_collector/postgres_store.py
+++ b/src/services/court_decision_collector/postgres_store.py
@@ -27,6 +27,24 @@ class CourtDecisionCollectorStatus:
     status: str
 
 
+@dataclass(frozen=True)
+class CourtDecisionStatistics:
+    total_decisions: int
+    published_decisions: int
+    total_versions: int
+    last_imported_decision_id: str
+    last_imported_source_guid: str
+    last_imported_at: str
+    last_imported_court_name: str
+    last_imported_court_type: str
+    last_imported_issue_date: str
+    last_imported_ecli: str
+    last_imported_file_number: str
+    collector_last_processed_at: str
+    collector_last_source_guid: str
+    collector_status: str
+
+
 class PostgresCourtDecisionStore:
     def __init__(self, *, connection_uri: str, embedding_dimensions: int = 32) -> None:
         self.connection_uri = connection_uri
@@ -320,6 +338,45 @@ class PostgresCourtDecisionStore:
 
     def status(self) -> CourtDecisionCollectorStatus:
         return self.get_import_state(source_system="infosud", cursor_kind="latest")
+
+    def statistics(self) -> CourtDecisionStatistics:
+        status = self.status()
+        with self._connect() as conn:
+            totals = conn.execute(
+                """
+                SELECT
+                    COUNT(*) AS total_decisions,
+                    COALESCE(SUM(CASE WHEN current_status = 'published' THEN 1 ELSE 0 END), 0)
+                        AS published_decisions
+                FROM court_decision_documents
+                """
+            ).fetchone()
+            versions = conn.execute("SELECT COUNT(*) AS total_versions FROM court_decision_versions").fetchone()
+            latest = conn.execute(
+                """
+                SELECT decision_id, source_guid, court_name, court_type, issue_date, ecli,
+                       file_number, last_stored_at
+                FROM court_decision_documents
+                ORDER BY last_stored_at DESC, updated_at DESC
+                LIMIT 1
+                """
+            ).fetchone()
+        return CourtDecisionStatistics(
+            total_decisions=int(totals["total_decisions"] if totals else 0),
+            published_decisions=int(totals["published_decisions"] if totals else 0),
+            total_versions=int(versions["total_versions"] if versions else 0),
+            last_imported_decision_id=str(latest["decision_id"] if latest else ""),
+            last_imported_source_guid=str(latest["source_guid"] if latest else ""),
+            last_imported_at=str(latest["last_stored_at"] if latest else ""),
+            last_imported_court_name=str(latest["court_name"] if latest else ""),
+            last_imported_court_type=str(latest["court_type"] if latest else ""),
+            last_imported_issue_date=str(latest["issue_date"] if latest else ""),
+            last_imported_ecli=str(latest["ecli"] if latest else ""),
+            last_imported_file_number=str(latest["file_number"] if latest else ""),
+            collector_last_processed_at=status.last_processed_at,
+            collector_last_source_guid=status.last_source_guid,
+            collector_status=status.status,
+        )
 
     def _record_event(
         self,


### PR DESCRIPTION
## Summary
- Add court-decision collector version and latest import metadata to MCP getVersion
- Add court-decision totals, latest imported decision, and collector cursor status to MCP getStatistics
- Add store-level court-decision statistics query and update MCP docs/tests

## Validation
- python -m py_compile api/aijuristiction-api/app/mcp_api.py src/services/court_decision_collector/postgres_store.py api/aijuristiction-api/tests/test_mcp_api.py
- git diff --check

## Validation caveat
- scripts/validate_api.ps1 and pytest could not run locally in this worktree because no usable conda/python environment exists; micromamba env creation failed on certificate revocation checks against conda-forge.