### PR TITLE
Update production SSH host documentation

### DIFF
--- a/Deployment/manual-server-setup.md
+++ b/Deployment/manual-server-setup.md
@@ -7,7 +7,7 @@ For package installation, GitHub checkout, Docker/PostgreSQL preparation, API sm
 Current server target:
 
 - Host alias: `jurisdigta-server`
-- Hostname/IP: `192.168.1.50`
+- Hostname/IP: `192.168.1.25`
 - Server user: `jurisdigta-admin`
 - Client key path: `C:\Users\maton\.ssh\id_ed25519`
 - Public key USB filename: `jurisdigta-server-id_ed25519.pub`
@@ -49,7 +49,7 @@ jurisdigta-server
 Expected LAN address for this setup:
 
 ```text
-192.168.1.50
+192.168.1.25
 ```
 
 ## 2. Install Or Enable OpenSSH Server
@@ -88,7 +88,7 @@ LISTEN 0 4096 [::]:22
 From the Windows workstation, confirm TCP access:
 
 ```powershell
-Test-NetConnection -ComputerName 192.168.1.50 -Port 22
+Test-NetConnection -ComputerName 192.168.1.25 -Port 22
 ```
 
 Expected result:
@@ -199,7 +199,7 @@ Create or update `C:\Users\maton\.ssh\config` on the Windows workstation:
 
 ```sshconfig
 Host jurisdigta-server
-    HostName 192.168.1.50
+    HostName 192.168.1.25
     User jurisdigta-admin
     IdentityFile ~/.ssh/id_ed25519
     IdentitiesOnly yes
@@ -251,7 +251,7 @@ If `Test-NetConnection` fails but ping works:
 
 - Confirm `sudo systemctl status ssh --no-pager`.
 - Confirm `ss -tlnp | grep ':22'`.
-- Confirm no network or VLAN rule blocks traffic between the workstation and `192.168.1.50`.
+- Confirm no network or VLAN rule blocks traffic between the workstation and `192.168.1.25`.
 
 If SSH says `Host key verification failed`:
 
@@ -259,7 +259,7 @@ If SSH says `Host key verification failed`:
 - If the server was reinstalled, remove the old key with:
 
 ```powershell
-ssh-keygen -R 192.168.1.50
+ssh-keygen -R 192.168.1.25
 ssh-keygen -R jurisdigta-server
 ```
 

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -343,7 +343,7 @@ These are used by `.github/workflows/self_managed_prod_deploy.yml` to deploy API
 
 Before the SSH deployment job starts, the workflow runs a GitHub-hosted `e2e_gate` job with `npm ci`, Chromium installation, and `npm run test:e2e` from `frontend/aijurisdictionfronend`. The E2E tests use local Vite plus mocked API responses, so the `prod` environment does not need extra secrets for this gate. If any E2E test fails, the deploy job is skipped and production is not updated.
 
-The workflow must run on a repository self-hosted runner with labels `self-hosted`, `Linux`, `X64`, and `jurisdigta-prod`. Keep this runner on the trusted server or trusted private network that can reach `jurisdigta-server` over SSH. Do not run the production deployment from a GitHub-hosted runner when `JURISDIGTA_SSH_HOST` is a private LAN address such as `192.168.1.50`.
+The workflow must run on a repository self-hosted runner with labels `self-hosted`, `Linux`, `X64`, and `jurisdigta-prod`. Keep this runner on the trusted server or trusted private network that can reach `jurisdigta-server` over SSH. Do not run the production deployment from a GitHub-hosted runner when `JURISDIGTA_SSH_HOST` is a private LAN address such as `192.168.1.25`.
 
 The workflow does not store application runtime secrets in GitHub. Keep Azure OpenAI, PostgreSQL, SMTP, MCP JWT, and API secrets in the server-local file:
 
@@ -359,7 +359,7 @@ Required `prod` GitHub Environment variable:
 
 | Variable | Purpose |
 | --- | --- |
-| `JURISDIGTA_SSH_HOST` | SSH host or DNS name for `jurisdigta-server`; `192.168.1.50` is valid only when the self-hosted `jurisdigta-prod` runner can reach that private LAN address |
+| `JURISDIGTA_SSH_HOST` | SSH host or DNS name for `jurisdigta-server`; production currently uses `192.168.1.25`, which is valid only when the self-hosted `jurisdigta-prod` runner can reach that private LAN address |
 
 Optional `prod` GitHub Environment variables:
 

--- a/docs/manual_infrastucture_setup.md
+++ b/docs/manual_infrastucture_setup.md
@@ -164,7 +164,7 @@ Use Firebase Cloud Messaging directly.
 
 Related runbook: `Deployment/manual-server-setup.md`
 
-Purpose: prepare the Ubuntu server `jurisdigta-server` at `192.168.1.50` for SSH access from Codex using public-key authentication.
+Purpose: prepare the Ubuntu server `jurisdigta-server` at `192.168.1.25` for SSH access from Codex using public-key authentication.
 
 ### Provider And Owner
 
@@ -177,7 +177,7 @@ Purpose: prepare the Ubuntu server `jurisdigta-server` at `192.168.1.50` for SSH
 1. Install Ubuntu Server and create the non-root administrator user `jurisdigta-admin`.
 2. Install and enable OpenSSH Server with `sudo apt install openssh-server` and `sudo systemctl enable --now ssh`.
 3. Validate port `22` locally with `ss -tlnp | grep ':22'`.
-4. Validate workstation connectivity with `Test-NetConnection -ComputerName 192.168.1.50 -Port 22`.
+4. Validate workstation connectivity with `Test-NetConnection -ComputerName 192.168.1.25 -Port 22`.
 5. Generate an Ed25519 SSH key on the Codex workstation.
 6. Copy only the public key to a USB drive.
 7. Mount the USB partition on Ubuntu, avoiding `/boot/efi`.
@@ -190,7 +190,7 @@ Purpose: prepare the Ubuntu server `jurisdigta-server` at `192.168.1.50` for SSH
 - Private key: `C:\Users\maton\.ssh\id_ed25519`; keep local and never commit or copy to the server.
 - Public key: `C:\Users\maton\.ssh\id_ed25519.pub`; safe to copy into `authorized_keys`.
 - Server user: `jurisdigta-admin`.
-- Server host/IP: `192.168.1.50`.
+- Server host/IP: `192.168.1.25`.
 
 ### Validation Steps
 


### PR DESCRIPTION
## Summary
- update production SSH host documentation from 192.168.1.50 to 192.168.1.25
- align GitHub Environment runbook and manual server setup commands with current reachable host

## Validation
- GitHub prod Environment variable JURISDIGTA_SSH_HOST updated to 192.168.1.25
- Test-NetConnection 192.168.1.25:22 succeeded locally