### PR TITLE
Make lowercase MCP endpoint canonical

### DIFF
--- a/.github/workflows/self_managed_prod_deploy.yml
+++ b/.github/workflows/self_managed_prod_deploy.yml
@@ -194,7 +194,7 @@ jobs:
             echo "| Ref | ${{ inputs.repo_ref }} |"
             echo "| API | http://127.0.0.1:${JURISDIGTA_API_PORT}/health on server |"
             echo "| MCP | http://127.0.0.1:${JURISDIGTA_MCP_PORT}/health on server |"
-            echo "| Public MCP Claude smoke | ${JURISDIGTA_MCP_PUBLIC_BASE_URL}/MCP |"
+            echo "| Public MCP Claude smoke | ${JURISDIGTA_MCP_PUBLIC_BASE_URL}/mcp |"
             echo "| Web | http://127.0.0.1:${JURISDIGTA_WEB_PORT}/health on server |"
             echo "| Document engine | ${JURISDIGTA_DOCUMENT_ENGINE_ENABLED} |"
             echo "| Document engine API | http://127.0.0.1:${JURISDIGTA_DOCUMENT_ENGINE_API_PORT}/health on server |"

--- a/Deployment/local-dynamic-dns-domain-setup.md
+++ b/Deployment/local-dynamic-dns-domain-setup.md
@@ -167,7 +167,7 @@ On the Ubuntu server, confirm the services work locally before exposing them thr
 curl -fsS http://127.0.0.1:8080/health
 # Replace these ports with the actual local web, MCP, and admin ports.
 curl -I http://127.0.0.1:<web-port>
-curl -I http://127.0.0.1:8070/.well-known/oauth-protected-resource/MCP
+curl -I http://127.0.0.1:8070/.well-known/oauth-protected-resource/mcp
 curl -I http://127.0.0.1:<admin-port>
 ```
 

--- a/Deployment/self-managed-server-deployment.md
+++ b/Deployment/self-managed-server-deployment.md
@@ -467,7 +467,7 @@ Configure these Cloudflare Tunnel public hostnames:
 | Hostname | Tunnel service | Current server target | Notes |
 | --- | --- | --- | --- |
 | `api.jurisdigta.eu` | HTTP | `http://127.0.0.1:8080` | API container; validate with `/health`. |
-| `mcp.jurisdigta.eu` | HTTP | `http://127.0.0.1:8070` | Dedicated MCP service; metadata is under `/.well-known/oauth-protected-resource/MCP`. |
+| `mcp.jurisdigta.eu` | HTTP | `http://127.0.0.1:8070` | Dedicated MCP service; metadata is under `/.well-known/oauth-protected-resource/mcp`. |
 | `admin.jurisdigta.eu` | HTTP | `http://127.0.0.1:3000` | Grafana path is `/grafana/`; protect with Cloudflare Access. |
 | `web.jurisdigta.eu` | HTTP | `http://127.0.0.1:8090` after web deployment | Frontend web container `jurisdigta-web`; validate with `/health`. |
 | `agent.jurisdigta.eu` | HTTP | `http://127.0.0.1:8090` after web deployment | Authenticated assistant route `/app/assistant`; current production uses JurisDigta account login against the API users table. |
@@ -479,7 +479,7 @@ Minimal runnable validation examples:
 ```bash
 curl -fsS http://127.0.0.1:8080/health
 curl -fsS http://127.0.0.1:8070/health
-curl -I http://127.0.0.1:8070/.well-known/oauth-protected-resource/MCP
+curl -I http://127.0.0.1:8070/.well-known/oauth-protected-resource/mcp
 docker inspect -f '{{.State.Running}}' jurisdigta-email-scheduler
 docker image inspect jurisdigta-document-processor:local >/dev/null
 test -x /srv/jurisdigta/ops/run_document_processor.sh
@@ -495,7 +495,7 @@ curl -fsS https://api.jurisdigta.eu/health
 curl -fsS https://web.jurisdigta.eu/health
 curl -fsS https://agent.jurisdigta.eu/health
 curl -I https://agent.jurisdigta.eu/app/assistant
-curl -I https://mcp.jurisdigta.eu/.well-known/oauth-protected-resource/MCP
+curl -I https://mcp.jurisdigta.eu/.well-known/oauth-protected-resource/mcp
 curl -I https://admin.jurisdigta.eu/grafana/
 ```
 
@@ -692,7 +692,7 @@ Then validate public Cloudflare Tunnel routing externally:
 
 ```bash
 curl -fsS https://api.jurisdigta.eu/health
-curl -I https://mcp.jurisdigta.eu/.well-known/oauth-protected-resource/MCP
+curl -I https://mcp.jurisdigta.eu/.well-known/oauth-protected-resource/mcp
 curl -fsS https://web.jurisdigta.eu/health
 ```
 

