### PR TITLE
Add Claude web public MCP compatibility

### DIFF
--- a/api/aijuristiction-api/app/mcp_api.py
+++ b/api/aijuristiction-api/app/mcp_api.py
@@ -61,6 +61,7 @@ MCP_SERVER_INSTRUCTIONS = (
     "If the legal conclusion depends on facts or amendment/effective-date status, say so explicitly."
 )
 _PUBLIC_TOOLS = {"getVersion", "getStatistics"}
+_CLAUDE_WEB_PUBLIC_TOOLS = _PUBLIC_TOOLS | {"searchLaws", "getLawText", "searchCourtDecisions"}
 _DEFAULT_ALLOWED_REDIRECT_HOSTS = (
     "chatgpt.com",
     "chat.openai.com",
@@ -289,7 +290,8 @@ async def mcp_json_rpc(
         _payload_message_count(payload),
         ",".join(_payload_methods(payload)),
     )
-    payload_requires_auth = _payload_requires_auth(payload)
+    public_tools = _public_tools_for_request(request)
+    payload_requires_auth = _payload_requires_auth(payload, public_tools=public_tools)
     api_key = _extract_mcp_api_key(
         authorization=authorization,
         x_mcp_api_key=x_mcp_api_key,
@@ -313,6 +315,7 @@ async def mcp_json_rpc(
             authorization=authorization,
             x_mcp_api_key=x_mcp_api_key,
             store=store,
+            public_tools=public_tools,
         )
         duration_ms = int((time.perf_counter() - started_at) * 1000)
         logger.info(
@@ -1258,6 +1261,7 @@ def _handle_json_rpc(
     authorization: str | None,
     x_mcp_api_key: str | None,
     store: ApiDatabaseStore | None,
+    public_tools: set[str],
 ) -> JSONResponse:
     if isinstance(payload, list):
         logger.info("mcp_json_rpc_batch_started message_count=%d", len(payload))
@@ -1267,6 +1271,7 @@ def _handle_json_rpc(
                 authorization=authorization,
                 x_mcp_api_key=x_mcp_api_key,
                 store=store,
+                public_tools=public_tools,
             )
             for item in payload
         ]
@@ -1279,6 +1284,7 @@ def _handle_json_rpc(
         authorization=authorization,
         x_mcp_api_key=x_mcp_api_key,
         store=store,
+        public_tools=public_tools,
     )
     if response is None:
         return JSONResponse(status_code=202, content={})
@@ -1291,6 +1297,7 @@ def _handle_json_rpc_message(
     authorization: str | None,
     x_mcp_api_key: str | None,
     store: ApiDatabaseStore | None,
+    public_tools: set[str],
 ) -> dict[str, Any] | None:
     if not isinstance(message, dict):
         logger.warning("mcp_json_rpc_invalid_message reason=non_object")
@@ -1351,13 +1358,14 @@ def _handle_json_rpc_message(
                 "mcp_tool_started tool=%s argument_keys=%s auth_required=%s",
                 tool_name,
                 ",".join(sorted(str(key) for key in arguments.keys())),
-                tool_name not in _PUBLIC_TOOLS,
+                tool_name not in public_tools,
             )
             _require_auth_for_tool(
                 tool_name=tool_name,
                 authorization=authorization,
                 x_mcp_api_key=x_mcp_api_key,
                 store=store,
+                public_tools=public_tools,
             )
             result = _call_tool(tool_name, arguments)
             logger.info(
@@ -1388,8 +1396,9 @@ def _require_auth_for_tool(
     authorization: str | None,
     x_mcp_api_key: str | None,
     store: ApiDatabaseStore | None,
+    public_tools: set[str],
 ) -> None:
-    if tool_name in _PUBLIC_TOOLS:
+    if tool_name in public_tools:
         logger.info("mcp_tool_auth_skipped tool=%s reason=public_tool", tool_name)
         return
     api_key = _extract_mcp_api_key(authorization=authorization, x_mcp_api_key=x_mcp_api_key)
@@ -2406,7 +2415,13 @@ def _allowed_oauth_redirect_hosts() -> set[str]:
     return set(_DEFAULT_ALLOWED_REDIRECT_HOSTS)
 
 
-def _payload_requires_auth(payload: Any) -> bool:
+def _public_tools_for_request(request: Request) -> set[str]:
+    if request.url.path.rstrip("/") == "/MCP":
+        return _CLAUDE_WEB_PUBLIC_TOOLS
+    return _PUBLIC_TOOLS
+
+
+def _payload_requires_auth(payload: Any, *, public_tools: set[str]) -> bool:
     messages = payload if isinstance(payload, list) else [payload]
     for message in messages:
         if not isinstance(message, dict):
@@ -2416,7 +2431,7 @@ def _payload_requires_auth(payload: Any) -> bool:
         raw_params = message.get("params")
         params: dict[str, Any] = raw_params if isinstance(raw_params, dict) else {}
         tool_name = params.get("name")
-        if isinstance(tool_name, str) and tool_name not in _PUBLIC_TOOLS:
+        if isinstance(tool_name, str) and tool_name not in public_tools:
             return True
     return False
 

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260498"
+version = "1.0.260499"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_mcp_api.py
+++ b/api/aijuristiction-api/tests/test_mcp_api.py
@@ -149,6 +149,29 @@ def test_mcp_initialize_defaults_to_latest_for_unknown_protocol() -> None:
     assert initialize_response.json()["result"]["serverInfo"]["name"] == "aijurisdiction-laws-mcp"
 
 
+def test_legacy_uppercase_mcp_allows_claude_web_public_law_search(monkeypatch, tmp_path: Path) -> None:
+    _configure_env(monkeypatch, tmp_path)
+    _create_laws_db(tmp_path / "laws.sqlite3")
+
+    lowercase_search = _mcp_call("searchLaws", {"query": "civil"})
+    assert lowercase_search.status_code == 401
+    assert "oauth-protected-resource" in lowercase_search.headers["www-authenticate"]
+
+    claude_search = _mcp_call("searchLaws", {"query": "civil"}, path="/MCP")
+    assert claude_search.status_code == 200
+    results = _tool_payload(claude_search)["results"]
+    assert results[0]["document_id"] == "doc-1"
+    assert results[0]["law_identifier_text"] == "1/1993 Z. z."
+
+    raw_court_decision = _mcp_call(
+        "getCourtDecision",
+        {"decisionId": "decision-1", "outputMode": "internal_raw"},
+        path="/MCP",
+    )
+    assert raw_court_decision.status_code == 401
+    assert "oauth-protected-resource" in raw_court_decision.headers["www-authenticate"]
+
+
 def test_mcp_empty_discovery_methods_for_claude_connector() -> None:
     expected_results = {
         "resources/list": {"resources": []},
@@ -1657,6 +1680,7 @@ def _mcp_call(
     name: str,
     arguments: dict[str, object] | None = None,
     headers: dict[str, str] | None = None,
+    path: str = "/mcp",
 ):
     payload = {
         "jsonrpc": "2.0",
@@ -1664,7 +1688,7 @@ def _mcp_call(
         "method": "tools/call",
         "params": {"name": name, "arguments": arguments or {}},
     }
-    return mcp_client.post("/mcp", json=payload, headers=headers or {})
+    return mcp_client.post(path, json=payload, headers=headers or {})
 
 
 def _tool_payload(response) -> dict[str, object]:

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -19,6 +19,12 @@ accidentally saved with the truncated Claude URL `/MC`. OAuth metadata keeps
 `https://mcp.jurisdigta.eu/mcp` for lowercase clients and advertises
 `https://mcp.jurisdigta.eu/MCP` from the uppercase protected-resource metadata
 path because Claude web may store custom connector URLs with uppercase `/MCP`.
+Because Claude web can complete OAuth and then reject the issued credentials
+without making an authenticated MCP call, `/MCP` also acts as a public-law
+compatibility endpoint for Claude web: it allows `getVersion`, `getStatistics`,
+`searchLaws`, `getLawText`, and `searchCourtDecisions` without a bearer token.
+The canonical lowercase `/mcp` endpoint still requires OAuth or an MCP API key
+for protected tools.
 
 `GET /` on the MCP service is a public human-facing setup page. In production,
 `https://mcp.jurisdigta.eu/` should show:
@@ -137,7 +143,7 @@ Manual JWT generation remains useful for local VS Code setups that pass an `Auth
 Use `https://mcp.jurisdigta.eu/mcp` as the remote MCP server URL in clients that support custom HTTP MCP servers.
 
 - ChatGPT custom connectors: create a remote MCP connector and enter the MCP server URL. Prefer OAuth discovery when the connector supports it. Users may self-register during the browser authorization flow, but ChatGPT only receives the OAuth access token and tool results, not a raw API key.
-- Claude: add a custom connector or remote MCP server and enter the MCP server URL. OAuth-capable Claude clients can discover authorization metadata from `https://mcp.jurisdigta.eu` and register dynamically. If Claude reports that automatic client registration is not supported, open Advanced settings, set OAuth Client ID to a stable public value such as `claude`, leave OAuth Client Secret empty, and retry after confirming `claude.ai` is allowed in `MCP_OAUTH_ALLOWED_REDIRECT_HOSTS`. Claude Desktop, Claude Code, and local OAuth proxies can use loopback callbacks such as `http://localhost/...`, `http://127.0.0.1/...`, or `http://[::1]/...`.
+- Claude web custom connectors: use `https://mcp.jurisdigta.eu/MCP`. This uppercase path is intentionally a public-law compatibility endpoint because Claude web may complete OAuth and then reject the issued credentials before making any authenticated MCP request. Claude Desktop, Claude Code, and local OAuth proxies can use loopback callbacks such as `http://localhost/...`, `http://127.0.0.1/...`, or `http://[::1]/...`.
 - VS Code: add an HTTP MCP server in MCP settings. If OAuth is unavailable in the client, include `Authorization: Bearer <mcp_api_key>` after generating a key from `/mcp/login`.
 - Perplexity and other clients: use the MCP server URL where custom remote MCP servers are supported. Hosted OAuth callbacks include `https://vscode.dev/redirect`, `https://claude.ai/api/mcp/auth_callback`, and `https://www.perplexity.ai/rest/connections/oauth_callback` when their hosts are listed in `MCP_OAUTH_ALLOWED_REDIRECT_HOSTS`. If a product only exposes its own MCP server and does not support registering external MCP servers, use another MCP-compatible host.
 

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -34,7 +34,7 @@ print(
 )
 print(
     "mcp_endpoint_claude_compat => /MCP remains accepted for Claude web and existing clients; "
-    "Claude OAuth without a resource parameter receives an /MCP audience token."
+    "it allows public-law tools without OAuth because Claude web can reject issued OAuth credentials."
 )
 print(
     "mcp_protocol_negotiation => initialize echoes supported client protocol versions "


### PR DESCRIPTION
## Summary
- Keep canonical `/mcp` OAuth behavior unchanged for protected tools
- Treat legacy uppercase `/MCP` as a Claude web public-law compatibility endpoint for public legal/statistics/search tools
- Add regression coverage proving `/mcp` still challenges while `/MCP` permits public-law search without OAuth
- Document the Claude web workaround and bump API package revision

## Why
Production logs show Claude successfully completes OAuth and exchanges the authorization code for a bearer token, then rejects the credentials internally without making an authenticated MCP request. The `/MCP` fallback avoids that Claude web OAuth broker failure for public-law tools only.

## Validation
- .\conda\python.exe -m pytest api\aijuristiction-api\tests\test_mcp_api.py -q
- ..\..\conda\python.exe -m ruff check app tests
- ..\..\conda\python.exe -m mypy app
- .\scripts\validate_api.ps1
- .\conda\python.exe -m pytest api\aijuristiction-api\tests
- .\conda\python.exe examples\minimal_demo.py

## Compliance
- No credentials, tokens, passwords, OTPs, prompts, or personal data are logged.
- The anonymous `/MCP` fallback is limited to public-law/statistics/search tools; lowercase `/mcp` remains protected for OAuth/API-key clients.