### PR TITLE
[codex] Add laws collector Grafana law count panels

### DIFF
--- a/Deployment/monitoring/README.md
+++ b/Deployment/monitoring/README.md
@@ -15,7 +15,7 @@ GET /v1/system/status?minutes=60
 - Aggregate user and case totals plus new users/cases in one-hour and 24-hour windows from PostgreSQL counts.
 - API/database/LLM/system/email scheduler/document processor/laws collector status through `scripts/server/export_system_status_metrics.py`.
 - Error counts for API, laws collector, and PostgreSQL from the status endpoint.
-- Last processed law, next law to check, latest laws collector run timestamps, and latest run duration.
+- Total imported laws over time, last imported law number/year, next law to check, latest laws collector run timestamps, and latest run duration.
 - Email sent counts, email queue counts, and aggregate email send duration from the outbox.
 - Document processor queue counts, processed document counts, latest run duration, and aggregate processing duration.
 - Court-decision collector status, imported decision/version counts, embedding-vector coverage, worker activity counts, activity timestamps, and sanitized recent errors.
@@ -517,7 +517,7 @@ Grafana loads JurisDigta dashboards from `grafana/dashboards` into the
 - `JurisDigta Server Performance`: CPU, RAM, disk, load, network, disk I/O, and container memory.
 - `JurisDigta Application Performance`: API/MCP/web/Grafana HTTP probes, component status, email queue/sent/time, document queue/processed/time, laws processing cursor and runtime, and application error counts.
 - `JurisDigta Ollama And AI Models`: Ollama API health, configured model presence, installed/running model counts, model size, loaded model VRAM, probe latency, local/Ollama tokens, paid-model tokens, requests, estimated cost, and masked top cases by token volume.
-- `JurisDigta Laws Collector`: execution time, imported laws per latest run, processed entries/documents, and recent sanitized collector errors.
+- `JurisDigta Laws Collector`: total imported laws over time, latest imported law number/year, execution time, imported laws per latest run, processed entries/documents, and recent sanitized collector errors.
 - `JurisDigta Court Decision Service`: collector status, imported decisions, stored versions, versions with embeddings, processing/processed/idle activity, storage totals, and recent sanitized collector errors.
 - `JurisDigta Errors`: total errors, error telemetry status, error counts by source, HTTP probe status codes, and scrape target health.
 - `JurisDigta System Logs`: Loki log stream with source, severity, stream, and regex search filters for Docker container logs and server job log files.
@@ -553,6 +553,7 @@ Useful starter queries:
 - `jurisdigta_errors_window`
 - `jurisdigta_laws_last_processed_number`
 - `jurisdigta_laws_last_processed_year`
+- `jurisdigta_laws_total{name="laws_imported"}`
 - `jurisdigta_laws_next_number`
 - `jurisdigta_laws_runtime_last_run_started_at_timestamp_seconds`
 - `jurisdigta_laws_runtime_last_run_finished_at_timestamp_seconds`

--- a/Deployment/monitoring/grafana/dashboards/jurisdigta-laws-collector.json
+++ b/Deployment/monitoring/grafana/dashboards/jurisdigta-laws-collector.json
@@ -298,6 +298,222 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "jurisdigta_laws_total{name=\"laws_imported\"}",
+          "legendFormat": "Total imported laws",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Laws Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "jurisdigta-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 7
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "jurisdigta_laws_last_processed_number",
+          "legendFormat": "Law number",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Last Imported Law Number",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "jurisdigta-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 7
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "jurisdigta_laws_last_processed_year",
+          "legendFormat": "Law year",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Last Imported Law Year",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "jurisdigta-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
             "fillOpacity": 8,
             "gradientMode": "none",
             "hideFrom": {
@@ -340,7 +556,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 7
+        "y": 16
       },
       "id": 5,
       "options": {
@@ -430,7 +646,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 7
+        "y": 16
       },
       "id": 6,
       "options": {
@@ -508,7 +724,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 25
       },
       "id": 7,
       "options": {
@@ -578,5 +794,5 @@
   "timezone": "browser",
   "title": "JurisDigta Laws Collector",
   "uid": "jurisdigta-laws-collector",
-  "version": 1
+  "version": 2
 }

