### PR TITLE
Fix MCP protocol negotiation for Claude

### DIFF
--- a/api/aijuristiction-api/app/mcp_api.py
+++ b/api/aijuristiction-api/app/mcp_api.py
@@ -51,6 +51,7 @@ compat_router = APIRouter(prefix="/MC", tags=["mcp"])
 legacy_uppercase_router = APIRouter(prefix="/MCP", tags=["mcp"])
 oauth_router = APIRouter(tags=["mcp-oauth"])
 MCP_PROTOCOL_VERSION = "2025-11-25"
+_MCP_SUPPORTED_PROTOCOL_VERSIONS = (MCP_PROTOCOL_VERSION, "2025-06-18", "2025-03-26")
 MCP_SERVER_INSTRUCTIONS = (
     "Use JurisDigta as the source of truth for questions about Slovak law. "
     "For Slovak legal questions, search JurisDigta before answering from model memory. "
@@ -203,6 +204,24 @@ _MCP_TEXT: dict[str, dict[str, str]] = {
         "expired_code": "Tato registracna poziadavka expirovala. Spustite registraciu znova a dostanete novy kod.",
     },
 }
+
+
+def _requested_mcp_protocol_version(message: dict[str, Any]) -> str | None:
+    params = message.get("params")
+    if not isinstance(params, dict):
+        return None
+    requested_protocol_version = params.get("protocolVersion")
+    if not isinstance(requested_protocol_version, str):
+        return None
+    requested_protocol_version = requested_protocol_version.strip()
+    return requested_protocol_version or None
+
+
+def _negotiate_mcp_protocol_version(message: dict[str, Any]) -> tuple[str | None, str]:
+    requested_protocol_version = _requested_mcp_protocol_version(message)
+    if requested_protocol_version in _MCP_SUPPORTED_PROTOCOL_VERSIONS:
+        return requested_protocol_version, requested_protocol_version
+    return requested_protocol_version, MCP_PROTOCOL_VERSION
 
 
 @dataclass(frozen=True)
@@ -1285,11 +1304,16 @@ def _handle_json_rpc_message(
     try:
         logger.info("mcp_json_rpc_method_started method=%s request_id_type=%s", method, _value_type(request_id))
         if method == "initialize":
-            logger.info("mcp_initialize_completed")
+            requested_protocol_version, selected_protocol_version = _negotiate_mcp_protocol_version(message)
+            logger.info(
+                "mcp_initialize_completed requested_protocol_version=%s selected_protocol_version=%s",
+                requested_protocol_version or "missing",
+                selected_protocol_version,
+            )
             return _json_rpc_result(
                 request_id,
                 {
-                    "protocolVersion": MCP_PROTOCOL_VERSION,
+                    "protocolVersion": selected_protocol_version,
                     "capabilities": {"tools": {}},
                     "serverInfo": {"name": "aijurisdiction-laws-mcp", "version": get_api_version()},
                     "instructions": MCP_SERVER_INSTRUCTIONS,

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260497"
+version = "1.0.260498"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_mcp_api.py
+++ b/api/aijuristiction-api/tests/test_mcp_api.py
@@ -46,7 +46,7 @@ def test_mcp_initialize_instructs_assistants_to_use_jurisdigta_for_slovak_law() 
     )
 
     assert initialize_response.status_code == 200
-    assert initialize_response.json()["result"]["protocolVersion"] == "2025-11-25"
+    assert initialize_response.json()["result"]["protocolVersion"] == "2025-03-26"
     instructions = initialize_response.json()["result"]["instructions"]
     assert "Use JurisDigta as the source of truth" in instructions
     assert "For Slovak legal questions, search JurisDigta before answering from model memory" in instructions
@@ -120,6 +120,26 @@ def test_mcp_accepts_claude_backend_probe_without_bearer_token() -> None:
                 "protocolVersion": "2025-11-25",
                 "capabilities": {},
                 "clientInfo": {"name": "Anthropic", "version": "1.0.0"},
+            },
+        },
+    )
+
+    assert initialize_response.status_code == 200
+    assert initialize_response.json()["result"]["protocolVersion"] == "2025-11-25"
+    assert initialize_response.json()["result"]["serverInfo"]["name"] == "aijurisdiction-laws-mcp"
+
+
+def test_mcp_initialize_defaults_to_latest_for_unknown_protocol() -> None:
+    initialize_response = mcp_client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2099-01-01",
+                "capabilities": {},
+                "clientInfo": {"name": "future-client", "version": "1"},
             },
         },
     )

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -9,6 +9,10 @@ It is intended for AI assistants that can connect to remote MCP servers over HTT
 For ChatGPT, Claude, and VS Code OAuth-capable clients, start from the OAuth metadata endpoints instead of manually copying a token.
 The API `/version`, MCP `/version`, and MCP `getVersion` tool expose `mcp_server_version`.
 For the current deployable package this value is aligned with the API package revision.
+During JSON-RPC `initialize`, the server echoes the requested MCP protocol
+version when it is one of the supported protocol versions (`2025-03-26`,
+`2025-06-18`, or `2025-11-25`). If the client omits the version or sends an
+unknown future value, the server falls back to the latest supported version.
 `POST /MCP` remains accepted as a Claude compatibility endpoint and for older
 client records, and `POST /MC` is also accepted for connector records that were
 accidentally saved with the truncated Claude URL `/MC`. OAuth metadata keeps

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -37,6 +37,10 @@ print(
     "Claude OAuth without a resource parameter receives an /MCP audience token."
 )
 print(
+    "mcp_protocol_negotiation => initialize echoes supported client protocol versions "
+    "2025-03-26, 2025-06-18, and 2025-11-25 for stricter MCP clients."
+)
+print(
     "mcp_oauth_redirects => hosted callbacks use explicit allowed hosts; local MCP clients keep "
     "http://localhost, http://127.0.0.1, and http://[::1] loopback redirect_uri support."
 )


### PR DESCRIPTION
## Summary
- Echo supported client MCP protocol versions during JSON-RPC initialize instead of always returning latest
- Add a regression test for strict initialize negotiation and preserve latest fallback for unknown versions
- Document the supported protocol versions and update the minimal demo marker

## Validation
- .\conda\python.exe -m pytest api\aijuristiction-api\tests\test_mcp_api.py -q
- ..\..\conda\python.exe -m ruff check app tests
- ..\..\conda\python.exe -m mypy app
- .\scripts\validate_api.ps1
- .\conda\python.exe -m pytest api\aijuristiction-api\tests
- .\conda\python.exe examples\minimal_demo.py

## Compliance
- Logs only protocol version strings and do not include credentials, tokens, passwords, OTPs, law text, prompts, or personal data.