### PR TITLE
Add MCP OAuth diagnostic logs

### DIFF
--- a/api/aijuristiction-api/app/mcp_api.py
+++ b/api/aijuristiction-api/app/mcp_api.py
@@ -257,6 +257,12 @@ async def mcp_json_rpc(
     request_id = getattr(request.state, "request_id", None)
     correlation_id = getattr(request.state, "correlation_id", None)
     logger.info(
+        "mcp_endpoint_called request_path=%s canonical_resource=%s user_agent=%s",
+        request.url.path,
+        _resource_url(request),
+        _oauth_user_agent_family(request),
+    )
+    logger.info(
         "mcp_json_rpc_received request_id=%s correlation_id=%s batch=%s message_count=%d methods=%s",
         request_id,
         correlation_id,
@@ -321,6 +327,13 @@ def mcp_sign_up_page(request: Request) -> HTMLResponse:
 def oauth_protected_resource_metadata(request: Request) -> dict[str, Any]:
     base_url = _base_url(request)
     resource = _resource_url(request)
+    logger.info(
+        "mcp_oauth_protected_resource_metadata_served request_path=%s resource=%s authorization_server=%s user_agent=%s",
+        request.url.path,
+        resource,
+        base_url,
+        _oauth_user_agent_family(request),
+    )
     return {
         "resource": resource,
         "resource_name": "JurisDigta MCP",
@@ -342,6 +355,14 @@ def oauth_mcp_protected_resource_metadata(request: Request) -> dict[str, Any]:
 @oauth_router.get("/.well-known/oauth-authorization-server/mcp")
 def oauth_authorization_server_metadata(request: Request) -> dict[str, Any]:
     base_url = _base_url(request)
+    resource = _resource_url(request)
+    logger.info(
+        "mcp_oauth_authorization_server_metadata_served request_path=%s issuer=%s protected_resource=%s user_agent=%s",
+        request.url.path,
+        base_url,
+        resource,
+        _oauth_user_agent_family(request),
+    )
     return {
         "issuer": base_url,
         "authorization_endpoint": f"{base_url}/oauth/authorize",
@@ -354,7 +375,7 @@ def oauth_authorization_server_metadata(request: Request) -> dict[str, Any]:
         "scopes_supported": [MCP_TOKEN_SCOPE, MCP_REFRESH_TOKEN_SCOPE],
         "client_id_metadata_document_supported": True,
         "authorization_response_iss_parameter_supported": _oauth_authorization_response_iss_enabled(),
-        "protected_resources": [_resource_url(request)],
+        "protected_resources": [resource],
     }
 
 
@@ -421,16 +442,59 @@ def oauth_authorize_page(
     code_challenge_method: str,
     state: str = "",
     resource: str = "",
+    scope: str = "",
+    prompt: str = "",
 ) -> HTMLResponse:
     resolved_resource = _resolve_oauth_resource(request=request, resource=resource)
-    _validate_oauth_authorize_request(
-        response_type=response_type,
-        client_id=client_id,
-        redirect_uri=redirect_uri,
-        code_challenge=code_challenge,
-        code_challenge_method=code_challenge_method,
-        resource=resolved_resource,
-        expected_resource=_resource_url(request),
+    expected_resource = _resource_url(request)
+    logger.info(
+        "mcp_oauth_authorize_started response_type=%s client_id_hash=%s client_id_host=%s client_id_path=%s "
+        "redirect_host=%s redirect_path=%s requested_scope=%s prompt=%s resource_supplied=%s "
+        "resolved_resource=%s expected_resource=%s user_agent=%s",
+        response_type,
+        _stable_hash(client_id),
+        _url_host(client_id),
+        _url_path(client_id),
+        _url_host(redirect_uri),
+        _url_path(redirect_uri),
+        _oauth_scope_summary(scope),
+        prompt,
+        bool(resource.strip()),
+        resolved_resource,
+        expected_resource,
+        _oauth_user_agent_family(request),
+    )
+    try:
+        _validate_oauth_authorize_request(
+            response_type=response_type,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            code_challenge=code_challenge,
+            code_challenge_method=code_challenge_method,
+            resource=resolved_resource,
+            expected_resource=expected_resource,
+        )
+    except HTTPException as exc:
+        logger.warning(
+            "mcp_oauth_authorize_failed reason=validation_error detail=%s client_id_hash=%s "
+            "redirect_host=%s redirect_path=%s resolved_resource=%s expected_resource=%s user_agent=%s",
+            _http_exception_detail(exc),
+            _stable_hash(client_id),
+            _url_host(redirect_uri),
+            _url_path(redirect_uri),
+            resolved_resource,
+            expected_resource,
+            _oauth_user_agent_family(request),
+        )
+        raise
+    logger.info(
+        "mcp_oauth_authorize_succeeded client_id_hash=%s redirect_host=%s redirect_path=%s "
+        "resolved_resource=%s user_agent=%s",
+        _stable_hash(client_id),
+        _url_host(redirect_uri),
+        _url_path(redirect_uri),
+        resolved_resource,
+        _oauth_user_agent_family(request),
     )
     return HTMLResponse(
         _oauth_login_form_html(
@@ -650,30 +714,96 @@ def oauth_token(
     refresh_token: str = Form(""),
     store: ApiDatabaseStore = Depends(get_user_store),
 ) -> JSONResponse:
+    logger.info(
+        "mcp_oauth_token_started grant_type=%s client_id_hash=%s client_id_host=%s client_id_path=%s "
+        "redirect_host=%s redirect_path=%s resource_supplied=%s requested_resource=%s user_agent=%s",
+        grant_type,
+        _stable_hash(client_id),
+        _url_host(client_id),
+        _url_path(client_id),
+        _url_host(redirect_uri),
+        _url_path(redirect_uri),
+        bool(resource.strip()),
+        _redacted_if_blank(resource),
+        _oauth_user_agent_family(request),
+    )
     if grant_type == "refresh_token":
         return _oauth_refresh_token_response(
             request=request,
             refresh_token=refresh_token,
+            client_id=client_id,
             resource=resource,
             store=store,
         )
     if grant_type != "authorization_code":
+        _log_oauth_token_failed(
+            reason="unsupported_grant_type",
+            grant_type=grant_type,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            resource=resource,
+            request=request,
+        )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported grant_type")
     if not code or not redirect_uri or not code_verifier:
+        _log_oauth_token_failed(
+            reason="missing_authorization_code_parameters",
+            grant_type=grant_type,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            resource=resource,
+            request=request,
+        )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing authorization code parameters")
     record = store.consume_mcp_oauth_authorization_code(code=code)
     if record is None:
+        _log_oauth_token_failed(
+            reason="invalid_authorization_code",
+            grant_type=grant_type,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            resource=resource,
+            request=request,
+        )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid authorization code")
     if record["client_id"] != client_id or record["redirect_uri"] != redirect_uri:
+        _log_oauth_token_failed(
+            reason="authorization_code_context_mismatch",
+            grant_type=grant_type,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            resource=resource,
+            request=request,
+            record_resource=str(record["resource"]),
+        )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Authorization code context mismatch")
     resolved_resource = _resolve_oauth_resource(request=request, resource=resource)
     if not _is_mcp_resource_match(request=request, resource=record["resource"]) or not _is_mcp_resource_match(
         request=request,
         resource=resolved_resource,
     ):
+        _log_oauth_token_failed(
+            reason="resource_mismatch",
+            grant_type=grant_type,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            resource=resolved_resource,
+            request=request,
+            record_resource=str(record["resource"]),
+        )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="OAuth resource mismatch")
     token_audience = resolved_resource if resource.strip() else str(record["resource"])
     if _pkce_s256_challenge(code_verifier) != record["code_challenge"]:
+        _log_oauth_token_failed(
+            reason="invalid_pkce_verifier",
+            grant_type=grant_type,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            resource=resolved_resource,
+            request=request,
+            record_resource=str(record["resource"]),
+            token_audience=token_audience,
+        )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid PKCE code verifier")
     user = store.get_user(user_id=record["user_id"])
     token, expires_at = _issue_mcp_api_key(
@@ -684,6 +814,23 @@ def oauth_token(
     )
     refresh_token_value, _ = _issue_mcp_refresh_token(user=user, audience=token_audience)
     expires_in = max(1, int((datetime.fromisoformat(expires_at) - datetime.now(timezone.utc)).total_seconds()))
+    logger.info(
+        "mcp_oauth_token_succeeded grant_type=%s client_id_hash=%s redirect_host=%s redirect_path=%s "
+        "resource_supplied=%s record_resource=%s token_audience=%s access_scope=%s refresh_scope=%s "
+        "expires_in=%d user_id=%s user_agent=%s",
+        grant_type,
+        _stable_hash(client_id),
+        _url_host(redirect_uri),
+        _url_path(redirect_uri),
+        bool(resource.strip()),
+        str(record["resource"]),
+        token_audience,
+        MCP_TOKEN_SCOPE,
+        MCP_REFRESH_TOKEN_SCOPE,
+        expires_in,
+        user.user_id,
+        _oauth_user_agent_family(request),
+    )
     return _oauth_token_json_response(
         {
             "access_token": token,
@@ -699,13 +846,28 @@ def _oauth_refresh_token_response(
     *,
     request: Request,
     refresh_token: str,
+    client_id: str,
     resource: str,
     store: ApiDatabaseStore,
 ) -> JSONResponse:
     if not refresh_token:
+        _log_oauth_token_failed(
+            reason="missing_refresh_token",
+            grant_type="refresh_token",
+            client_id=client_id,
+            resource=resource,
+            request=request,
+        )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing refresh_token")
     resolved_resource = _resolve_oauth_resource(request=request, resource=resource)
     if not _is_mcp_resource_match(request=request, resource=resolved_resource):
+        _log_oauth_token_failed(
+            reason="refresh_resource_mismatch",
+            grant_type="refresh_token",
+            client_id=client_id,
+            resource=resolved_resource,
+            request=request,
+        )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="OAuth resource mismatch")
     payload = validate_mcp_refresh_token(refresh_token, audience=resolved_resource)
     if payload is None:
@@ -713,9 +875,24 @@ def _oauth_refresh_token_response(
         if canonical_resource != resolved_resource:
             payload = validate_mcp_refresh_token(refresh_token, audience=canonical_resource)
     if payload is None:
+        _log_oauth_token_failed(
+            reason="invalid_refresh_token",
+            grant_type="refresh_token",
+            client_id=client_id,
+            resource=resolved_resource,
+            request=request,
+        )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid refresh_token")
     user = store.find_user_by_id(user_id=str(payload["sub"]))
     if user is None or not user.mcp_api_key_hash:
+        _log_oauth_token_failed(
+            reason="mcp_access_revoked",
+            grant_type="refresh_token",
+            client_id=client_id,
+            resource=resolved_resource,
+            request=request,
+            token_audience=str(payload.get("aud") or ""),
+        )
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="MCP access revoked")
     token, expires_at = _issue_mcp_api_key(
         store=store,
@@ -725,6 +902,18 @@ def _oauth_refresh_token_response(
     )
     refresh_token_value, _ = _issue_mcp_refresh_token(user=user, audience=resolved_resource)
     expires_in = max(1, int((datetime.fromisoformat(expires_at) - datetime.now(timezone.utc)).total_seconds()))
+    logger.info(
+        "mcp_oauth_token_succeeded grant_type=refresh_token client_id_hash=%s resource_supplied=%s "
+        "token_audience=%s access_scope=%s refresh_scope=%s expires_in=%d user_id=%s user_agent=%s",
+        _stable_hash(client_id),
+        bool(resource.strip()),
+        resolved_resource,
+        MCP_TOKEN_SCOPE,
+        MCP_REFRESH_TOKEN_SCOPE,
+        expires_in,
+        user.user_id,
+        _oauth_user_agent_family(request),
+    )
     return _oauth_token_json_response(
         {
             "access_token": token,
@@ -1916,6 +2105,7 @@ def _authenticate_mcp_api_token(*, api_key: str, store: ApiDatabaseStore) -> Use
         audience=expected_audience,
         required_scope=MCP_TOKEN_SCOPE,
     )
+    legacy_audience = ""
     if payload is None and expected_audience.lower().endswith("/mcp"):
         legacy_audience = f"{expected_audience[:-4]}/MCP"
         payload = validate_mcp_api_token(
@@ -1926,7 +2116,11 @@ def _authenticate_mcp_api_token(*, api_key: str, store: ApiDatabaseStore) -> Use
     if payload is None:
         user = store.find_user_by_mcp_api_key(api_key=api_key)
         if user is None:
-            logger.warning("mcp_auth_failed reason=invalid_or_expired_token")
+            logger.warning(
+                "mcp_auth_failed reason=invalid_or_expired_token expected_audience=%s legacy_audience=%s",
+                expected_audience,
+                legacy_audience,
+            )
             raise HTTPException(status_code=401, detail="Invalid or expired MCP API key")
         logger.info("mcp_auth_succeeded token_type=opaque user_id=%s", user.user_id)
         return user
@@ -1940,6 +2134,12 @@ def _authenticate_mcp_api_token(*, api_key: str, store: ApiDatabaseStore) -> Use
     if not user.mcp_api_key_hash:
         logger.warning("mcp_auth_failed reason=mcp_access_revoked user_id=%s", user.user_id)
         raise HTTPException(status_code=401, detail="Invalid or expired MCP API key")
+    logger.info(
+        "mcp_auth_succeeded token_type=jwt user_id=%s token_audience=%s token_scope=%s",
+        user.user_id,
+        payload.get("aud"),
+        payload.get("scope"),
+    )
     return user
 
 
@@ -2332,6 +2532,71 @@ def _value_type(value: Any) -> str:
     if isinstance(value, str):
         return "str"
     return type(value).__name__
+
+
+def _url_host(value: str) -> str:
+    parsed = urlparse(value)
+    return (parsed.hostname or "").lower()
+
+
+def _url_path(value: str) -> str:
+    return urlparse(value).path or ""
+
+
+def _oauth_scope_summary(scope: str) -> str:
+    values = sorted({item for item in scope.split() if item})
+    return ",".join(values)
+
+
+def _oauth_user_agent_family(request: Request) -> str:
+    user_agent = request.headers.get("user-agent", "").lower()
+    if "python-httpx" in user_agent:
+        return "python-httpx"
+    if "claude" in user_agent:
+        return "claude"
+    if "mozilla" in user_agent or "chrome" in user_agent or "safari" in user_agent:
+        return "browser"
+    return "unknown"
+
+
+def _http_exception_detail(exc: HTTPException) -> str:
+    if isinstance(exc.detail, str):
+        return exc.detail
+    return _value_type(exc.detail)
+
+
+def _redacted_if_blank(value: str) -> str:
+    return value.strip() or "<not_supplied>"
+
+
+def _log_oauth_token_failed(
+    *,
+    reason: str,
+    grant_type: str,
+    client_id: str,
+    request: Request,
+    redirect_uri: str = "",
+    resource: str = "",
+    record_resource: str = "",
+    token_audience: str = "",
+) -> None:
+    logger.warning(
+        "mcp_oauth_token_failed reason=%s grant_type=%s client_id_hash=%s client_id_host=%s client_id_path=%s "
+        "redirect_host=%s redirect_path=%s resource_supplied=%s requested_resource=%s record_resource=%s "
+        "token_audience=%s user_agent=%s",
+        reason,
+        grant_type,
+        _stable_hash(client_id),
+        _url_host(client_id),
+        _url_path(client_id),
+        _url_host(redirect_uri),
+        _url_path(redirect_uri),
+        bool(resource.strip()),
+        _redacted_if_blank(resource),
+        _redacted_if_blank(record_resource),
+        _redacted_if_blank(token_audience),
+        _oauth_user_agent_family(request),
+    )
 
 
 def _stable_hash(value: str) -> str:

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260493"
+version = "1.0.260494"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_mcp_api.py
+++ b/api/aijuristiction-api/tests/test_mcp_api.py
@@ -80,7 +80,9 @@ def test_mcp_accepts_mc_path_compatibility_alias_for_claude_connector_typo() -> 
     assert "Use JurisDigta as the source of truth" in payload["result"]["instructions"]
 
 
-def test_mcp_accepts_legacy_uppercase_path_compatibility_alias() -> None:
+def test_mcp_accepts_legacy_uppercase_path_compatibility_alias(monkeypatch, tmp_path: Path, caplog) -> None:
+    _configure_env(monkeypatch, tmp_path)
+    caplog.set_level(logging.INFO, logger="aijuristiction-api.mcp")
     initialize_response = mcp_client.post(
         "/MCP",
         json={
@@ -97,6 +99,13 @@ def test_mcp_accepts_legacy_uppercase_path_compatibility_alias() -> None:
 
     assert initialize_response.status_code == 200
     assert initialize_response.json()["result"]["serverInfo"]["name"] == "aijurisdiction-laws-mcp"
+    mcp_messages = [
+        record.getMessage() for record in caplog.records if record.name == "aijuristiction-api.mcp"
+    ]
+    assert any(
+        "mcp_endpoint_called request_path=/MCP canonical_resource=https://mcp.jurisdigta.eu/mcp" in message
+        for message in mcp_messages
+    )
 
 
 def test_mcp_accepts_claude_backend_probe_without_bearer_token() -> None:
@@ -880,9 +889,10 @@ def test_mcp_sign_up_invalid_otp_returns_localized_html_warning(monkeypatch, tmp
     assert 'name="email" type="hidden" value="mcp-new-warning@example.com"' in verify_response.text
 
 
-def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path) -> None:
+def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path, caplog) -> None:
     _configure_env(monkeypatch, tmp_path)
     _create_laws_db(tmp_path / "laws.sqlite3")
+    caplog.set_level(logging.INFO, logger="aijuristiction-api.mcp")
     monkeypatch.setenv("LOCAL_AUTH_ACCEPT_ANY_CODE", "true")
     sign_up_response = api_client.post(
         "/v1/users/sign-up",
@@ -1166,6 +1176,26 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
     )
     assert existing_oauth_search.status_code == 200
     assert _tool_payload(existing_oauth_search)["results"][0]["document_id"] == "doc-1"
+
+    mcp_log_text = "\n".join(
+        record.getMessage() for record in caplog.records if record.name == "aijuristiction-api.mcp"
+    )
+    assert "mcp_oauth_protected_resource_metadata_served" in mcp_log_text
+    assert "mcp_oauth_authorization_server_metadata_served" in mcp_log_text
+    assert "mcp_oauth_authorize_started" in mcp_log_text
+    assert "mcp_oauth_authorize_succeeded" in mcp_log_text
+    assert "mcp_oauth_token_started grant_type=authorization_code" in mcp_log_text
+    assert "mcp_oauth_token_succeeded grant_type=authorization_code" in mcp_log_text
+    assert "mcp_oauth_token_succeeded grant_type=refresh_token" in mcp_log_text
+    assert "redirect_host=client.example redirect_path=/callback" in mcp_log_text
+    assert "token_audience=https://mcp.jurisdigta.eu/mcp" in mcp_log_text
+    assert "mcp_auth_succeeded token_type=jwt" in mcp_log_text
+    assert "secret-pass" not in mcp_log_text
+    assert "mcp-oauth@example.com" not in mcp_log_text
+    assert code_verifier not in mcp_log_text
+    assert authorization_code not in mcp_log_text
+    assert token_payload["access_token"] not in mcp_log_text
+    assert token_payload["refresh_token"] not in mcp_log_text
 
 
 def test_oauth_authorization_response_issuer_can_be_enabled(monkeypatch, tmp_path: Path) -> None:

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -250,6 +250,19 @@ For protected tools, send the MCP API key as a Bearer token or `x-mcp-api-key` h
 MCP server logs use the `jurisdigta-mcp-server.http` and `aijuristiction-api.mcp` loggers with the shared `API_LOG_LEVEL` or `LOG_LEVEL` setting.
 Each JSON-RPC request logs request and correlation IDs from `x-request-id` and `x-correlation-id`, batch/message counts, method names, HTTP status, and request duration.
 Tool calls log stable event names such as `mcp_tool_started`, `mcp_tool_completed`, `mcp_tool_auth_failed`, and `mcp_laws_db_session_failed`.
+OAuth connector diagnostics log stable event names such as
+`mcp_oauth_protected_resource_metadata_served`,
+`mcp_oauth_authorization_server_metadata_served`,
+`mcp_oauth_authorize_started`, `mcp_oauth_authorize_succeeded`,
+`mcp_oauth_authorize_failed`, `mcp_oauth_token_started`,
+`mcp_oauth_token_succeeded`, and `mcp_oauth_token_failed`.
+These records include the request path, redirect host/path, client id hash,
+whether a `resource` parameter was supplied, the resolved resource, stored
+authorization-code resource, token audience, scopes, and user-agent family so
+Claude-style connector failures can be correlated without exposing credentials.
+MCP endpoint entry logs use `mcp_endpoint_called` and include the actual request
+path, which helps distinguish canonical `/mcp` traffic from legacy `/MCP` or
+`/MC` compatibility traffic.
 The HTTP middleware also emits `mcp_wire_request` and `mcp_wire_response`
 records for MCP-service traffic. These records include method, path, redacted
 query string, selected headers, content type, body bytes, and a body preview.
@@ -259,7 +272,7 @@ Set `MCP_WIRE_LOGGING_ENABLED=false` to disable these wire-level records.
 
 Debugging fields are intentionally minimized:
 
-- Logged: tool name, argument keys, country code, limit, query length, result count, content length, database backend, user id after successful authentication, and a short SHA-256 hash for document ids.
+- Logged: tool name, argument keys, country code, limit, query length, result count, content length, database backend, user id after successful authentication, OAuth endpoint path/resource/audience context, redirect host/path, user-agent family, and short SHA-256 hashes for document ids and OAuth client ids.
 - Redacted from wire logs: authorization and cookie headers, MCP API keys,
   OAuth/JWT access and refresh tokens, OAuth authorization codes, PKCE
   verifiers, passwords, OTP verification codes, client secrets, pending ids,

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -41,6 +41,10 @@ print(
     "set MCP_WIRE_LOGGING_ENABLED=false to disable or MCP_WIRE_LOG_MAX_BYTES to adjust preview size."
 )
 print(
+    "mcp_oauth_diagnostic_logs => OAuth metadata, authorize, token, refresh, and endpoint entry "
+    "events log path/resource/audience context without passwords, OTPs, auth codes, PKCE verifiers, or tokens."
+)
+print(
     "case_document_pdf_export => linked generated PDFs export the selected legal-document block only; "
     "assistant chatter, alternate-language blocks, and raw markdown stay out of the PDF."
 )


### PR DESCRIPTION
## Summary
- add privacy-minimized OAuth/MCP diagnostic events for metadata, authorize, token, refresh, endpoint path, and JWT auth outcomes
- document the new MCP troubleshooting events and update the minimal runnable demo
- bump the API revision to 1.0.260494

## Validation
- python -m pytest api/aijuristiction-api/tests/test_mcp_api.py -q
- python -m ruff check app tests
- python -m mypy app
- .\scripts\validate_api.ps1
- python -m pytest api/aijuristiction-api/tests -q
- python examples/minimal_demo.py

## Compliance
- Logs remain privacy-minimized: no OAuth codes, tokens, PKCE verifiers, passwords, OTPs, raw emails, or raw legal content are added.