### PR TITLE
Fix Claude MCP uppercase resource auth

### DIFF
--- a/api/aijuristiction-api/app/mcp_api.py
+++ b/api/aijuristiction-api/app/mcp_api.py
@@ -326,7 +326,7 @@ def mcp_sign_up_page(request: Request) -> HTMLResponse:
 @oauth_router.get("/.well-known/oauth-protected-resource")
 def oauth_protected_resource_metadata(request: Request) -> dict[str, Any]:
     base_url = _base_url(request)
-    resource = _resource_url(request)
+    resource = _metadata_resource_url(request)
     logger.info(
         "mcp_oauth_protected_resource_metadata_served request_path=%s resource=%s authorization_server=%s user_agent=%s",
         request.url.path,
@@ -355,12 +355,12 @@ def oauth_mcp_protected_resource_metadata(request: Request) -> dict[str, Any]:
 @oauth_router.get("/.well-known/oauth-authorization-server/mcp")
 def oauth_authorization_server_metadata(request: Request) -> dict[str, Any]:
     base_url = _base_url(request)
-    resource = _resource_url(request)
+    protected_resources = _all_mcp_resource_urls(request)
     logger.info(
-        "mcp_oauth_authorization_server_metadata_served request_path=%s issuer=%s protected_resource=%s user_agent=%s",
+        "mcp_oauth_authorization_server_metadata_served request_path=%s issuer=%s protected_resources=%s user_agent=%s",
         request.url.path,
         base_url,
-        resource,
+        ",".join(protected_resources),
         _oauth_user_agent_family(request),
     )
     return {
@@ -375,7 +375,7 @@ def oauth_authorization_server_metadata(request: Request) -> dict[str, Any]:
         "scopes_supported": [MCP_TOKEN_SCOPE, MCP_REFRESH_TOKEN_SCOPE],
         "client_id_metadata_document_supported": True,
         "authorization_response_iss_parameter_supported": _oauth_authorization_response_iss_enabled(),
-        "protected_resources": [resource],
+        "protected_resources": protected_resources,
     }
 
 
@@ -445,7 +445,12 @@ def oauth_authorize_page(
     scope: str = "",
     prompt: str = "",
 ) -> HTMLResponse:
-    resolved_resource = _resolve_oauth_resource(request=request, resource=resource)
+    resolved_resource = _resolve_oauth_resource(
+        request=request,
+        resource=resource,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+    )
     expected_resource = _resource_url(request)
     logger.info(
         "mcp_oauth_authorize_started response_type=%s client_id_hash=%s client_id_host=%s client_id_path=%s "
@@ -525,7 +530,12 @@ def oauth_authorize_login(
     store: ApiDatabaseStore = Depends(get_user_store),
     scheduler: EmailScheduler = Depends(get_email_scheduler),
 ) -> Response:
-    resolved_resource = _resolve_oauth_resource(request=request, resource=resource)
+    resolved_resource = _resolve_oauth_resource(
+        request=request,
+        resource=resource,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+    )
     _validate_oauth_authorize_request(
         response_type=response_type,
         client_id=client_id,
@@ -594,7 +604,12 @@ def oauth_authorize_mfa_method(
     store: ApiDatabaseStore = Depends(get_user_store),
     scheduler: EmailScheduler = Depends(get_email_scheduler),
 ) -> HTMLResponse:
-    resolved_resource = _resolve_oauth_resource(request=request, resource=resource)
+    resolved_resource = _resolve_oauth_resource(
+        request=request,
+        resource=resource,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+    )
     _validate_oauth_authorize_request(
         response_type=response_type,
         client_id=client_id,
@@ -653,7 +668,12 @@ def oauth_authorize_verify(
     state: str = Form(""),
     store: ApiDatabaseStore = Depends(get_user_store),
 ) -> Response:
-    resolved_resource = _resolve_oauth_resource(request=request, resource=resource)
+    resolved_resource = _resolve_oauth_resource(
+        request=request,
+        resource=resource,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+    )
     _validate_oauth_authorize_request(
         response_type=response_type,
         client_id=client_id,
@@ -777,7 +797,12 @@ def oauth_token(
             record_resource=str(record["resource"]),
         )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Authorization code context mismatch")
-    resolved_resource = _resolve_oauth_resource(request=request, resource=resource)
+    resolved_resource = _resolve_oauth_resource(
+        request=request,
+        resource=resource,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+    )
     if not _is_mcp_resource_match(request=request, resource=record["resource"]) or not _is_mcp_resource_match(
         request=request,
         resource=resolved_resource,
@@ -859,7 +884,11 @@ def _oauth_refresh_token_response(
             request=request,
         )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing refresh_token")
-    resolved_resource = _resolve_oauth_resource(request=request, resource=resource)
+    resolved_resource = _resolve_oauth_resource(
+        request=request,
+        resource=resource,
+        client_id=client_id,
+    )
     if not _is_mcp_resource_match(request=request, resource=resolved_resource):
         _log_oauth_token_failed(
             reason="refresh_resource_mismatch",
@@ -869,11 +898,13 @@ def _oauth_refresh_token_response(
             request=request,
         )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="OAuth resource mismatch")
-    payload = validate_mcp_refresh_token(refresh_token, audience=resolved_resource)
-    if payload is None:
-        canonical_resource = _canonicalize_mcp_resource(request=request, resource=resolved_resource)
-        if canonical_resource != resolved_resource:
-            payload = validate_mcp_refresh_token(refresh_token, audience=canonical_resource)
+    matched_audience = resolved_resource
+    payload = None
+    for audience in _mcp_resource_audience_candidates(request=request, preferred=resolved_resource):
+        payload = validate_mcp_refresh_token(refresh_token, audience=audience)
+        if payload is not None:
+            matched_audience = audience
+            break
     if payload is None:
         _log_oauth_token_failed(
             reason="invalid_refresh_token",
@@ -898,16 +929,16 @@ def _oauth_refresh_token_response(
         store=store,
         user=user,
         expires_in_days=1,
-        audience=resolved_resource,
+        audience=matched_audience,
     )
-    refresh_token_value, _ = _issue_mcp_refresh_token(user=user, audience=resolved_resource)
+    refresh_token_value, _ = _issue_mcp_refresh_token(user=user, audience=matched_audience)
     expires_in = max(1, int((datetime.fromisoformat(expires_at) - datetime.now(timezone.utc)).total_seconds()))
     logger.info(
         "mcp_oauth_token_succeeded grant_type=refresh_token client_id_hash=%s resource_supplied=%s "
         "token_audience=%s access_scope=%s refresh_scope=%s expires_in=%d user_id=%s user_agent=%s",
         _stable_hash(client_id),
         bool(resource.strip()),
-        resolved_resource,
+        matched_audience,
         MCP_TOKEN_SCOPE,
         MCP_REFRESH_TOKEN_SCOPE,
         expires_in,
@@ -2275,6 +2306,20 @@ def _resource_url(request: Request) -> str:
     return f"{_base_url(request)}/mcp"
 
 
+def _uppercase_resource_url(request: Request) -> str:
+    return f"{_base_url(request)}/MCP"
+
+
+def _all_mcp_resource_urls(request: Request) -> list[str]:
+    return [_uppercase_resource_url(request), _resource_url(request)]
+
+
+def _metadata_resource_url(request: Request) -> str:
+    if request.url.path.rstrip("/").endswith("/MCP"):
+        return _uppercase_resource_url(request)
+    return _resource_url(request)
+
+
 def _base_url_from_resource(resource: str) -> str:
     parsed = urlparse(resource)
     if parsed.scheme and parsed.netloc:
@@ -2282,8 +2327,32 @@ def _base_url_from_resource(resource: str) -> str:
     return resource.rstrip("/")
 
 
-def _resolve_oauth_resource(*, request: Request, resource: str) -> str:
-    return resource.strip() or _resource_url(request)
+def _resolve_oauth_resource(
+    *,
+    request: Request,
+    resource: str,
+    client_id: str = "",
+    redirect_uri: str = "",
+) -> str:
+    if resource.strip():
+        return resource.strip()
+    if _is_claude_oauth_client(client_id=client_id, redirect_uri=redirect_uri):
+        return _uppercase_resource_url(request)
+    return _resource_url(request)
+
+
+def _is_claude_oauth_client(*, client_id: str, redirect_uri: str = "") -> bool:
+    return _url_host(client_id) == "claude.ai" or _url_host(redirect_uri) == "claude.ai"
+
+
+def _mcp_resource_audience_candidates(*, request: Request, preferred: str) -> list[str]:
+    candidates = [preferred, _canonicalize_mcp_resource(request=request, resource=preferred)]
+    candidates.extend(_all_mcp_resource_urls(request))
+    unique: list[str] = []
+    for candidate in candidates:
+        if candidate and candidate not in unique:
+            unique.append(candidate)
+    return unique
 
 
 def _canonicalize_mcp_resource(*, request: Request, resource: str) -> str:
@@ -2345,7 +2414,8 @@ def _first_payload_id(payload: Any) -> Any:
 
 
 def _www_authenticate_header(request: Request) -> str:
-    metadata_url = f"{_base_url(request)}/.well-known/oauth-protected-resource/mcp"
+    resource_path = "MCP" if request.url.path.rstrip("/").endswith("/MCP") else "mcp"
+    metadata_url = f"{_base_url(request)}/.well-known/oauth-protected-resource/{resource_path}"
     return f'Bearer resource_metadata="{metadata_url}", scope="{MCP_TOKEN_SCOPE}"'
 
 

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260496"
+version = "1.0.260497"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_mcp_api.py
+++ b/api/aijuristiction-api/tests/test_mcp_api.py
@@ -949,7 +949,10 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
     assert authorization_metadata.json()["scopes_supported"] == ["mcp:laws", "offline_access"]
     assert authorization_metadata.json()["registration_endpoint"].endswith("/oauth/register")
     assert authorization_metadata.json()["authorization_response_iss_parameter_supported"] is True
-    assert authorization_metadata.json()["protected_resources"] == ["https://mcp.jurisdigta.eu/mcp"]
+    assert authorization_metadata.json()["protected_resources"] == [
+        "https://mcp.jurisdigta.eu/MCP",
+        "https://mcp.jurisdigta.eu/mcp",
+    ]
 
     registration_response = mcp_client.post(
         "/oauth/register",
@@ -1198,6 +1201,98 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
     assert token_payload["refresh_token"] not in mcp_log_text
 
 
+def test_claude_oauth_without_resource_uses_uppercase_mcp_audience(monkeypatch, tmp_path: Path) -> None:
+    _configure_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("LOCAL_AUTH_ACCEPT_ANY_CODE", "true")
+    client_id = "https://claude.ai/oauth/mcp-oauth-client-metadata"
+    redirect_uri = "https://claude.ai/api/mcp/auth_callback"
+    monkeypatch.setattr(
+        "app.mcp_api._fetch_client_id_metadata_document",
+        lambda fetched_client_id: {
+            "client_id": fetched_client_id,
+            "client_name": "Claude",
+            "redirect_uris": [redirect_uri],
+        },
+    )
+    sign_up_response = api_client.post(
+        "/v1/users/sign-up",
+        headers=AUTH_HEADERS,
+        json={
+            "phone_number": "+421 900 111 239",
+            "email": "mcp-claude-oauth@example.com",
+            "password": "secret-pass",
+        },
+    )
+    assert sign_up_response.status_code == 201
+
+    code_verifier = "test-code-verifier-claude-1234567890"
+    code_challenge = _pkce_challenge(code_verifier)
+    authorize_page = mcp_client.get(
+        "/oauth/authorize",
+        params={
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "state": "claude-no-resource",
+            "scope": "mcp:laws offline_access",
+            "prompt": "consent",
+        },
+    )
+    assert authorize_page.status_code == 200
+    selected_resource = _extract_hidden_value(authorize_page.text, "resource")
+    assert selected_resource == "https://mcp.jurisdigta.eu/MCP"
+
+    verify_response = mcp_client.post(
+        "/oauth/authorize/verify",
+        data={
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "state": "claude-no-resource",
+            "resource": selected_resource,
+            "email": "mcp-claude-oauth@example.com",
+            "verification_code": "123456",
+        },
+        follow_redirects=False,
+    )
+    assert verify_response.status_code == 303
+    callback_query = parse_qs(urlparse(verify_response.headers["location"]).query)
+    authorization_code = callback_query["code"][0]
+
+    token_response = mcp_client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": authorization_code,
+            "redirect_uri": redirect_uri,
+            "client_id": client_id,
+            "code_verifier": code_verifier,
+        },
+    )
+    assert token_response.status_code == 200
+    token_payload = token_response.json()
+    access_claims = _jwt_claims(token_payload["access_token"])
+    refresh_claims = _jwt_claims(token_payload["refresh_token"])
+    assert access_claims["aud"] == "https://mcp.jurisdigta.eu/MCP"
+    assert refresh_claims["aud"] == "https://mcp.jurisdigta.eu/MCP"
+
+    refresh_response = mcp_client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": token_payload["refresh_token"],
+            "client_id": client_id,
+        },
+    )
+    assert refresh_response.status_code == 200
+    refreshed_claims = _jwt_claims(refresh_response.json()["access_token"])
+    assert refreshed_claims["aud"] == "https://mcp.jurisdigta.eu/MCP"
+
+
 def test_oauth_authorization_response_issuer_can_be_enabled(monkeypatch, tmp_path: Path) -> None:
     _configure_env(monkeypatch, tmp_path)
     monkeypatch.setenv("LOCAL_AUTH_ACCEPT_ANY_CODE", "true")
@@ -1376,12 +1471,17 @@ def test_oauth_discovery_uses_public_base_url(monkeypatch, tmp_path: Path) -> No
     assert protected_metadata.json()["resource"] == "https://mcp.jurisdigta.eu/mcp"
     assert protected_metadata.json()["authorization_servers"] == ["https://mcp.jurisdigta.eu"]
     assert legacy_mcp_protected_metadata.status_code == 200
-    assert legacy_mcp_protected_metadata.json() == protected_metadata.json()
+    assert legacy_mcp_protected_metadata.json()["resource"] == "https://mcp.jurisdigta.eu/MCP"
+    assert legacy_mcp_protected_metadata.json()["authorization_servers"] == ["https://mcp.jurisdigta.eu"]
     assert authorization_metadata.status_code == 200
     assert authorization_metadata.json()["issuer"] == "https://mcp.jurisdigta.eu"
     assert authorization_metadata.json()["token_endpoint"] == "https://mcp.jurisdigta.eu/oauth/token"
     assert authorization_metadata.json()["registration_endpoint"] == "https://mcp.jurisdigta.eu/oauth/register"
     assert authorization_metadata.json()["client_id_metadata_document_supported"] is True
+    assert authorization_metadata.json()["protected_resources"] == [
+        "https://mcp.jurisdigta.eu/MCP",
+        "https://mcp.jurisdigta.eu/mcp",
+    ]
     assert mcp_path_authorization_metadata.status_code == 200
     assert mcp_path_authorization_metadata.json() == authorization_metadata.json()
     assert legacy_mcp_authorization_metadata.status_code == 200

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -9,17 +9,20 @@ It is intended for AI assistants that can connect to remote MCP servers over HTT
 For ChatGPT, Claude, and VS Code OAuth-capable clients, start from the OAuth metadata endpoints instead of manually copying a token.
 The API `/version`, MCP `/version`, and MCP `getVersion` tool expose `mcp_server_version`.
 For the current deployable package this value is aligned with the API package revision.
-`POST /MCP` remains accepted as a legacy compatibility alias for older client
-records, and `POST /MC` is also accepted for connector records that were
-accidentally saved with the truncated Claude URL `/MC`; OAuth metadata
-advertises the canonical protected resource as `https://mcp.jurisdigta.eu/mcp`.
+`POST /MCP` remains accepted as a Claude compatibility endpoint and for older
+client records, and `POST /MC` is also accepted for connector records that were
+accidentally saved with the truncated Claude URL `/MC`. OAuth metadata keeps
+`https://mcp.jurisdigta.eu/mcp` for lowercase clients and advertises
+`https://mcp.jurisdigta.eu/MCP` from the uppercase protected-resource metadata
+path because Claude web may store custom connector URLs with uppercase `/MCP`.
 
 `GET /` on the MCP service is a public human-facing setup page. In production,
 `https://mcp.jurisdigta.eu/` should show:
 
 - Registration and login steps for creating an MCP account and short-lived MCP API key.
 - Remote MCP setup guidance for ChatGPT custom connectors, Claude, Perplexity-compatible clients, VS Code, and other MCP clients.
-- OAuth discovery URLs and the canonical MCP endpoint `https://mcp.jurisdigta.eu/mcp`.
+- OAuth discovery URLs and the MCP endpoints `https://mcp.jurisdigta.eu/mcp`
+  and Claude-compatible `https://mcp.jurisdigta.eu/MCP`.
 - Privacy and compliance notes explaining that protected tools require per-user authentication and privacy-safe logging.
 
 Start locally with Docker Compose:
@@ -56,11 +59,14 @@ remote clients that request `offline_access`. Remote clients can use OAuth
 Client ID Metadata Documents, dynamic client registration at `/oauth/register`,
 or a preconfigured public OAuth Client ID. New dynamic registrations may return
 either `200 OK` or `201 Created` with the issued public client metadata.
-ChatGPT and Claude should pass the protected resource value
+ChatGPT and other lowercase clients should pass the protected resource value
 `https://mcp.jurisdigta.eu/mcp` on the authorization, token, and refresh
-requests. Protected-resource metadata includes a human-readable
-`resource_name`, and authorization-server metadata advertises the protected MCP
-resource, `client_id_metadata_document_supported=true`, and
+requests. Claude web custom connectors may omit `resource` and store the server
+URL as `https://mcp.jurisdigta.eu/MCP`; JurisDigta detects Claude OAuth clients
+from the public client id/redirect host and issues `/MCP`-audience access and
+refresh tokens for that flow. Protected-resource metadata includes a
+human-readable `resource_name`, and authorization-server metadata advertises
+both protected MCP resources, `client_id_metadata_document_supported=true`, and
 `authorization_response_iss_parameter_supported=true`. The authorization
 callback returns `iss=https://mcp.jurisdigta.eu` with the authorization code so
 strict OAuth clients can bind the response to the issuer.
@@ -263,6 +269,9 @@ These records include the request path, redirect host/path, client id hash,
 whether a `resource` parameter was supplied, the resolved resource, stored
 authorization-code resource, token audience, scopes, and user-agent family so
 Claude-style connector failures can be correlated without exposing credentials.
+For Claude web, `resource_supplied=false` with
+`token_audience=https://mcp.jurisdigta.eu/MCP` is expected when Claude omits the
+OAuth `resource` parameter.
 MCP endpoint entry logs use `mcp_endpoint_called` and include the actual request
 path, which helps distinguish canonical `/mcp` traffic from legacy `/MCP` or
 `/MC` compatibility traffic.

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -29,9 +29,13 @@ print(
 )
 print(
     "mcp_auth_contract => getVersion/getStatistics are public; searchLaws/getLawText require "
-    "a Bearer MCP token or x-mcp-api-key, and Claude should use https://mcp.jurisdigta.eu/mcp."
+    "a Bearer MCP token or x-mcp-api-key, and lowercase OAuth clients should use "
+    "https://mcp.jurisdigta.eu/mcp."
 )
-print("mcp_endpoint_legacy => /MCP remains accepted as a compatibility alias for existing clients.")
+print(
+    "mcp_endpoint_claude_compat => /MCP remains accepted for Claude web and existing clients; "
+    "Claude OAuth without a resource parameter receives an /MCP audience token."
+)
 print(
     "mcp_oauth_redirects => hosted callbacks use explicit allowed hosts; local MCP clients keep "
     "http://localhost, http://127.0.0.1, and http://[::1] loopback redirect_uri support."


### PR DESCRIPTION
## Summary
- Treat /MCP protected-resource metadata as a first-class Claude-compatible OAuth resource while preserving lowercase /mcp for other clients.
- Default Claude OAuth flows that omit resource to the /MCP token audience and preserve that audience on refresh.
- Document the compatibility behavior and cover it in MCP OAuth regression tests.

## Validation
- .\\conda\\python.exe -m pytest api\\aijuristiction-api\\tests\\test_mcp_api.py -q
- ..\\..\\conda\\python.exe -m ruff check app tests
- ..\\..\\conda\\python.exe -m mypy app
- .\\scripts\\validate_api.ps1
- .\\conda\\python.exe -m pytest api\\aijuristiction-api\\tests
- .\\conda\\python.exe examples\\minimal_demo.py