### PR TITLE
Fix MCP court decision search timeouts

### DIFF
--- a/api/aijuristiction-api/app/mcp_api.py
+++ b/api/aijuristiction-api/app/mcp_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextvars import ContextVar
 from dataclasses import dataclass
 import base64
 import hashlib
@@ -60,7 +61,11 @@ _DEFAULT_ALLOWED_REDIRECT_HOSTS = ("chatgpt.com", "chat.openai.com", "claude.ai"
 _MCP_OTP_VERIFICATION_PURPOSE = "mcp_access"
 _DEFAULT_LAW_TEXT_MAX_CHARS = 20_000
 _MAX_LAW_TEXT_CHARS = 100_000
+_COURT_DECISION_MCP_SEARCH_TIMEOUT_MS = 8_000
+_COURT_DECISION_MCP_CONNECT_TIMEOUT_SECONDS = 3
 logger = logging.getLogger("aijuristiction-api.mcp")
+_CURRENT_MCP_REQUEST_ID: ContextVar[str | None] = ContextVar("current_mcp_request_id", default=None)
+_CURRENT_MCP_CORRELATION_ID: ContextVar[str | None] = ContextVar("current_mcp_correlation_id", default=None)
 _MCP_SUPPORTED_LOCALES = {"en", "sk"}
 _MCP_TEXT: dict[str, dict[str, str]] = {
     "en": {
@@ -262,21 +267,27 @@ async def mcp_json_rpc(
             headers={"WWW-Authenticate": _www_authenticate_header(request)},
         )
     store = get_user_store() if payload_requires_auth else None
-    response = _handle_json_rpc(
-        payload=payload,
-        authorization=authorization,
-        x_mcp_api_key=x_mcp_api_key,
-        store=store,
-    )
-    duration_ms = int((time.perf_counter() - started_at) * 1000)
-    logger.info(
-        "mcp_json_rpc_completed request_id=%s correlation_id=%s status_code=%d duration_ms=%d",
-        request_id,
-        correlation_id,
-        response.status_code,
-        duration_ms,
-    )
-    return response
+    request_id_token = _CURRENT_MCP_REQUEST_ID.set(str(request_id) if request_id else None)
+    correlation_id_token = _CURRENT_MCP_CORRELATION_ID.set(str(correlation_id) if correlation_id else None)
+    try:
+        response = _handle_json_rpc(
+            payload=payload,
+            authorization=authorization,
+            x_mcp_api_key=x_mcp_api_key,
+            store=store,
+        )
+        duration_ms = int((time.perf_counter() - started_at) * 1000)
+        logger.info(
+            "mcp_json_rpc_completed request_id=%s correlation_id=%s status_code=%d duration_ms=%d",
+            request_id,
+            correlation_id,
+            response.status_code,
+            duration_ms,
+        )
+        return response
+    finally:
+        _CURRENT_MCP_REQUEST_ID.reset(request_id_token)
+        _CURRENT_MCP_CORRELATION_ID.reset(correlation_id_token)
 
 
 @router.get("/login", response_class=HTMLResponse)
@@ -1407,28 +1418,73 @@ def _tool_search_court_decisions(arguments: dict[str, Any]) -> dict[str, Any]:
     if len(query) < 2:
         raise HTTPException(status_code=400, detail="query must contain at least 2 characters")
     limit = _bounded_int(arguments.get("limit"), default=10, minimum=1, maximum=50)
-    logger.info("mcp_tool_search_court_decisions_query query_length=%d limit=%d", len(query), limit)
-    store = _court_decision_store()
-    results = [
-        {
-            "decision_id": item.decision_id,
-            "version_id": item.version_id,
-            "source_guid": item.source_guid,
-            "court_name": item.court_name,
-            "court_type": item.court_type,
-            "file_number": item.file_number,
-            "case_number": item.case_number,
-            "ecli": item.ecli,
-            "issue_date": item.issue_date,
-            "source_url": item.source_url,
-            "snippet": item.snippet,
-            "score": item.score,
-            "output_mode": "public",
-        }
-        for item in store.search(query=query, limit=limit)
-    ]
-    logger.info("mcp_tool_search_court_decisions_result result_count=%d", len(results))
-    return {"query": query, "results": results, "output_mode": "public"}
+    started_at = time.perf_counter()
+    logger.info(
+        "mcp_tool_search_court_decisions_query query_length=%d limit=%d timeout_ms=%d",
+        len(query),
+        limit,
+        _COURT_DECISION_MCP_SEARCH_TIMEOUT_MS,
+    )
+    try:
+        store = _court_decision_store(
+            initialize=False,
+            connect_timeout_seconds=_COURT_DECISION_MCP_CONNECT_TIMEOUT_SECONDS,
+            statement_timeout_ms=_COURT_DECISION_MCP_SEARCH_TIMEOUT_MS,
+        )
+        results = [
+            {
+                "decision_id": item.decision_id,
+                "version_id": item.version_id,
+                "source_guid": item.source_guid,
+                "court_name": item.court_name,
+                "court_type": item.court_type,
+                "file_number": item.file_number,
+                "case_number": item.case_number,
+                "ecli": item.ecli,
+                "issue_date": item.issue_date,
+                "source_url": item.source_url,
+                "snippet": item.snippet,
+                "score": item.score,
+                "output_mode": "public",
+            }
+            for item in store.search(query=query, limit=limit)
+        ]
+    except Exception as exc:
+        duration_ms = int((time.perf_counter() - started_at) * 1000)
+        error_kind = _court_decision_search_error_kind(exc)
+        logger.warning(
+            (
+                "mcp_tool_search_court_decisions_degraded query_length=%d limit=%d "
+                "duration_ms=%d error_kind=%s exception=%s request_id=%s correlation_id=%s"
+            ),
+            len(query),
+            limit,
+            duration_ms,
+            error_kind,
+            exc.__class__.__name__,
+            _CURRENT_MCP_REQUEST_ID.get(),
+            _CURRENT_MCP_CORRELATION_ID.get(),
+        )
+        return _court_decision_search_degraded_result(
+            query=query,
+            limit=limit,
+            duration_ms=duration_ms,
+            error_kind=error_kind,
+        )
+    duration_ms = int((time.perf_counter() - started_at) * 1000)
+    logger.info(
+        "mcp_tool_search_court_decisions_result result_count=%d duration_ms=%d",
+        len(results),
+        duration_ms,
+    )
+    return {
+        "query": query,
+        "results": results,
+        "output_mode": "public",
+        "status": "ok",
+        "duration_ms": duration_ms,
+        "timeout_ms": _COURT_DECISION_MCP_SEARCH_TIMEOUT_MS,
+    }
 
 
 def _tool_get_court_decision(arguments: dict[str, Any]) -> dict[str, Any]:
@@ -1565,14 +1621,25 @@ class _LawsQuerySession:
             logger.info("mcp_laws_db_session_closed")
 
 
-def _court_decision_store() -> Any:
+def _court_decision_store(
+    *,
+    initialize: bool = False,
+    connect_timeout_seconds: int | None = None,
+    statement_timeout_ms: int | None = None,
+) -> Any:
     from services.court_decision_collector.config import CourtDecisionCollectorConfig
     from services.court_decision_collector.postgres_store import PostgresCourtDecisionStore
 
     config = CourtDecisionCollectorConfig.from_env()
     config.validate()
-    store = PostgresCourtDecisionStore.from_config(config)
-    store.initialize()
+    store = PostgresCourtDecisionStore(
+        connection_uri=config.db_cloud,
+        embedding_dimensions=config.embedding_dimensions,
+        connect_timeout_seconds=connect_timeout_seconds,
+        statement_timeout_ms=statement_timeout_ms,
+    )
+    if initialize:
+        store.initialize()
     return store
 
 
@@ -1617,6 +1684,46 @@ def _court_decision_statistics() -> dict[str, Any]:
         "collector_last_processed_at": stats.collector_last_processed_at or None,
         "collector_last_source_guid": stats.collector_last_source_guid or None,
     }
+
+
+def _court_decision_search_degraded_result(
+    *,
+    query: str,
+    limit: int,
+    duration_ms: int,
+    error_kind: str,
+) -> dict[str, Any]:
+    message = (
+        "Court-decision search is temporarily unavailable or exceeded the server search budget. "
+        "Retry the same MCP call later or narrow the query."
+    )
+    return {
+        "query": query,
+        "results": [],
+        "output_mode": "public",
+        "status": "degraded",
+        "retryable": True,
+        "error": {
+            "code": "court_decision_search_timeout"
+            if error_kind == "timeout"
+            else "court_decision_search_unavailable",
+            "message": message,
+            "kind": error_kind,
+            "correlation_id": _CURRENT_MCP_CORRELATION_ID.get(),
+            "request_id": _CURRENT_MCP_REQUEST_ID.get(),
+        },
+        "limit": limit,
+        "duration_ms": duration_ms,
+        "timeout_ms": _COURT_DECISION_MCP_SEARCH_TIMEOUT_MS,
+    }
+
+
+def _court_decision_search_error_kind(exc: Exception) -> str:
+    exception_name = exc.__class__.__name__.lower()
+    message = str(exc).lower()
+    if isinstance(exc, TimeoutError) or "timeout" in exception_name or "timeout" in message:
+        return "timeout"
+    return "unavailable"
 
 
 def _mcp_tools() -> list[dict[str, Any]]:

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260487"
+version = "1.0.260488"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_mcp_api.py
+++ b/api/aijuristiction-api/tests/test_mcp_api.py
@@ -17,6 +17,7 @@ from app.mcp_main import app as mcp_app
 from app.mcp_main import _redact_header_value
 from app.mcp_main import _redact_payload
 from app.users.totp import current_totp_code
+from services.court_decision_collector.domain import CourtDecisionSearchResult
 
 AUTH_HEADERS = {"x-api-key": "aijuris"}
 api_client = TestClient(api_app)
@@ -215,6 +216,115 @@ def test_mcp_court_decision_tools_require_auth() -> None:
 
     unauthenticated_detail = _mcp_call("getCourtDecision", {"decision_id": "decision-1"})
     assert unauthenticated_detail.status_code == 401
+
+
+def test_mcp_search_court_decisions_returns_bounded_results_and_privacy_safe_logs(
+    monkeypatch,
+    tmp_path: Path,
+    caplog,
+) -> None:
+    _configure_env(monkeypatch, tmp_path)
+    mcp_key = _create_mcp_key(tmp_path)
+
+    class FakeCourtDecisionStore:
+        def search(self, *, query: str, limit: int) -> list[CourtDecisionSearchResult]:
+            assert query == "zobraz mi posledne sudne rozhodnutie ktore sa tykalo rozdelenia pozemku podla podielu"
+            assert limit == 1
+            return [
+                CourtDecisionSearchResult(
+                    decision_id="decision-1",
+                    version_id="version-1",
+                    source_guid="infosud-1",
+                    court_name="Okresny sud Bratislava I",
+                    court_type="Okresny sud",
+                    file_number="12C/34/2026",
+                    case_number="12C/34/2026",
+                    ecli="ECLI:SK:OSBA1:2026:1234567890.1",
+                    issue_date="2026-06-29",
+                    source_url="https://example.test/decision/1",
+                    snippet="Pseudonymizovane rozhodnutie o rozdeleni pozemku podla podielu.",
+                    score=0.91,
+                )
+            ]
+
+    def fake_court_decision_store(**kwargs: object) -> FakeCourtDecisionStore:
+        assert kwargs["initialize"] is False
+        assert kwargs["connect_timeout_seconds"] == 3
+        assert kwargs["statement_timeout_ms"] == 8000
+        return FakeCourtDecisionStore()
+
+    monkeypatch.setattr(mcp_api, "_court_decision_store", fake_court_decision_store)
+    caplog.set_level(logging.INFO, logger="aijuristiction-api.mcp")
+    secret_query = "zobraz mi posledne sudne rozhodnutie ktore sa tykalo rozdelenia pozemku podla podielu"
+
+    response = _mcp_call(
+        "searchCourtDecisions",
+        {"query": secret_query, "limit": 1},
+        headers={"authorization": f"Bearer {mcp_key}", "x-request-id": "court-search-request"},
+    )
+
+    assert response.status_code == 200
+    payload = _tool_payload(response)
+    assert payload["status"] == "ok"
+    assert payload["output_mode"] == "public"
+    assert payload["timeout_ms"] == 8000
+    assert payload["results"][0]["decision_id"] == "decision-1"
+    assert payload["results"][0]["issue_date"] == "2026-06-29"
+    mcp_log_messages = [
+        record.getMessage() for record in caplog.records if record.name == "aijuristiction-api.mcp"
+    ]
+    assert any("mcp_tool_search_court_decisions_result result_count=1" in message for message in mcp_log_messages)
+    joined_logs = "\n".join(mcp_log_messages)
+    assert secret_query not in joined_logs
+    assert "Pseudonymizovane rozhodnutie" not in joined_logs
+    assert mcp_key not in joined_logs
+
+
+def test_mcp_search_court_decisions_timeout_returns_structured_degraded_result(
+    monkeypatch,
+    tmp_path: Path,
+    caplog,
+) -> None:
+    _configure_env(monkeypatch, tmp_path)
+    mcp_key = _create_mcp_key(tmp_path)
+
+    class TimeoutCourtDecisionStore:
+        def search(self, *, query: str, limit: int) -> list[CourtDecisionSearchResult]:
+            raise TimeoutError("statement timeout")
+
+    monkeypatch.setattr(mcp_api, "_court_decision_store", lambda **_kwargs: TimeoutCourtDecisionStore())
+    caplog.set_level(logging.INFO, logger="aijuristiction-api.mcp")
+
+    response = _mcp_call(
+        "searchCourtDecisions",
+        {
+            "query": "zobraz mi posledne sudne rozhodnutie ktore sa tykalo rozdelenia pozemku podla podielu",
+            "limit": 5,
+        },
+        headers={
+            "authorization": f"Bearer {mcp_key}",
+            "x-request-id": "court-timeout-request",
+            "x-correlation-id": "court-timeout-correlation",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = _tool_payload(response)
+    assert payload["status"] == "degraded"
+    assert payload["retryable"] is True
+    assert payload["results"] == []
+    assert payload["error"]["code"] == "court_decision_search_timeout"
+    assert payload["error"]["kind"] == "timeout"
+    assert payload["error"]["correlation_id"] == "court-timeout-correlation"
+    assert payload["error"]["request_id"] == "court-timeout-request"
+    assert payload["timeout_ms"] == 8000
+    assert payload["limit"] == 5
+    assert any(
+        "mcp_tool_search_court_decisions_degraded" in record.getMessage()
+        and "error_kind=timeout" in record.getMessage()
+        for record in caplog.records
+        if record.name == "aijuristiction-api.mcp"
+    )
 
 
 def test_mcp_search_prefers_base_law_over_newer_amendment(monkeypatch, tmp_path: Path) -> None:

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -211,7 +211,7 @@ These tools require an MCP API key:
 
 - `searchLaws`: searches imported laws by title, identifier, and lawyer-facing title.
 - `getLawText`: returns bounded latest imported text for a law document id. For large codes, pass `section_number` or `section_start`/`section_end` to retrieve only the relevant sections; use `offset` and `max_chars` when pagination is needed.
-- `searchCourtDecisions`: searches the dedicated court-decision vector store and returns pseudonymized public snippets with court/date/ECLI/file-number metadata.
+- `searchCourtDecisions`: searches the dedicated court-decision vector store and returns pseudonymized public snippets with court/date/ECLI/file-number metadata. MCP court-decision search is bounded by a server-side PostgreSQL connect timeout and statement timeout so slow database calls return a structured `status=degraded`, `retryable=true` payload with request/correlation identifiers instead of hanging until the MCP client times out. Logs record query length, limit, duration, error kind, request ID, and correlation ID, but not the raw query, credentials, tokens, snippets, or court-decision text.
 - `getCourtDecision`: returns one imported court decision. `outputMode=public` is the default and returns pseudonymized text. `outputMode=internal_raw` is blocked unless `COURT_DECISIONS_ALLOW_INTERNAL_RAW_MCP=true` is enabled for a controlled internal runtime; it must not be used for normal external model prompts or UI display.
 
 ## Minimal JSON-RPC Example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aijurisdictionagents"
-version = "1.0.260407"
+version = "1.0.260408"
 description = "Multi-agent legal discussion scaffold."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260407"
+__version__ = "1.0.260408"

--- a/src/services/court_decision_collector/postgres_store.py
+++ b/src/services/court_decision_collector/postgres_store.py
@@ -46,9 +46,18 @@ class CourtDecisionStatistics:
 
 
 class PostgresCourtDecisionStore:
-    def __init__(self, *, connection_uri: str, embedding_dimensions: int = 32) -> None:
+    def __init__(
+        self,
+        *,
+        connection_uri: str,
+        embedding_dimensions: int = 32,
+        connect_timeout_seconds: int | None = None,
+        statement_timeout_ms: int | None = None,
+    ) -> None:
         self.connection_uri = connection_uri
         self.embedding_dimensions = embedding_dimensions
+        self.connect_timeout_seconds = connect_timeout_seconds
+        self.statement_timeout_ms = statement_timeout_ms
 
     @classmethod
     def from_config(cls, config: CourtDecisionCollectorConfig) -> "PostgresCourtDecisionStore":
@@ -196,12 +205,32 @@ class PostgresCourtDecisionStore:
         query_vector = parse_embedding_vector(
             build_embedding_vector(query, dimensions=self.embedding_dimensions)
         )
+        candidate_limit = max(limit * 10, 100)
+        pattern = f"%{query.lower()}%"
         with self._connect() as conn:
             rows = conn.execute(
                 """
+                WITH search_query AS (
+                    SELECT websearch_to_tsquery('simple', %(query)s) AS tsq
+                )
                 SELECT d.decision_id, d.source_guid, d.court_name, d.court_type,
                        d.file_number, d.case_number, d.ecli, d.issue_date, d.source_url,
-                       v.version_id, v.pseudonymized_text, v.embedding_vector_json
+                       v.version_id, v.pseudonymized_text, v.embedding_vector_json,
+                       ts_rank_cd(
+                           to_tsvector(
+                               'simple',
+                               concat_ws(
+                                   ' ',
+                                   d.court_name,
+                                   d.court_type,
+                                   d.file_number,
+                                   d.case_number,
+                                   d.ecli,
+                                   v.pseudonymized_text
+                               )
+                           ),
+                           search_query.tsq
+                       ) AS lexical_rank
                 FROM court_decision_documents AS d
                 JOIN LATERAL (
                     SELECT version_id, pseudonymized_text, embedding_vector_json, stored_at
@@ -210,10 +239,32 @@ class PostgresCourtDecisionStore:
                     ORDER BY stored_at DESC
                     LIMIT 1
                 ) AS v ON true
+                CROSS JOIN search_query
                 WHERE d.current_status = 'published'
-                ORDER BY d.issue_date DESC NULLS LAST, d.updated_at DESC
-                LIMIT 500
-                """
+                  AND (
+                      to_tsvector(
+                          'simple',
+                          concat_ws(
+                              ' ',
+                              d.court_name,
+                              d.court_type,
+                              d.file_number,
+                              d.case_number,
+                              d.ecli,
+                              v.pseudonymized_text
+                          )
+                      ) @@ search_query.tsq
+                      OR LOWER(d.court_name) LIKE %(pattern)s
+                      OR LOWER(d.court_type) LIKE %(pattern)s
+                      OR LOWER(d.file_number) LIKE %(pattern)s
+                      OR LOWER(d.case_number) LIKE %(pattern)s
+                      OR LOWER(d.ecli) LIKE %(pattern)s
+                      OR LOWER(v.pseudonymized_text) LIKE %(pattern)s
+                  )
+                ORDER BY lexical_rank DESC, d.issue_date DESC NULLS LAST, d.updated_at DESC
+                LIMIT %(candidate_limit)s
+                """,
+                {"query": query, "pattern": pattern, "candidate_limit": candidate_limit},
             ).fetchall()
         scored: list[CourtDecisionSearchResult] = []
         for row in rows:
@@ -405,7 +456,12 @@ class PostgresCourtDecisionStore:
         )
 
     def _connect(self) -> psycopg.Connection[dict[str, object]]:
-        return psycopg.connect(self.connection_uri, row_factory=dict_row)
+        kwargs: dict[str, object] = {"row_factory": dict_row}
+        if self.connect_timeout_seconds is not None:
+            kwargs["connect_timeout"] = self.connect_timeout_seconds
+        if self.statement_timeout_ms is not None:
+            kwargs["options"] = f"-c statement_timeout={self.statement_timeout_ms}"
+        return psycopg.connect(self.connection_uri, **kwargs)
 
 
 def _document_params(record: CourtDecisionRecord, *, decision_id: str, now: str) -> dict[str, object]:
@@ -535,5 +591,11 @@ _SCHEMA_SQL = (
     """
     CREATE INDEX IF NOT EXISTS idx_court_decision_documents_issue_date
     ON court_decision_documents(issue_date)
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_court_decision_search_text
+    ON court_decision_versions USING GIN (
+        to_tsvector('simple', pseudonymized_text)
+    )
     """,
 )


### PR DESCRIPTION
## Summary
- Bound MCP `searchCourtDecisions` with PostgreSQL connect/statement timeouts and structured degraded responses.
- Move court-decision candidate filtering into PostgreSQL and avoid schema initialization on MCP read calls.
- Add regression coverage for the Slovak land-division query, timeout/degraded response shape, and privacy-safe logs.
- Document the MCP court-decision timeout behavior and bump API/core revision versions.

## Validation
- `scripts/validate_api.ps1` with bundled Python first on PATH: passed
- `python -m ruff check app tests`: passed
- `python -m mypy app`: passed
- `python -m pytest api/aijuristiction-api/tests/test_mcp_api.py tests/test_court_decision_collector.py -q`: passed

## Note
Full `api/aijuristiction-api/tests` under bundled Python stops in unrelated `test_ai_model_routing.py::test_expired_paid_subscription_routes_as_free_local_model` with `OPENSSL_Uplink ... no OPENSSL_Applink`. The branch conda env setup also hit Windows denial while creating `python.exe`, so targeted API/MCP validation used the bundled runtime with editable installs from this worktree.

Fixes #445