### PR TITLE
Report MCP OAuth access token scope only

### DIFF
--- a/api/aijuristiction-api/app/mcp_api.py
+++ b/api/aijuristiction-api/app/mcp_api.py
@@ -837,7 +837,7 @@ def oauth_token(
             "refresh_token": refresh_token_value,
             "token_type": "Bearer",
             "expires_in": expires_in,
-            "scope": f"{MCP_TOKEN_SCOPE} {MCP_REFRESH_TOKEN_SCOPE}",
+            "scope": MCP_TOKEN_SCOPE,
         }
     )
 
@@ -920,7 +920,7 @@ def _oauth_refresh_token_response(
             "refresh_token": refresh_token_value,
             "token_type": "Bearer",
             "expires_in": expires_in,
-            "scope": f"{MCP_TOKEN_SCOPE} {MCP_REFRESH_TOKEN_SCOPE}",
+            "scope": MCP_TOKEN_SCOPE,
         }
     )
 

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260494"
+version = "1.0.260495"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_mcp_api.py
+++ b/api/aijuristiction-api/tests/test_mcp_api.py
@@ -1104,7 +1104,7 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
     assert token_response.headers["pragma"] == "no-cache"
     token_payload = token_response.json()
     assert token_payload["token_type"] == "Bearer"
-    assert token_payload["scope"] == "mcp:laws offline_access"
+    assert token_payload["scope"] == "mcp:laws"
     assert token_payload["refresh_token"]
     access_claims = _jwt_claims(token_payload["access_token"])
     assert access_claims["sub"] == sign_up_response.json()["user_id"]
@@ -1152,7 +1152,7 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
     assert refresh_response.headers["pragma"] == "no-cache"
     refreshed_payload = refresh_response.json()
     assert refreshed_payload["token_type"] == "Bearer"
-    assert refreshed_payload["scope"] == "mcp:laws offline_access"
+    assert refreshed_payload["scope"] == "mcp:laws"
     assert refreshed_payload["access_token"] != token_payload["access_token"]
     assert refreshed_payload["refresh_token"] != token_payload["refresh_token"]
     refreshed_access_claims = _jwt_claims(refreshed_payload["access_token"])

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -68,7 +68,10 @@ The browser authorization page validates the user password, sends an email OTP,
 and only creates a short-lived authorization code after OTP verification. The
 token endpoint exchanges that code for the same revocable JWT bearer token
 accepted by `POST /mcp` and a separate audience-bound refresh token. Token
-responses include `Cache-Control: no-store` and `Pragma: no-cache`.
+responses include `Cache-Control: no-store` and `Pragma: no-cache`. Clients may
+request `offline_access` to receive a refresh token, but the token response
+`scope` reports only the access-token scope, `mcp:laws`; the refresh token
+itself carries `offline_access`.
 
 Production settings:
 


### PR DESCRIPTION
## Summary
- change OAuth token and refresh responses to report only the access-token scope (`mcp:laws`)
- keep refresh-token issuance and `offline_access` support intact
- document that `offline_access` belongs to the refresh token, not the MCP access-token scope
- bump API revision to 1.0.260495

## Why
Claude completed authorization and token exchange, then reverted before making an authenticated MCP call. The production diagnostics showed token issuance succeeded, so this removes a likely strict-client scope mismatch: the protected MCP resource supports `mcp:laws`, while the previous token response also echoed `offline_access`.

## Validation
- python -m pytest api/aijuristiction-api/tests/test_mcp_api.py -q
- python -m ruff check app tests
- python -m mypy app
- .\scripts\validate_api.ps1
- python -m pytest api/aijuristiction-api/tests -q
- python examples/minimal_demo.py