--- a/api/aijuristiction-api/app/chat/mcp_law_context.py
+++ b/api/aijuristiction-api/app/chat/mcp_law_context.py
@@ -182,7 +182,7 @@ def _call_remote_mcp_tool(*, remote_base_url: str, name: str, arguments: dict[st
     }
     with httpx.Client(timeout=10.0) as client:
         response = client.post(
-            f"{remote_base_url}/MCP",
+            f"{remote_base_url}/mcp",
             json=payload,
             headers={"Content-Type": "application/json"},
         )

--- a/api/aijuristiction-api/app/mcp_api.py
+++ b/api/aijuristiction-api/app/mcp_api.py
@@ -46,9 +46,9 @@ from app.versioning import (
 )
 from aijurisdictionagents.api_db import ApiDatabaseStore, User, generate_one_time_code
 
-router = APIRouter(prefix="/MCP", tags=["mcp"])
+router = APIRouter(prefix="/mcp", tags=["mcp"])
 compat_router = APIRouter(prefix="/MC", tags=["mcp"])
-lowercase_compat_router = APIRouter(prefix="/mcp", tags=["mcp"])
+legacy_uppercase_router = APIRouter(prefix="/MCP", tags=["mcp"])
 oauth_router = APIRouter(tags=["mcp-oauth"])
 MCP_PROTOCOL_VERSION = "2025-11-25"
 MCP_SERVER_INSTRUCTIONS = (
@@ -137,7 +137,7 @@ _MCP_TEXT: dict[str, dict[str, str]] = {
         "key_created_title": "MCP API key created",
         "key_created_subtitle": "Copy the key now. It is shown once and expires at the configured time.",
         "key_expires": "This key expires at {expires_at}.",
-        "key_note": "Use it as a Bearer token or as the x-mcp-api-key header when connecting your AI assistant to /MCP.",
+        "key_note": "Use it as a Bearer token or as the x-mcp-api-key header when connecting your AI assistant to /mcp.",
         "invalid_code": "The verification code is invalid or has expired. Check the code and try again.",
         "expired_code": "This sign-up request expired. Start sign-up again to receive a new code.",
     },
@@ -198,7 +198,7 @@ _MCP_TEXT: dict[str, dict[str, str]] = {
         "key_created_title": "MCP API kluc bol vytvoreny",
         "key_created_subtitle": "Skopirujte si kluc teraz. Zobrazi sa iba raz a expiruje v nastavenom case.",
         "key_expires": "Tento kluc expiruje {expires_at}.",
-        "key_note": "Pouzite ho ako Bearer token alebo hlavicku x-mcp-api-key pri pripajani AI asistenta k /MCP.",
+        "key_note": "Pouzite ho ako Bearer token alebo hlavicku x-mcp-api-key pri pripajani AI asistenta k /mcp.",
         "invalid_code": "Overovaci kod je neplatny alebo expiroval. Skontrolujte kod a skuste to znova.",
         "expired_code": "Tato registracna poziadavka expirovala. Spustite registraciu znova a dostanete novy kod.",
     },
@@ -227,12 +227,13 @@ def require_mcp_api_key(
 
 
 @router.get("", response_class=JSONResponse)
-@lowercase_compat_router.get("", response_class=JSONResponse)
+@legacy_uppercase_router.get("", response_class=JSONResponse)
 def mcp_status() -> JSONResponse:
     return JSONResponse(status_code=405, content={"detail": "Use POST /mcp for Streamable HTTP JSON-RPC."})
 
 
 @router.get("/status", response_class=JSONResponse)
+@legacy_uppercase_router.get("/status", response_class=JSONResponse)
 def mcp_authenticated_status(user_id: str = Depends(require_mcp_api_key)) -> dict[str, str]:
     logger.info("mcp_status_checked user_id=%s", user_id)
     return {
@@ -245,7 +246,7 @@ def mcp_authenticated_status(user_id: str = Depends(require_mcp_api_key)) -> dic
 
 @router.post("", response_class=JSONResponse)
 @compat_router.post("", response_class=JSONResponse)
-@lowercase_compat_router.post("", response_class=JSONResponse)
+@legacy_uppercase_router.post("", response_class=JSONResponse)
 async def mcp_json_rpc(
     request: Request,
     authorization: str | None = Header(default=None),
@@ -303,12 +304,14 @@ async def mcp_json_rpc(
 
 
 @router.get("/login", response_class=HTMLResponse)
+@legacy_uppercase_router.get("/login", response_class=HTMLResponse)
 def mcp_login_page(request: Request) -> HTMLResponse:
     locale = _mcp_locale(request)
     return HTMLResponse(_login_form_html(locale=locale))
 
 
 @router.get("/sign-up", response_class=HTMLResponse)
+@legacy_uppercase_router.get("/sign-up", response_class=HTMLResponse)
 def mcp_sign_up_page(request: Request) -> HTMLResponse:
     locale = _mcp_locale(request)
     return HTMLResponse(_sign_up_form_html(locale=locale))
@@ -324,7 +327,7 @@ def oauth_protected_resource_metadata(request: Request) -> dict[str, Any]:
         "authorization_servers": [base_url],
         "bearer_methods_supported": ["header"],
         "scopes_supported": [MCP_TOKEN_SCOPE],
-        "resource_documentation": f"{base_url}/MCP/login",
+        "resource_documentation": f"{base_url}/mcp/login",
     }
 
 
@@ -771,6 +774,7 @@ def _redirect_with_oauth_authorization_code(
 
 
 @router.post("/login", response_class=HTMLResponse)
+@legacy_uppercase_router.post("/login", response_class=HTMLResponse)
 def mcp_login_submit(
     request: Request,
     email: str = Form(...),
@@ -805,6 +809,7 @@ def mcp_login_submit(
 
 
 @router.post("/login/mfa", response_class=HTMLResponse)
+@legacy_uppercase_router.post("/login/mfa", response_class=HTMLResponse)
 def mcp_login_mfa_method(
     request: Request,
     email: str = Form(...),
@@ -830,6 +835,7 @@ def mcp_login_mfa_method(
 
 
 @router.post("/login/verify", response_class=HTMLResponse)
+@legacy_uppercase_router.post("/login/verify", response_class=HTMLResponse)
 def mcp_login_verify(
     request: Request,
     email: str = Form(...),
@@ -866,6 +872,7 @@ def mcp_login_verify(
 
 
 @router.post("/sign-up", response_class=HTMLResponse)
+@legacy_uppercase_router.post("/sign-up", response_class=HTMLResponse)
 def mcp_sign_up_submit(
     request: Request,
     email: str = Form(...),
@@ -936,6 +943,7 @@ def mcp_sign_up_submit(
 
 
 @router.post("/sign-up/verify", response_class=HTMLResponse)
+@legacy_uppercase_router.post("/sign-up/verify", response_class=HTMLResponse)
 def mcp_sign_up_verify(
     request: Request,
     pending_id: str = Form(...),
@@ -1908,8 +1916,8 @@ def _authenticate_mcp_api_token(*, api_key: str, store: ApiDatabaseStore) -> Use
         audience=expected_audience,
         required_scope=MCP_TOKEN_SCOPE,
     )
-    if payload is None and expected_audience.endswith("/MCP"):
-        legacy_audience = f"{expected_audience[:-4]}/mcp"
+    if payload is None and expected_audience.lower().endswith("/mcp"):
+        legacy_audience = f"{expected_audience[:-4]}/MCP"
         payload = validate_mcp_api_token(
             api_key,
             audience=legacy_audience,
@@ -2064,7 +2072,7 @@ def _base_url(request: Request) -> str:
 
 
 def _resource_url(request: Request) -> str:
-    return f"{_base_url(request)}/MCP"
+    return f"{_base_url(request)}/mcp"
 
 
 def _base_url_from_resource(resource: str) -> str:
@@ -2137,7 +2145,7 @@ def _first_payload_id(payload: Any) -> Any:
 
 
 def _www_authenticate_header(request: Request) -> str:
-    metadata_url = f"{_base_url(request)}/.well-known/oauth-protected-resource/MCP"
+    metadata_url = f"{_base_url(request)}/.well-known/oauth-protected-resource/mcp"
     return f'Bearer resource_metadata="{metadata_url}", scope="{MCP_TOKEN_SCOPE}"'
 
 
@@ -2680,7 +2688,7 @@ def _login_form_html(*, locale: str) -> str:
         title=_mcp_t(locale, "login_title"),
         subtitle=_mcp_t(locale, "login_subtitle"),
         body_html=f"""    <p class="form-note">{escape(_mcp_t(locale, "login_note"), quote=False)}</p>
-    <form method="post" action="/MCP/login">
+    <form method="post" action="/mcp/login">
       <div class="form-grid">
         <label class="field wide">{escape(_mcp_t(locale, "email"), quote=False)}
           <input name="email" type="email" autocomplete="username" required>
@@ -2697,7 +2705,7 @@ def _login_form_html(*, locale: str) -> str:
 """,
         footer_html=(
             f'    <p class="auth-footer">{escape(_mcp_t(locale, "need_account"), quote=False)} '
-            f'<a href="/MCP/sign-up">{escape(_mcp_t(locale, "sign_up_link"), quote=False)}</a></p>'
+            f'<a href="/mcp/sign-up">{escape(_mcp_t(locale, "sign_up_link"), quote=False)}</a></p>'
         ),
     )
 
@@ -2744,7 +2752,7 @@ def _oauth_login_form_html(
 """,
         footer_html=(
             f'    <p class="auth-footer">{escape(_mcp_t(locale, "need_account"), quote=False)} '
-            f'<a href="/MCP/sign-up">{escape(_mcp_t(locale, "sign_up_link"), quote=False)}</a></p>'
+            f'<a href="/mcp/sign-up">{escape(_mcp_t(locale, "sign_up_link"), quote=False)}</a></p>'
         ),
     )
 
@@ -2888,7 +2896,7 @@ def _otp_form_html(
         title=_mcp_t(locale, "verify_login_title"),
         subtitle=_mcp_t(locale, "verify_login_subtitle"),
         body_html=f"""{_warning_html(locale=locale, warning_key=warning_key)}    <p class="email-note">{escape(_mcp_t(locale, "otp_sent", email=escaped_email), quote=False)}</p>
-    <form method="post" action="/MCP/login/verify">
+    <form method="post" action="/mcp/login/verify">
       <input name="email" type="hidden" value="{escaped_email}">
       <input name="expires_in_days" type="hidden" value="{expires_in_days}">
       <label class="field wide">{escape(_mcp_t(locale, "otp_code"), quote=False)}
@@ -2906,7 +2914,7 @@ def _mfa_method_form_html(*, locale: str, email: str, expires_in_days: int) -> s
         locale=locale,
         title=_mcp_t(locale, "choose_mfa_title"),
         subtitle=_mcp_t(locale, "choose_mfa_subtitle"),
-        body_html=f"""    <form method="post" action="/MCP/login/mfa">
+        body_html=f"""    <form method="post" action="/mcp/login/mfa">
       <input name="email" type="hidden" value="{escaped_email}">
       <input name="expires_in_days" type="hidden" value="{expires_in_days}">
       <label class="field wide">{escape(_mcp_t(locale, "mfa_method"), quote=False)}
@@ -2934,7 +2942,7 @@ def _totp_form_html(
         title=_mcp_t(locale, "verify_login_title"),
         subtitle=_mcp_t(locale, "verify_login_subtitle"),
         body_html=f"""{_warning_html(locale=locale, warning_key=warning_key)}    <p class="form-note">{escape(_mcp_t(locale, "totp_note"), quote=False)}</p>
-    <form method="post" action="/MCP/login/verify">
+    <form method="post" action="/mcp/login/verify">
       <input name="email" type="hidden" value="{escaped_email}">
       <input name="mfa_method" type="hidden" value="totp">
       <input name="expires_in_days" type="hidden" value="{expires_in_days}">
@@ -2953,7 +2961,7 @@ def _sign_up_form_html(*, locale: str) -> str:
         title=_mcp_t(locale, "create_account_title"),
         subtitle=_mcp_t(locale, "create_account_subtitle"),
         body_html=f"""    <p class="form-note">{escape(_mcp_t(locale, "create_account_note"), quote=False)}</p>
-    <form method="post" action="/MCP/sign-up">
+    <form method="post" action="/mcp/sign-up">
       <div class="form-grid">
         <label class="field wide">{escape(_mcp_t(locale, "email"), quote=False)}
           <input name="email" type="email" autocomplete="username" required>
@@ -2995,7 +3003,7 @@ def _sign_up_form_html(*, locale: str) -> str:
 """,
         footer_html=(
             f'    <p class="auth-footer">{escape(_mcp_t(locale, "already_registered"), quote=False)} '
-            f'<a href="/MCP/login">{escape(_mcp_t(locale, "log_in_link"), quote=False)}</a></p>'
+            f'<a href="/mcp/login">{escape(_mcp_t(locale, "log_in_link"), quote=False)}</a></p>'
         ),
     )
 
@@ -3014,7 +3022,7 @@ def _sign_up_otp_form_html(
         title=_mcp_t(locale, "verify_signup_title"),
         subtitle=_mcp_t(locale, "verify_signup_subtitle"),
         body_html=f"""{_warning_html(locale=locale, warning_key=warning_key)}    <p class="email-note">{escape(_mcp_t(locale, "otp_sent", email=escaped_email), quote=False)}</p>
-    <form method="post" action="/MCP/sign-up/verify">
+    <form method="post" action="/mcp/sign-up/verify">
 {hidden_html}
       <label class="field wide">{escape(_mcp_t(locale, "otp_code"), quote=False)}
         <input name="verification_code" type="text" inputmode="numeric" autocomplete="one-time-code" required>
@@ -3039,7 +3047,7 @@ def _sign_up_complete_html(*, locale: str, email: str) -> str:
         title=_mcp_t(locale, "account_created_title"),
         subtitle=_mcp_t(locale, "account_created_subtitle"),
         body_html=f"""    <p class="email-note">{escape(_mcp_t(locale, "account_created", email=escaped_email), quote=False)}</p>
-    <p class="auth-footer"><a href="/MCP/login">{escape(_mcp_t(locale, "log_in_link"), quote=False)}</a></p>
+    <p class="auth-footer"><a href="/mcp/login">{escape(_mcp_t(locale, "log_in_link"), quote=False)}</a></p>
 """,
     )
 

--- a/api/aijuristiction-api/app/mcp_main.py
+++ b/api/aijuristiction-api/app/mcp_main.py
@@ -20,7 +20,7 @@ from app.chat.result_metadata import get_law_knowledge_snapshot
 from app.logging_config import configure_logging
 from app.mcp_api import oauth_router as mcp_oauth_router
 from app.mcp_api import compat_router as mcp_compat_router
-from app.mcp_api import lowercase_compat_router as mcp_lowercase_compat_router
+from app.mcp_api import legacy_uppercase_router as mcp_legacy_uppercase_router
 from app.mcp_api import router as mcp_router
 from app.telemetry import configure_telemetry, instrument_fastapi
 from app.versioning import (
@@ -315,11 +315,11 @@ def _mcp_page_text(locale: str, key: str, **values: str) -> str:
 
 
 def _mcp_instructions_html(*, base_url: str, locale: str = "en") -> str:
-    mcp_url = f"{base_url}/MCP"
-    protected_resource_url = f"{base_url}/.well-known/oauth-protected-resource/MCP"
+    mcp_url = f"{base_url}/mcp"
+    protected_resource_url = f"{base_url}/.well-known/oauth-protected-resource/mcp"
     authorization_server_url = f"{base_url}/.well-known/oauth-authorization-server"
-    login_url = f"{base_url}/MCP/login"
-    sign_up_url = f"{base_url}/MCP/sign-up"
+    login_url = f"{base_url}/mcp/login"
+    sign_up_url = f"{base_url}/mcp/sign-up"
     version_url = f"{base_url}/version"
     return f"""<!doctype html>
 <html lang="{locale}">
@@ -478,7 +478,7 @@ app.add_middleware(
 app.include_router(mcp_oauth_router)
 app.include_router(mcp_router)
 app.include_router(mcp_compat_router)
-app.include_router(mcp_lowercase_compat_router)
+app.include_router(mcp_legacy_uppercase_router)
 instrument_fastapi(app)
 
 

--- a/api/aijuristiction-api/app/mcp_tokens.py
+++ b/api/aijuristiction-api/app/mcp_tokens.py
@@ -123,7 +123,7 @@ def _validate_mcp_token(token: str, *, audience: str) -> dict[str, Any] | None:
 
 def default_mcp_resource_url() -> str:
     base_url = os.getenv("MCP_PUBLIC_BASE_URL", "https://mcp.jurisdigta.eu").strip().rstrip("/")
-    return f"{base_url}/MCP"
+    return f"{base_url}/mcp"
 
 
 def _issuer_from_audience(audience: str) -> str:

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260492"
+version = "1.0.260493"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -1761,8 +1761,8 @@ def test_mcp_law_context_prefers_remote_mcp_endpoint(monkeypatch) -> None:
 
     assert context is not None
     assert [request["url"] for request in requests] == [
-        "http://jurisdigta-mcp:8070/MCP",
-        "http://jurisdigta-mcp:8070/MCP",
+        "http://jurisdigta-mcp:8070/mcp",
+        "http://jurisdigta-mcp:8070/mcp",
     ]
     assert "§ 588 text" in context.prompt_note
 

--- a/api/aijuristiction-api/tests/test_health.py
+++ b/api/aijuristiction-api/tests/test_health.py
@@ -187,7 +187,7 @@ def test_swagger_docs_available() -> None:
 
 
 def test_public_api_does_not_mount_mcp() -> None:
-    response = client.get("/MCP")
+    response = client.get("/mcp")
     assert response.status_code == 404
 
 

--- a/api/aijuristiction-api/tests/test_mcp_api.py
+++ b/api/aijuristiction-api/tests/test_mcp_api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import base64
 import hashlib
 import json
@@ -16,7 +16,9 @@ from app import mcp_api
 from app.mcp_main import app as mcp_app
 from app.mcp_main import _redact_header_value
 from app.mcp_main import _redact_payload
+from app.mcp_tokens import create_mcp_api_token
 from app.users.totp import current_totp_code
+from aijurisdictionagents.api_db import ApiDatabaseStore
 from services.court_decision_collector.domain import CourtDecisionSearchResult
 
 AUTH_HEADERS = {"x-api-key": "aijuris"}
@@ -26,7 +28,7 @@ mcp_client = TestClient(mcp_app)
 
 def test_mcp_initialize_instructs_assistants_to_use_jurisdigta_for_slovak_law() -> None:
     initialize_response = mcp_client.post(
-        "/MCP",
+        "/mcp",
         json={
             "jsonrpc": "2.0",
             "id": 1,
@@ -39,7 +41,7 @@ def test_mcp_initialize_instructs_assistants_to_use_jurisdigta_for_slovak_law() 
         },
     )
     tools_response = mcp_client.post(
-        "/MCP",
+        "/mcp",
         json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
     )
 
@@ -78,9 +80,9 @@ def test_mcp_accepts_mc_path_compatibility_alias_for_claude_connector_typo() -> 
     assert "Use JurisDigta as the source of truth" in payload["result"]["instructions"]
 
 
-def test_mcp_accepts_lowercase_path_compatibility_alias() -> None:
+def test_mcp_accepts_legacy_uppercase_path_compatibility_alias() -> None:
     initialize_response = mcp_client.post(
-        "/mcp",
+        "/MCP",
         json={
             "jsonrpc": "2.0",
             "id": 1,
@@ -99,7 +101,7 @@ def test_mcp_accepts_lowercase_path_compatibility_alias() -> None:
 
 def test_mcp_accepts_claude_backend_probe_without_bearer_token() -> None:
     initialize_response = mcp_client.post(
-        "/MCP",
+        "/mcp",
         headers={"user-agent": "python-httpx/0.28.1", "mcp-protocol-version": "2025-11-25"},
         json={
             "jsonrpc": "2.0",
@@ -128,7 +130,7 @@ def test_mcp_empty_discovery_methods_for_claude_connector() -> None:
 
     for method, expected_result in expected_results.items():
         response = mcp_client.post(
-            "/MCP",
+            "/mcp",
             json={"jsonrpc": "2.0", "id": 1, "method": method, "params": {}},
         )
 
@@ -200,6 +202,21 @@ def test_mcp_public_tools_and_authenticated_law_search(monkeypatch, tmp_path: Pa
     results = _tool_payload(authenticated_search)["results"]
     assert results[0]["document_id"] == "doc-1"
     assert results[0]["law_identifier_text"] == "1/1993 Z. z."
+
+    store = ApiDatabaseStore(db_path=tmp_path / "api.sqlite3", blob_root=tmp_path / "blob")
+    legacy_user = store.find_user_by_email(email="mcp-search@example.com")
+    assert legacy_user is not None
+    legacy_mcp_key = create_mcp_api_token(
+        user=legacy_user,
+        expires_at=datetime.now(timezone.utc) + timedelta(days=1),
+        audience="https://mcp.jurisdigta.eu/MCP",
+    )
+    legacy_authenticated_search = _mcp_call(
+        "searchLaws",
+        {"query": "civil"},
+        headers={"authorization": f"Bearer {legacy_mcp_key}"},
+    )
+    assert legacy_authenticated_search.status_code == 200
 
     text_response = _mcp_call(
         "getLawText",
@@ -501,7 +518,7 @@ def test_mcp_wire_logging_records_redacted_request_and_response(monkeypatch, tmp
     caplog.set_level(logging.INFO, logger="jurisdigta-mcp-server.http")
 
     response = mcp_client.post(
-        "/MCP?code=secret-code&state=public-state",
+        "/mcp?code=secret-code&state=public-state",
         headers={
             "authorization": "Bearer secret-bearer-token",
             "x-mcp-api-key": "secret-api-key",
@@ -601,7 +618,7 @@ def test_user_mcp_api_key_defaults_to_one_day(monkeypatch, tmp_path: Path) -> No
     token = create_key_response.json()["mcp_api_key"]
     claims = _jwt_claims(token)
     assert claims["sub"] == sign_up_response.json()["user_id"]
-    assert claims["aud"] == "https://mcp.jurisdigta.eu/MCP"
+    assert claims["aud"] == "https://mcp.jurisdigta.eu/mcp"
     assert claims["iss"] == "https://mcp.jurisdigta.eu"
     assert claims["scope"] == "mcp:laws"
     assert claims["token_use"] == "access"
@@ -628,7 +645,7 @@ def test_mcp_login_page_can_generate_key(monkeypatch, tmp_path: Path) -> None:
     )
     assert sign_up_response.status_code == 201
 
-    page_response = mcp_client.get("/MCP/login")
+    page_response = mcp_client.get("/mcp/login")
     assert page_response.status_code == 200
     assert "JurisDigta MCP" in page_response.text
     assert "auth-shell" in page_response.text
@@ -636,14 +653,14 @@ def test_mcp_login_page_can_generate_key(monkeypatch, tmp_path: Path) -> None:
     assert "AIJurisdiction MCP Login" not in page_response.text
 
     login_response = mcp_client.post(
-        "/MCP/login",
+        "/mcp/login",
         data={"email": "mcp-login@example.com", "password": "secret-pass"},
     )
     assert login_response.status_code == 200
     assert "Verify MCP login" in login_response.text
 
     verify_response = mcp_client.post(
-        "/MCP/login/verify",
+        "/mcp/login/verify",
         data={
             "email": "mcp-login@example.com",
             "verification_code": "123456",
@@ -675,7 +692,7 @@ def test_mcp_login_invalid_otp_returns_localized_html_warning(monkeypatch, tmp_p
     assert sign_up_response.status_code == 201
 
     login_response = mcp_client.post(
-        "/MCP/login",
+        "/mcp/login",
         data={"email": "mcp-login-warning@example.com", "password": "secret-pass"},
         headers={"accept-language": "sk-SK,sk;q=0.9,en;q=0.8"},
     )
@@ -684,7 +701,7 @@ def test_mcp_login_invalid_otp_returns_localized_html_warning(monkeypatch, tmp_p
     assert "Overenie MCP prihlasenia" in login_response.text
 
     verify_response = mcp_client.post(
-        "/MCP/login/verify",
+        "/mcp/login/verify",
         data={
             "email": "mcp-login-warning@example.com",
             "verification_code": "000000",
@@ -726,7 +743,7 @@ def test_mcp_login_supports_totp_mfa_choice(monkeypatch, tmp_path: Path) -> None
     assert confirm_response.status_code == 200
 
     login_response = mcp_client.post(
-        "/MCP/login",
+        "/mcp/login",
         data={"email": "mcp-totp@example.com", "password": "secret-pass", "expires_in_days": "1"},
     )
     assert login_response.status_code == 200
@@ -735,14 +752,14 @@ def test_mcp_login_supports_totp_mfa_choice(monkeypatch, tmp_path: Path) -> None
     assert 'option value="totp"' in login_response.text
 
     method_response = mcp_client.post(
-        "/MCP/login/mfa",
+        "/mcp/login/mfa",
         data={"email": "mcp-totp@example.com", "mfa_method": "totp", "expires_in_days": "1"},
     )
     assert method_response.status_code == 200
     assert "Authenticator code" in method_response.text
 
     verify_response = mcp_client.post(
-        "/MCP/login/verify",
+        "/mcp/login/verify",
         data={
             "email": "mcp-totp@example.com",
             "mfa_method": "totp",
@@ -758,7 +775,7 @@ def test_mcp_sign_up_requires_email_otp_and_profile_fields(monkeypatch, tmp_path
     _configure_env(monkeypatch, tmp_path)
     monkeypatch.setenv("LOCAL_AUTH_ACCEPT_ANY_CODE", "true")
 
-    page_response = mcp_client.get("/MCP/sign-up")
+    page_response = mcp_client.get("/mcp/sign-up")
     assert page_response.status_code == 200
     assert "JurisDigta MCP" in page_response.text
     assert "auth-shell" in page_response.text
@@ -766,7 +783,7 @@ def test_mcp_sign_up_requires_email_otp_and_profile_fields(monkeypatch, tmp_path
     assert "AIJurisdiction MCP Sign up" not in page_response.text
 
     send_code_response = mcp_client.post(
-        "/MCP/sign-up",
+        "/mcp/sign-up",
         data={
             "email": "mcp-new@example.com",
             "phone_number": "+421 900 111 229",
@@ -787,7 +804,7 @@ def test_mcp_sign_up_requires_email_otp_and_profile_fields(monkeypatch, tmp_path
     assert "AB123456" not in send_code_response.text
 
     verify_response = mcp_client.post(
-        "/MCP/sign-up/verify",
+        "/mcp/sign-up/verify",
         data={
             "pending_id": _extract_hidden_value(send_code_response.text, "pending_id"),
             "verification_code": "123456",
@@ -821,13 +838,13 @@ def test_mcp_sign_up_requires_email_otp_and_profile_fields(monkeypatch, tmp_path
 def test_mcp_sign_up_invalid_otp_returns_localized_html_warning(monkeypatch, tmp_path: Path) -> None:
     _configure_env(monkeypatch, tmp_path)
 
-    page_response = mcp_client.get("/MCP/sign-up", headers={"accept-language": "sk"})
+    page_response = mcp_client.get("/mcp/sign-up", headers={"accept-language": "sk"})
     assert page_response.status_code == 200
     assert '<html lang="sk">' in page_response.text
     assert "Cislo obcianskeho preukazu" in page_response.text
 
     send_code_response = mcp_client.post(
-        "/MCP/sign-up",
+        "/mcp/sign-up",
         data={
             "email": "mcp-new-warning@example.com",
             "phone_number": "+421 900 111 232",
@@ -847,7 +864,7 @@ def test_mcp_sign_up_invalid_otp_returns_localized_html_warning(monkeypatch, tmp
     assert "Overenie MCP registracie" in send_code_response.text
 
     verify_response = mcp_client.post(
-        "/MCP/sign-up/verify",
+        "/mcp/sign-up/verify",
         data={
             "pending_id": _extract_hidden_value(send_code_response.text, "pending_id"),
             "email": _extract_hidden_value(send_code_response.text, "email"),
@@ -878,13 +895,13 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
     )
     assert sign_up_response.status_code == 201
 
-    protected_metadata = mcp_client.get("/.well-known/oauth-protected-resource/MCP")
+    protected_metadata = mcp_client.get("/.well-known/oauth-protected-resource/mcp")
     assert protected_metadata.status_code == 200
-    assert protected_metadata.json()["resource"].endswith("/MCP")
+    assert protected_metadata.json()["resource"].endswith("/mcp")
     assert protected_metadata.json()["resource_name"] == "JurisDigta MCP"
     assert protected_metadata.json()["scopes_supported"] == ["mcp:laws"]
     claude_web_protected_metadata = mcp_client.get(
-        "/.well-known/oauth-protected-resource/MCP",
+        "/.well-known/oauth-protected-resource/mcp",
         headers={"user-agent": "python-httpx/0.28.1", "mcp-protocol-version": "2025-11-25"},
     )
     assert claude_web_protected_metadata.status_code == 200
@@ -922,7 +939,7 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
     assert authorization_metadata.json()["scopes_supported"] == ["mcp:laws", "offline_access"]
     assert authorization_metadata.json()["registration_endpoint"].endswith("/oauth/register")
     assert authorization_metadata.json()["authorization_response_iss_parameter_supported"] is True
-    assert authorization_metadata.json()["protected_resources"] == ["https://mcp.jurisdigta.eu/MCP"]
+    assert authorization_metadata.json()["protected_resources"] == ["https://mcp.jurisdigta.eu/mcp"]
 
     registration_response = mcp_client.post(
         "/oauth/register",
@@ -1005,7 +1022,7 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
 
     code_verifier = "test-code-verifier-1234567890"
     code_challenge = _pkce_challenge(code_verifier)
-    resource = "https://mcp.jurisdigta.eu/MCP"
+    resource = "https://mcp.jurisdigta.eu/mcp"
     authorize_page = mcp_client.get(
         "/oauth/authorize",
         params={
@@ -1305,7 +1322,7 @@ def test_oauth_discovery_uses_public_base_url(monkeypatch, tmp_path: Path) -> No
     monkeypatch.setenv("MCP_PUBLIC_BASE_URL", "https://mcp.jurisdigta.eu")
 
     protected_metadata = mcp_client.get(
-        "/.well-known/oauth-protected-resource/MCP",
+        "/.well-known/oauth-protected-resource/mcp",
         headers={"x-forwarded-proto": "http", "x-forwarded-host": "internal.local"},
     )
     authorization_metadata = mcp_client.get(
@@ -1313,23 +1330,23 @@ def test_oauth_discovery_uses_public_base_url(monkeypatch, tmp_path: Path) -> No
         headers={"x-forwarded-proto": "http", "x-forwarded-host": "internal.local"},
     )
     mcp_path_authorization_metadata = mcp_client.get(
-        "/.well-known/oauth-authorization-server/MCP",
-        headers={"x-forwarded-proto": "http", "x-forwarded-host": "internal.local"},
-    )
-    lower_mcp_protected_metadata = mcp_client.get(
-        "/.well-known/oauth-protected-resource/mcp",
-        headers={"x-forwarded-proto": "http", "x-forwarded-host": "internal.local"},
-    )
-    lower_mcp_authorization_metadata = mcp_client.get(
         "/.well-known/oauth-authorization-server/mcp",
+        headers={"x-forwarded-proto": "http", "x-forwarded-host": "internal.local"},
+    )
+    legacy_mcp_protected_metadata = mcp_client.get(
+        "/.well-known/oauth-protected-resource/MCP",
+        headers={"x-forwarded-proto": "http", "x-forwarded-host": "internal.local"},
+    )
+    legacy_mcp_authorization_metadata = mcp_client.get(
+        "/.well-known/oauth-authorization-server/MCP",
         headers={"x-forwarded-proto": "http", "x-forwarded-host": "internal.local"},
     )
 
     assert protected_metadata.status_code == 200
-    assert protected_metadata.json()["resource"] == "https://mcp.jurisdigta.eu/MCP"
+    assert protected_metadata.json()["resource"] == "https://mcp.jurisdigta.eu/mcp"
     assert protected_metadata.json()["authorization_servers"] == ["https://mcp.jurisdigta.eu"]
-    assert lower_mcp_protected_metadata.status_code == 200
-    assert lower_mcp_protected_metadata.json() == protected_metadata.json()
+    assert legacy_mcp_protected_metadata.status_code == 200
+    assert legacy_mcp_protected_metadata.json() == protected_metadata.json()
     assert authorization_metadata.status_code == 200
     assert authorization_metadata.json()["issuer"] == "https://mcp.jurisdigta.eu"
     assert authorization_metadata.json()["token_endpoint"] == "https://mcp.jurisdigta.eu/oauth/token"
@@ -1337,8 +1354,8 @@ def test_oauth_discovery_uses_public_base_url(monkeypatch, tmp_path: Path) -> No
     assert authorization_metadata.json()["client_id_metadata_document_supported"] is True
     assert mcp_path_authorization_metadata.status_code == 200
     assert mcp_path_authorization_metadata.json() == authorization_metadata.json()
-    assert lower_mcp_authorization_metadata.status_code == 200
-    assert lower_mcp_authorization_metadata.json() == authorization_metadata.json()
+    assert legacy_mcp_authorization_metadata.status_code == 200
+    assert legacy_mcp_authorization_metadata.json() == authorization_metadata.json()
 
 
 def test_oauth_registration_accepts_loopback_redirect_for_local_clients(monkeypatch, tmp_path: Path) -> None:
@@ -1406,7 +1423,7 @@ def test_oauth_authorize_accepts_client_id_metadata_document(monkeypatch, tmp_pa
             "redirect_uri": "http://127.0.0.1:3334/callback",
             "code_challenge": "test-challenge",
             "code_challenge_method": "S256",
-            "resource": "https://mcp.jurisdigta.eu/MCP",
+            "resource": "https://mcp.jurisdigta.eu/mcp",
             "state": "abc",
         },
     )
@@ -1439,7 +1456,7 @@ def test_oauth_authorize_rejects_unregistered_client_id_metadata_redirect(
             "redirect_uri": "http://127.0.0.1:3334/callback",
             "code_challenge": "test-challenge",
             "code_challenge_method": "S256",
-            "resource": "https://mcp.jurisdigta.eu/MCP",
+            "resource": "https://mcp.jurisdigta.eu/mcp",
         },
     )
 
@@ -1497,7 +1514,7 @@ def _mcp_call(
         "method": "tools/call",
         "params": {"name": name, "arguments": arguments or {}},
     }
-    return mcp_client.post("/MCP", json=payload, headers=headers or {})
+    return mcp_client.post("/mcp", json=payload, headers=headers or {})
 
 
 def _tool_payload(response) -> dict[str, object]:

--- a/api/aijuristiction-api/tests/test_mcp_service.py
+++ b/api/aijuristiction-api/tests/test_mcp_service.py
@@ -104,13 +104,13 @@ def test_mcp_root_shows_assistant_setup_and_registration_steps() -> None:
     assert response.status_code == 200
     assert "JurisDigta MCP server" in response.text
     assert "Registration" in response.text
-    assert "/MCP/sign-up" in response.text
-    assert "/MCP/login" in response.text
+    assert "/mcp/sign-up" in response.text
+    assert "/mcp/login" in response.text
     assert "ChatGPT custom connector" in response.text
     assert "Claude" in response.text
     assert "VS Code" in response.text
     assert "Perplexity" in response.text
-    assert "/.well-known/oauth-protected-resource/MCP" in response.text
+    assert "/.well-known/oauth-protected-resource/mcp" in response.text
     assert "Authorization: Bearer" in response.text
 
 
@@ -121,7 +121,7 @@ def test_mcp_root_localizes_for_slovak_browser() -> None:
     assert "Registracia" in response.text
     assert "Nastavenie asistenta" in response.text
     assert "Metadata autorizacneho servera" in response.text
-    assert "/MCP/sign-up" in response.text
+    assert "/mcp/sign-up" in response.text
     assert "Authorization: Bearer" in response.text
 
 
@@ -134,5 +134,5 @@ def test_mcp_root_uses_forwarded_public_origin() -> None:
         },
     )
     assert response.status_code == 200
-    assert "https://mcp.jurisdigta.eu/MCP" in response.text
+    assert "https://mcp.jurisdigta.eu/mcp" in response.text
     assert "https://mcp.jurisdigta.eu/.well-known/oauth-authorization-server" in response.text

--- a/api/aijuristiction-api/tests/test_users.py
+++ b/api/aijuristiction-api/tests/test_users.py
@@ -919,12 +919,12 @@ def test_user_can_create_and_delete_mcp_api_key_and_call_mcp(monkeypatch, tmp_pa
     assert create_key_response.status_code == 200
     mcp_key = create_key_response.json()["mcp_api_key"]
 
-    mcp_response = mcp_client.get("/MCP/status", headers={"x-mcp-api-key": mcp_key})
+    mcp_response = mcp_client.get("/mcp/status", headers={"x-mcp-api-key": mcp_key})
     assert mcp_response.status_code == 200
     assert mcp_response.json()["user_id"] == user_id
 
     delete_key_response = client.delete(f"/v1/users/{user_id}/mcp-api-key", headers=AUTH_HEADERS)
     assert delete_key_response.status_code == 200
 
-    expired_response = mcp_client.get("/MCP/status", headers={"x-mcp-api-key": mcp_key})
+    expired_response = mcp_client.get("/mcp/status", headers={"x-mcp-api-key": mcp_key})
     assert expired_response.status_code == 401

--- a/corporate-web/index.html
+++ b/corporate-web/index.html
@@ -1090,7 +1090,7 @@
           },
           {
             type: "p",
-            text: "Plánovaná URL endpointu je https://mcp.jurisdigta.eu/MCP. Prístup má byť viazaný na používateľom vytvorený MCP API kľúč s expiráciou, rozsahmi oprávnení a možnosťou okamžitého zrušenia."
+            text: "Plánovaná URL endpointu je https://mcp.jurisdigta.eu/mcp. Prístup má byť viazaný na používateľom vytvorený MCP API kľúč s expiráciou, rozsahmi oprávnení a možnosťou okamžitého zrušenia."
           },
           {
             type: "h3",

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -454,7 +454,7 @@ curl -fsS http://127.0.0.1:11434/v1/models || curl -fsS "http://$(docker network
 
 ```bash
 curl -fsS https://api.jurisdigta.eu/health
-curl -I https://mcp.jurisdigta.eu/.well-known/oauth-protected-resource/MCP
+curl -I https://mcp.jurisdigta.eu/.well-known/oauth-protected-resource/mcp
 curl -fsS https://web.jurisdigta.eu/health
 curl -fsS https://agent.jurisdigta.eu/health
 curl -I https://agent.jurisdigta.eu/app/assistant

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -4,23 +4,22 @@ JurisDigta runs MCP as a dedicated service, separate from the public API app.
 The local default is `http://127.0.0.1:8070`, and production routing should map
 `https://mcp.jurisdigta.eu` to the MCP service, not to `api.jurisdigta.eu`.
 
-The MCP service exposes a Streamable HTTP-style MCP JSON-RPC endpoint at `POST /MCP`.
+The MCP service exposes a Streamable HTTP-style MCP JSON-RPC endpoint at `POST /mcp`.
 It is intended for AI assistants that can connect to remote MCP servers over HTTP.
 For ChatGPT, Claude, and VS Code OAuth-capable clients, start from the OAuth metadata endpoints instead of manually copying a token.
 The API `/version`, MCP `/version`, and MCP `getVersion` tool expose `mcp_server_version`.
 For the current deployable package this value is aligned with the API package revision.
-`POST /MC` is also accepted as a compatibility alias for connector records that
-were accidentally saved with the truncated Claude URL `/MC`; OAuth metadata
+`POST /MCP` remains accepted as a legacy compatibility alias for older client
+records, and `POST /MC` is also accepted for connector records that were
+accidentally saved with the truncated Claude URL `/MC`; OAuth metadata
 advertises the canonical protected resource as `https://mcp.jurisdigta.eu/mcp`.
-`POST /mcp` is accepted as a lowercase compatibility alias for clients that
-normalize the path.
 
 `GET /` on the MCP service is a public human-facing setup page. In production,
 `https://mcp.jurisdigta.eu/` should show:
 
 - Registration and login steps for creating an MCP account and short-lived MCP API key.
 - Remote MCP setup guidance for ChatGPT custom connectors, Claude, Perplexity-compatible clients, VS Code, and other MCP clients.
-- OAuth discovery URLs and the canonical MCP endpoint `https://mcp.jurisdigta.eu/MCP`.
+- OAuth discovery URLs and the canonical MCP endpoint `https://mcp.jurisdigta.eu/mcp`.
 - Privacy and compliance notes explaining that protected tools require per-user authentication and privacy-safe logging.
 
 Start locally with Docker Compose:
@@ -45,9 +44,9 @@ curl http://127.0.0.1:8070/
 
 ## OAuth Discovery
 
-- Protected resource metadata: `GET /.well-known/oauth-protected-resource/MCP`
+- Protected resource metadata: `GET /.well-known/oauth-protected-resource/mcp`
 - Authorization server metadata: `GET /.well-known/oauth-authorization-server`
-- Claude/path-derived authorization server metadata: `GET /.well-known/oauth-authorization-server/MCP`
+- Claude/path-derived authorization server metadata: `GET /.well-known/oauth-authorization-server/mcp`
 - Dynamic client registration endpoint: `POST /oauth/register`
 - Authorization endpoint: `GET /oauth/authorize`
 - Token endpoint: `POST /oauth/token`
@@ -58,7 +57,7 @@ Client ID Metadata Documents, dynamic client registration at `/oauth/register`,
 or a preconfigured public OAuth Client ID. New dynamic registrations may return
 either `200 OK` or `201 Created` with the issued public client metadata.
 ChatGPT and Claude should pass the protected resource value
-`https://mcp.jurisdigta.eu/MCP` on the authorization, token, and refresh
+`https://mcp.jurisdigta.eu/mcp` on the authorization, token, and refresh
 requests. Protected-resource metadata includes a human-readable
 `resource_name`, and authorization-server metadata advertises the protected MCP
 resource, `client_id_metadata_document_supported=true`, and
@@ -68,7 +67,7 @@ strict OAuth clients can bind the response to the issuer.
 The browser authorization page validates the user password, sends an email OTP,
 and only creates a short-lived authorization code after OTP verification. The
 token endpoint exchanges that code for the same revocable JWT bearer token
-accepted by `POST /MCP` and a separate audience-bound refresh token. Token
+accepted by `POST /mcp` and a separate audience-bound refresh token. Token
 responses include `Cache-Control: no-store` and `Pragma: no-cache`.
 
 Production settings:
@@ -106,8 +105,8 @@ registration response before it can start the browser authorization flow.
 
 Users can generate a key in either way:
 
-- Browser login page: `GET /MCP/login`, then submit username/email and password. The MCP service emails an OTP code through the shared email queue. Submitting the OTP at `POST /MCP/login/verify` generates and stores the MCP API key.
-- Browser sign-up page: `GET /MCP/sign-up`, then submit email, phone number, password, first name, last name, address, ID card number, and data-processing consent. The MCP service emails an OTP code. Submitting the OTP at `POST /MCP/sign-up/verify` creates the user; the user can then log in to generate an MCP API key.
+- Browser login page: `GET /mcp/login`, then submit username/email and password. The MCP service emails an OTP code through the shared email queue. Submitting the OTP at `POST /mcp/login/verify` generates and stores the MCP API key.
+- Browser sign-up page: `GET /mcp/sign-up`, then submit email, phone number, password, first name, last name, address, ID card number, and data-processing consent. The MCP service emails an OTP code. Submitting the OTP at `POST /mcp/sign-up/verify` creates the user; the user can then log in to generate an MCP API key.
 - API endpoint: `POST /v1/users/{user_id}/mcp-api-key` with optional `{ "expires_in_days": 1 }`.
 
 The browser login, sign-up, OTP, OAuth authorization, and key-created pages share the JurisDigta MCP auth shell in `api/aijuristiction-api/app/mcp_api.py`. Keep the form field names and POST targets stable when changing UX, because external MCP and OAuth clients rely on those routes. Do not add remote tracking images or echo submitted password, ID-card, or profile values back into the OTP pages.
@@ -118,15 +117,15 @@ Keys can be revoked with:
 
 - `DELETE /v1/users/{user_id}/mcp-api-key`
 
-Manual JWT generation remains useful for local VS Code setups that pass an `Authorization` header directly. Standards-based remote clients should prefer OAuth discovery. Existing tokens issued before the audience/scope claim update must be regenerated.
+Manual JWT generation remains useful for local VS Code setups that pass an `Authorization` header directly. Standards-based remote clients should prefer OAuth discovery. Newly issued tokens use the lowercase `/mcp` audience; existing `/MCP` audience tokens remain accepted as a compatibility path until they expire or are revoked.
 
 ## Assistant Setup
 
-Use `https://mcp.jurisdigta.eu/MCP` as the remote MCP server URL in clients that support custom HTTP MCP servers.
+Use `https://mcp.jurisdigta.eu/mcp` as the remote MCP server URL in clients that support custom HTTP MCP servers.
 
 - ChatGPT custom connectors: create a remote MCP connector and enter the MCP server URL. Prefer OAuth discovery when the connector supports it. Users may self-register during the browser authorization flow, but ChatGPT only receives the OAuth access token and tool results, not a raw API key.
 - Claude: add a custom connector or remote MCP server and enter the MCP server URL. OAuth-capable Claude clients can discover authorization metadata from `https://mcp.jurisdigta.eu` and register dynamically. If Claude reports that automatic client registration is not supported, open Advanced settings, set OAuth Client ID to a stable public value such as `claude`, leave OAuth Client Secret empty, and retry after confirming `claude.ai` is allowed in `MCP_OAUTH_ALLOWED_REDIRECT_HOSTS`. Claude Desktop, Claude Code, and local OAuth proxies can use loopback callbacks such as `http://localhost/...`, `http://127.0.0.1/...`, or `http://[::1]/...`.
-- VS Code: add an HTTP MCP server in MCP settings. If OAuth is unavailable in the client, include `Authorization: Bearer <mcp_api_key>` after generating a key from `/MCP/login`.
+- VS Code: add an HTTP MCP server in MCP settings. If OAuth is unavailable in the client, include `Authorization: Bearer <mcp_api_key>` after generating a key from `/mcp/login`.
 - Perplexity and other clients: use the MCP server URL where custom remote MCP servers are supported. Hosted OAuth callbacks include `https://vscode.dev/redirect`, `https://claude.ai/api/mcp/auth_callback`, and `https://www.perplexity.ai/rest/connections/oauth_callback` when their hosts are listed in `MCP_OAUTH_ALLOWED_REDIRECT_HOSTS`. If a product only exposes its own MCP server and does not support registering external MCP servers, use another MCP-compatible host.
 
 ### Claude Desktop via `mcp-remote`
@@ -155,7 +154,7 @@ Add or merge this `mcpServers` entry while keeping existing preferences:
       "args": [
         "-y",
         "mcp-remote",
-        "https://mcp.jurisdigta.eu/MCP"
+        "https://mcp.jurisdigta.eu/mcp"
       ],
       "env": {
         "NODE_OPTIONS": "--use-system-ca"
@@ -197,9 +196,9 @@ curl.exe -Iv https://mcp.jurisdigta.eu/health
 
 Discovery endpoints:
 
-- `https://mcp.jurisdigta.eu/.well-known/oauth-protected-resource/MCP`
+- `https://mcp.jurisdigta.eu/.well-known/oauth-protected-resource/mcp`
 - `https://mcp.jurisdigta.eu/.well-known/oauth-authorization-server`
-- `https://mcp.jurisdigta.eu/.well-known/oauth-authorization-server/MCP`
+- `https://mcp.jurisdigta.eu/.well-known/oauth-authorization-server/mcp`
 - `https://mcp.jurisdigta.eu/oauth/register`
 
 Client documentation:

--- a/docs/manual_infrastucture_setup.md
+++ b/docs/manual_infrastucture_setup.md
@@ -423,7 +423,7 @@ The self-managed production deployment script performs the Ollama install, priva
 - Optional Grafana default dashboard setting: `GRAFANA_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/jurisdigta-application-performance.json`.
 - Cloudflare Tunnel service: `cloudflared.service` on `jurisdigta-server`.
 - Cloudflare Tunnel API hostname: `api.jurisdigta.eu` -> `http://127.0.0.1:8080`.
-- Cloudflare Tunnel MCP hostname: `mcp.jurisdigta.eu` -> `http://127.0.0.1:8070`, with MCP served by the dedicated MCP service at `/MCP`.
+- Cloudflare Tunnel MCP hostname: `mcp.jurisdigta.eu` -> `http://127.0.0.1:8070`, with MCP served by the dedicated MCP service at `/mcp`.
 - Cloudflare Tunnel admin hostname: `admin.jurisdigta.eu` -> `http://127.0.0.1:3000`, with Grafana served at `/grafana/`.
 - Cloudflare Tunnel web hostname: `web.jurisdigta.eu` -> `http://127.0.0.1:8090` only after the `jurisdigta-web` frontend container serves the intended web app.
 - Cloudflare Tunnel assistant hostname: `agent.jurisdigta.eu` -> `http://127.0.0.1:8090`, with JurisDigta account login required before legal users access `/app/assistant`.
@@ -449,7 +449,7 @@ The self-managed production deployment script performs the Ollama install, priva
 - API health check returns HTTP 200 at `http://127.0.0.1:8080/health`.
 - Admin model route check with both API keys returns the seeded `local_ollama_default` and `azure_foundry_gpt_4o_mini` profiles, and credential reads are redacted unless `reveal=true` is used by an authorized admin.
 - MCP health check returns HTTP 200 at `http://127.0.0.1:8070/health`.
-- MCP OAuth metadata at `https://mcp.jurisdigta.eu/.well-known/oauth-protected-resource/MCP` advertises `https://mcp.jurisdigta.eu/MCP` as the protected resource.
+- MCP OAuth metadata at `https://mcp.jurisdigta.eu/.well-known/oauth-protected-resource/mcp` advertises `https://mcp.jurisdigta.eu/mcp` as the protected resource.
 - `docker ps --filter name=jurisdigta-court-decision-collector` shows the court-decision collector container running.
 - `tail -n 80 /srv/jurisdigta/runs/logs/court-decision-collector.log` shows `processing_judicial_decision` or `waiting_for_new_judicial_decisions` without raw decision text.
 - `docker exec aijurisdiction-postgres psql -U "${LOCAL_POSTGRES_USER:-postgres}" -d "${COURT_DECISIONS_DATABASE_NAME:-court_decisions_sk}" -c "SELECT count(*) AS versions, count(embedding_vector) AS versions_with_vector FROM court_decision_versions;"` confirms imported court-decision vectors.
@@ -468,7 +468,7 @@ The self-managed production deployment script performs the Ollama install, priva
 - If Prometheus/Grafana monitoring is enabled, `cd /srv/jurisdigta/app && PROMETHEUS_BASE_URL=http://127.0.0.1:9091 python3 examples/monitoring_scrape_demo.py` reports all scrapes and HTTP probes healthy.
 - If Prometheus/Grafana monitoring is enabled, Prometheus queries for `jurisdigta_http_requests_total_window`, `jurisdigta_http_request_duration_seconds_avg`, `jurisdigta_users_total`, `jurisdigta_cases_total`, `jurisdigta_ollama_up`, and `jurisdigta_ai_model_output_tokens_window` return aggregate samples.
 - `systemctl status cloudflared --no-pager` shows the Cloudflare tunnel active when public hostnames are enabled.
-- If Cloudflare Tunnel public hostnames are enabled, `curl -fsS https://api.jurisdigta.eu/health`, `curl -fsS https://agent.jurisdigta.eu/health`, `curl -I https://agent.jurisdigta.eu/app/assistant`, `curl -I https://mcp.jurisdigta.eu/.well-known/oauth-protected-resource/MCP`, and `curl -I https://admin.jurisdigta.eu/grafana/` succeed from outside the server.
+- If Cloudflare Tunnel public hostnames are enabled, `curl -fsS https://api.jurisdigta.eu/health`, `curl -fsS https://agent.jurisdigta.eu/health`, `curl -I https://agent.jurisdigta.eu/app/assistant`, `curl -I https://mcp.jurisdigta.eu/.well-known/oauth-protected-resource/mcp`, and `curl -I https://admin.jurisdigta.eu/grafana/` succeed from outside the server.
 - If the frontend web container is enabled, `curl -fsS http://127.0.0.1:8090/health` and `curl -I http://127.0.0.1:8090/privacy` succeed on the server.
 - GitHub Actions workflow `Self-Managed Prod Deploy` completes for `repo_ref=main` only after the frontend Playwright E2E gate passes.
 - Cloudflare Access protects `agent.jurisdigta.eu` and `admin.jurisdigta.eu` before public use.

--- a/examples/mcp_laws_server_demo.py
+++ b/examples/mcp_laws_server_demo.py
@@ -35,7 +35,7 @@ def mcp_call(tool_name: str, arguments: dict[str, object] | None = None) -> dict
         "params": {"name": tool_name, "arguments": arguments or {}},
     }
     req = request.Request(
-        url=f"{BASE_URL}/MCP",
+        url=f"{BASE_URL}/mcp",
         data=json.dumps(payload).encode("utf-8"),
         method="POST",
         headers=headers,

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -29,8 +29,9 @@ print(
 )
 print(
     "mcp_auth_contract => getVersion/getStatistics are public; searchLaws/getLawText require "
-    "a Bearer MCP token or x-mcp-api-key, and Claude OAuth discovery remains visible to local proxies."
+    "a Bearer MCP token or x-mcp-api-key, and Claude should use https://mcp.jurisdigta.eu/mcp."
 )
+print("mcp_endpoint_legacy => /MCP remains accepted as a compatibility alias for existing clients.")
 print(
     "mcp_oauth_redirects => hosted callbacks use explicit allowed hosts; local MCP clients keep "
     "http://localhost, http://127.0.0.1, and http://[::1] loopback redirect_uri support."

--- a/scripts/prod_mcp_claude_smoke.py
+++ b/scripts/prod_mcp_claude_smoke.py
@@ -91,18 +91,18 @@ def check_health(base_url: str) -> str:
 
 
 def check_protected_resource(base_url: str) -> str:
-    payload = request_json("GET", f"{base_url}/.well-known/oauth-protected-resource/MCP")
+    payload = request_json("GET", f"{base_url}/.well-known/oauth-protected-resource/mcp")
     assert_equal(payload.get("resource_name"), "JurisDigta MCP", "resource_name")
     assert_equal(payload.get("authorization_servers"), [base_url], "authorization_servers")
     assert_equal(payload.get("scopes_supported"), ["mcp:laws"], "scopes_supported")
     resource = str(payload.get("resource") or "")
-    if resource != f"{base_url}/MCP":
+    if resource != f"{base_url}/mcp":
         raise AssertionError(f"Unexpected protected resource URL: {resource!r}")
     return "OAuth protected resource metadata is advertised"
 
 
 def check_authorization_server(base_url: str) -> str:
-    for path in ("/.well-known/oauth-authorization-server", "/.well-known/oauth-authorization-server/MCP"):
+    for path in ("/.well-known/oauth-authorization-server", "/.well-known/oauth-authorization-server/mcp"):
         payload = request_json("GET", f"{base_url}{path}")
         assert_equal(payload.get("issuer"), base_url, f"{path}.issuer")
         assert_equal(payload.get("authorization_endpoint"), f"{base_url}/oauth/authorize", "authorization_endpoint")
@@ -114,7 +114,7 @@ def check_authorization_server(base_url: str) -> str:
         methods = set(payload.get("token_endpoint_auth_methods_supported") or [])
         if "none" not in methods:
             raise AssertionError(f"Authorization server must support public OAuth clients, got {sorted(methods)}")
-    return "OAuth authorization metadata is advertised for root and /MCP"
+    return "OAuth authorization metadata is advertised for root and /mcp"
 
 
 def check_claude_registration(base_url: str) -> str:
@@ -193,7 +193,7 @@ def check_public_tool_call(base_url: str) -> str:
 def check_auth_challenge(base_url: str) -> str:
     response = request(
         "POST",
-        f"{base_url}/MCP",
+        f"{base_url}/mcp",
         {
             "jsonrpc": "2.0",
             "id": 4,
@@ -213,7 +213,7 @@ def check_auth_challenge(base_url: str) -> str:
 
 
 def check_auth_pages(base_url: str) -> str:
-    for path, marker in (("/MCP/login", "form"), ("/MCP/sign-up", "form")):
+    for path, marker in (("/mcp/login", "form"), ("/mcp/sign-up", "form")):
         response = request("GET", f"{base_url}{path}")
         text = response.body.decode("utf-8", errors="replace").lower()
         if marker not in text:
@@ -224,7 +224,7 @@ def check_auth_pages(base_url: str) -> str:
 def mcp_rpc(base_url: str, request_id: int, method: str, params: dict[str, Any]) -> dict[str, Any]:
     payload = request_json(
         "POST",
-        f"{base_url}/MCP",
+        f"{base_url}/mcp",
         {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params},
         extra_headers=mcp_headers(),
     )


### PR DESCRIPTION
## Summary
- make `https://mcp.jurisdigta.eu/mcp` the canonical MCP endpoint and OAuth protected resource audience
- keep `/MCP` and `/MC` as compatibility aliases for existing clients and old uppercase-audience tokens
- update MCP setup page, Claude smoke script, internal MCP law context, docs, workflow summary, examples, and static website URL
- bump API revision to `1.0.260493`

## Compliance
- GDPR/EU AI Act review: endpoint canonicalization only; no new personal data processing, consent flow, retention policy, or legal-output automation behavior.
- Existing authentication, OTP, PKCE, OAuth scopes, audience binding, token expiry/revocation, and privacy-safe MCP logging remain in place.

## Validation
- `python -m pytest tests/test_mcp_api.py tests/test_mcp_service.py` from `api/aijuristiction-api` -> 38 passed
- `python -m ruff check app tests` from `api/aijuristiction-api`
- `python -m mypy app` from `api/aijuristiction-api`
- `./scripts/validate_api.ps1`
- `python -m pytest api/aijuristiction-api/tests` -> 338 passed
- `python examples/minimal_demo.py`

## Note
- Fresh conda creation through `scripts/new_task_worktree.ps1` failed on local SSL certificate verification while fetching conda metadata, so validation used the available Python 3.13.5 runtime.