### PR TITLE
Fix Claude web MCP OAuth discovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,6 +149,7 @@ JURISDIGTA_ADMIN_EMAILS=mmaideveloper@gmail.com
 # Hours to skip a repeat email OTP after the same MCP user successfully verifies one.
 # Set to 0 to require OTP on every MCP login/OAuth authorization.
 MCP_OTP_REUSE_WINDOW_HOURS=24
+MCP_OAUTH_AUTHORIZATION_RESPONSE_ISS=true
 # Dedicated local MCP server port and optional browser origins.
 # MCP_PORT=8070
 # MCP_CORS_ALLOW_ORIGINS=https://mcp.jurisdigta.eu

--- a/api/aijuristiction-api/app/mcp_api.py
+++ b/api/aijuristiction-api/app/mcp_api.py
@@ -304,8 +304,6 @@ def mcp_sign_up_page(request: Request) -> HTMLResponse:
 
 @oauth_router.get("/.well-known/oauth-protected-resource")
 def oauth_protected_resource_metadata(request: Request) -> dict[str, Any]:
-    if _should_hide_oauth_metadata_for_claude_web(request):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="OAuth metadata is not advertised")
     base_url = _base_url(request)
     resource = _resource_url(request)
     return {
@@ -328,8 +326,6 @@ def oauth_mcp_protected_resource_metadata(request: Request) -> dict[str, Any]:
 @oauth_router.get("/.well-known/oauth-authorization-server/MCP")
 @oauth_router.get("/.well-known/oauth-authorization-server/mcp")
 def oauth_authorization_server_metadata(request: Request) -> dict[str, Any]:
-    if _should_hide_oauth_metadata_for_claude_web(request):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="OAuth metadata is not advertised")
     base_url = _base_url(request)
     return {
         "issuer": base_url,
@@ -351,9 +347,6 @@ def oauth_dynamic_client_registration(
     request: Request,
     metadata: dict[str, Any] = Body(default_factory=dict),
 ) -> dict[str, Any]:
-    if _should_hide_oauth_metadata_for_claude_web(request):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="OAuth metadata is not advertised")
-
     redirect_uris = _registration_string_list(metadata.get("redirect_uris"))
     if not redirect_uris:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="redirect_uris is required")
@@ -2122,26 +2115,9 @@ def _should_challenge_oauth_probe(*, request: Request, payload: Any) -> bool:
     return bool(methods & {"initialize", "tools/list", "resources/list", "resources/templates/list", "prompts/list"})
 
 
