### PR TITLE
Fix court decision collector deploy permissions

### DIFF
--- a/Deployment/server/deploy_jurisdigta_prod.sh
+++ b/Deployment/server/deploy_jurisdigta_prod.sh
@@ -542,10 +542,28 @@ build_laws_collector() {
   docker build -t jurisdigta-laws-collector:local -f src/services/laws_collector/Dockerfile .
 }
 
+prepare_court_decision_runtime_paths() {
+  local runtime_uid
+  local runtime_gid
+  local log_file="$DEPLOY_ROOT/runs/logs/court-decision-collector.log"
+  local storage_dir="$DEPLOY_ROOT/runs/storage/court-decision-collector"
+
+  runtime_uid="$(docker run --rm --entrypoint id aijuristiction-api:local -u)"
+  runtime_gid="$(docker run --rm --entrypoint id aijuristiction-api:local -g)"
+
+  mkdir -p "$storage_dir/files/sk" "$(dirname "$log_file")"
+  touch "$log_file"
+  sudo chown "$runtime_uid:$runtime_gid" "$log_file"
+  sudo chmod 664 "$log_file"
+  sudo chown -R "$runtime_uid:$runtime_gid" "$storage_dir"
+  sudo chmod -R u+rwX,g+rwX "$storage_dir"
+}
+
 start_court_decision_collector() {
   log "starting court decision collector container"
   local court_decisions_db_cloud
   court_decisions_db_cloud="$(postgres_url "postgres" "$COURT_DECISIONS_DATABASE_NAME")"
+  prepare_court_decision_runtime_paths
   docker rm -f jurisdigta-court-decision-collector >/dev/null 2>&1 || true
   docker run -d \
     --name jurisdigta-court-decision-collector \

--- a/docs/manual_infrastucture_setup.md
+++ b/docs/manual_infrastucture_setup.md
@@ -397,6 +397,7 @@ The self-managed production deployment script performs the Ollama install, priva
 - Public DNS/TLS values may include `jurisdigta.eu`, `www.jurisdigta.eu`, `api.jurisdigta.eu`, `web.jurisdigta.eu`, `agent.jurisdigta.eu`, `services.jurisdigta.eu`, and `admin.jurisdigta.eu`.
 - Self-managed court-decision collector default: container `jurisdigta-court-decision-collector`, database `court_decisions_sk`, Docker restart policy `unless-stopped`, and log path `/srv/jurisdigta/runs/logs/court-decision-collector.log`.
 - The self-managed deploy script creates/applies the `court_decisions_sk` schema, injects `COURT_DECISIONS_DB_CLOUD` into API/MCP, and starts the court-decision collector with `python -m services.court_decision_collector --run-service`.
+- Before starting the collector, the self-managed deploy script creates `/srv/jurisdigta/runs/logs/court-decision-collector.log` and grants the API image runtime user ownership of that file and `/srv/jurisdigta/runs/storage/court-decision-collector/`. Keep the shared `/srv/jurisdigta/runs/logs/` directory owned by the deploy user so host cron jobs can continue writing their own logs.
 - Self-managed laws collector default: `LAWS_COLLECTOR_RUN_MODE=continuous`, container `jurisdigta-laws-collector`, `LAWS_WORKER_POLL_SECONDS=3600`, and Docker restart policy `unless-stopped`.
 - Legacy scheduled laws collector wrapper path: `/srv/jurisdigta/ops/run_laws_collector_daily.sh`.
 - Legacy scheduled laws collector log path: `/srv/jurisdigta/runs/logs/laws-collector-daily-latest.log`.


### PR DESCRIPTION
## Summary
- prepare court-decision collector log/storage ownership before starting the prod container
- document the runtime ownership expectation in the manual infrastructure setup

## Validation
- \C:\\Program Files\\Git\\bin\\bash.exe\ \-n Deployment/server/deploy_jurisdigta_prod.sh\
- \git diff --check\
- live prod collector restarted after equivalent ownership fix and imported court decisions