--- a/docs/SYSTEM_STATUS_MONITORING.md
+++ b/docs/SYSTEM_STATUS_MONITORING.md
@@ -14,7 +14,7 @@ The endpoint returns safe operational status only:
 
 - API health, API version, core system version, database status, and LLM provider status.
 - Host status from `jurisdigta-server`: disk, memory, Git commit, Docker container state.
-- Laws collector status: last collector run, last processed law, next law to check, import state, totals, latest run duration.
+- Laws collector status: total imported laws over time, last imported law number/year, next law to check, import state, totals, latest run duration.
 - Error counts by application for the requested time window.
 
 The endpoint requires the existing `x-api-key` header.
@@ -245,6 +245,8 @@ Useful Grafana panels:
 - `jurisdigta_component_status{component="laws_collector"}`
 - `jurisdigta_errors_window`
 - `jurisdigta_laws_last_processed_number`
+- `jurisdigta_laws_last_processed_year`
+- `jurisdigta_laws_total{name="laws_imported"}`
 - `jurisdigta_laws_next_number`
 - `jurisdigta_laws_runtime_last_run_started_at_timestamp_seconds`
 - `jurisdigta_laws_runtime_last_run_finished_at_timestamp_seconds`

--- a/examples/monitoring_scrape_demo.py
+++ b/examples/monitoring_scrape_demo.py
@@ -50,6 +50,9 @@ def main() -> int:
             "jurisdigta_ollama_up",
             "jurisdigta_ai_model_total_tokens_window",
             "jurisdigta_ai_model_top_case_total_tokens_window",
+            'jurisdigta_laws_total{name="laws_imported"}',
+            "jurisdigta_laws_last_processed_number",
+            "jurisdigta_laws_last_processed_year",
             "jurisdigta_component_status{component=\"court_decision_collector\"}",
             "jurisdigta_court_decisions_total",
         )
@@ -86,7 +89,8 @@ def main() -> int:
 
     print(
         "Monitoring validation passed: Prometheus scrapes, JurisDigta HTTP probes, "
-        "AI token metrics, court-decision metrics, and AI model alert rules are healthy."
+        "AI token metrics, laws collector metrics, court-decision metrics, "
+        "and AI model alert rules are healthy."
     )
     return 0
 

--- a/tests/test_server_monitoring.py
+++ b/tests/test_server_monitoring.py
@@ -86,6 +86,26 @@ def test_monitoring_dashboards_include_court_decision_service_dashboard() -> Non
     assert "Recent Sanitized Error List" in panel_titles
 
 
+def test_monitoring_dashboards_include_laws_collector_corpus_panels() -> None:
+    dashboard_path = MONITORING_DIR / "grafana" / "dashboards" / "jurisdigta-laws-collector.json"
+    dashboard = json.loads(dashboard_path.read_text(encoding="utf-8"))
+    panel_titles = {str(panel.get("title")) for panel in dashboard["panels"]}
+    target_queries = {
+        str(target.get("expr"))
+        for panel in dashboard["panels"]
+        for target in panel.get("targets", [])
+        if isinstance(target, dict)
+    }
+
+    assert dashboard["uid"] == "jurisdigta-laws-collector"
+    assert "Total Laws Over Time" in panel_titles
+    assert "Last Imported Law Number" in panel_titles
+    assert "Last Imported Law Year" in panel_titles
+    assert 'jurisdigta_laws_total{name="laws_imported"}' in target_queries
+    assert "jurisdigta_laws_last_processed_number" in target_queries
+    assert "jurisdigta_laws_last_processed_year" in target_queries
+
+
 def test_monitoring_stack_loads_ai_model_alert_rules() -> None:
     compose = (MONITORING_DIR / "docker-compose.yml").read_text(encoding="utf-8")
     prometheus_config = (MONITORING_DIR / "prometheus.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add cumulative laws imported over time panel to the JurisDigta Laws Collector dashboard
- add latest imported law number and year stat panels
- update monitoring docs, validation demo, and dashboard regression test

## Validation
- python -m pytest tests\\test_server_monitoring.py
- python -m json.tool Deployment\\monitoring\\grafana\\dashboards\\jurisdigta-laws-collector.json
- git diff --check