-def _should_hide_oauth_metadata_for_claude_web(request: Request) -> bool:
-    enabled = os.getenv("MCP_CLAUDE_WEB_PUBLIC_DISCOVERY", "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
-    if not enabled:
-        return False
-    user_agent = request.headers.get("user-agent", "").lower()
-    return "python-httpx" in user_agent
-
-
 def _oauth_authorization_response_iss_enabled() -> bool:
-    return os.getenv("MCP_OAUTH_AUTHORIZATION_RESPONSE_ISS", "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
+    raw_value = os.getenv("MCP_OAUTH_AUTHORIZATION_RESPONSE_ISS", "true").strip().lower()
+    return raw_value not in {"0", "false", "no", "off"}
 
 
 def _first_payload_id(payload: Any) -> Any:

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260489"
+version = "1.0.260490"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_mcp_api.py
+++ b/api/aijuristiction-api/tests/test_mcp_api.py
@@ -893,13 +893,14 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
         headers={"user-agent": "python-httpx/0.28.1"},
     )
     assert claude_web_authorization_metadata.status_code == 200
+    assert claude_web_authorization_metadata.json()["authorization_response_iss_parameter_supported"] is True
     monkeypatch.setenv("MCP_CLAUDE_WEB_PUBLIC_DISCOVERY", "true")
-    hidden_claude_web_authorization_metadata = mcp_client.get(
+    claude_web_authorization_metadata_with_legacy_flag = mcp_client.get(
         "/.well-known/oauth-authorization-server",
         headers={"user-agent": "python-httpx/0.28.1"},
     )
-    assert hidden_claude_web_authorization_metadata.status_code == 404
-    hidden_claude_web_registration = mcp_client.post(
+    assert claude_web_authorization_metadata_with_legacy_flag.status_code == 200
+    claude_web_registration_with_legacy_flag = mcp_client.post(
         "/oauth/register",
         headers={"user-agent": "python-httpx/0.28.1"},
         json={
@@ -911,7 +912,7 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
             "scope": "mcp:laws offline_access",
         },
     )
-    assert hidden_claude_web_registration.status_code == 404
+    assert claude_web_registration_with_legacy_flag.status_code == 201
     monkeypatch.delenv("MCP_CLAUDE_WEB_PUBLIC_DISCOVERY")
     authorization_metadata = mcp_client.get("/.well-known/oauth-authorization-server")
     assert authorization_metadata.status_code == 200
@@ -919,7 +920,7 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
     assert authorization_metadata.json()["grant_types_supported"] == ["authorization_code", "refresh_token"]
     assert authorization_metadata.json()["scopes_supported"] == ["mcp:laws", "offline_access"]
     assert authorization_metadata.json()["registration_endpoint"].endswith("/oauth/register")
-    assert authorization_metadata.json()["authorization_response_iss_parameter_supported"] is False
+    assert authorization_metadata.json()["authorization_response_iss_parameter_supported"] is True
     assert authorization_metadata.json()["protected_resources"] == ["https://mcp.jurisdigta.eu/MCP"]
 
     registration_response = mcp_client.post(
@@ -1012,7 +1013,7 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
     assert location.startswith("https://client.example/callback?")
     callback_query = parse_qs(urlparse(location).query)
     assert callback_query["state"] == ["abc"]
-    assert "iss" not in callback_query
+    assert callback_query["iss"] == ["https://mcp.jurisdigta.eu"]
     authorization_code = callback_query["code"][0]
 
     token_response = mcp_client.post(
@@ -1107,7 +1108,7 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
 def test_oauth_authorization_response_issuer_can_be_enabled(monkeypatch, tmp_path: Path) -> None:
     _configure_env(monkeypatch, tmp_path)
     monkeypatch.setenv("LOCAL_AUTH_ACCEPT_ANY_CODE", "true")
-    monkeypatch.setenv("MCP_OAUTH_AUTHORIZATION_RESPONSE_ISS", "true")
+    monkeypatch.delenv("MCP_OAUTH_AUTHORIZATION_RESPONSE_ISS", raising=False)
     sign_up_response = api_client.post(
         "/v1/users/sign-up",
         headers=AUTH_HEADERS,

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -157,6 +157,7 @@ Required GitHub Environment secret:
 | --- | --- |
 | `AZURE_OPENAI_API_KEY` | Azure OpenAI key used by the API and document processor for chat completions and embeddings |
 | `MCP_API_JWT_SECRET` | Long random secret used to sign MCP OAuth/JWT bearer tokens for ChatGPT, Claude, VS Code, and other remote MCP clients |
+| `MCP_OAUTH_AUTHORIZATION_RESPONSE_ISS` | Optional issuer callback flag for strict OAuth clients; default `true`, keep enabled for Claude web custom connectors |
 | `AZURE_POSTGRES_ADMIN_PASSWORD` | PostgreSQL admin password |
 
 Optional and conditional GitHub Environment secrets:

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -76,6 +76,12 @@ Production settings:
 - `MCP_OAUTH_ALLOWED_REDIRECT_HOSTS=chatgpt.com,chat.openai.com,claude.ai`
 - `MCP_API_JWT_SECRET=<long-random-secret>`
 - `MCP_OTP_REUSE_WINDOW_HOURS=24`
+- `MCP_OAUTH_AUTHORIZATION_RESPONSE_ISS=true` by default; keep it enabled for Claude web custom connectors so the authorization callback includes `iss`.
+
+Do not hide OAuth discovery from Claude web custom connector probes. Claude web
+uses `python-httpx` while validating custom connectors and must receive the
+protected-resource metadata, authorization-server metadata, and dynamic client
+registration response before it can start the browser authorization flow.
 
 ## Authentication
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aijurisdictionagents"
-version = "1.0.260408"
+version = "1.0.260409"
 description = "Multi-agent legal discussion scaffold."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260408"
+__version__ = "1.0.260409"


### PR DESCRIPTION
## Summary
- stop hiding OAuth discovery and dynamic client registration from Claude web `python-httpx` probes
- advertise OAuth authorization response `iss` support by default and include it in callback tests
- document the Claude connector requirements and production env defaults

## Validation
- `python -m pytest api/aijuristiction-api/tests/test_mcp_api.py -q` (with ignored local `.env` temporarily hidden)
- `python -m ruff check app tests`
- `python -m mypy app`