### PR TITLE
Fix Claude web public MCP discovery

### DIFF
--- a/api/aijuristiction-api/app/mcp_api.py
+++ b/api/aijuristiction-api/app/mcp_api.py
@@ -366,10 +366,19 @@ def oauth_protected_resource_metadata(request: Request) -> dict[str, Any]:
     }
 
 
-@oauth_router.get("/.well-known/oauth-protected-resource/MCP")
 @oauth_router.get("/.well-known/oauth-protected-resource/mcp")
 def oauth_mcp_protected_resource_metadata(request: Request) -> dict[str, Any]:
     return oauth_protected_resource_metadata(request)
+
+
+@oauth_router.get("/.well-known/oauth-protected-resource/MCP")
+def oauth_legacy_public_mcp_protected_resource_metadata() -> JSONResponse:
+    return JSONResponse(
+        status_code=status.HTTP_404_NOT_FOUND,
+        content={
+            "detail": "Legacy Claude web MCP compatibility endpoint is public and is not an OAuth protected resource"
+        },
+    )
 
 
 @oauth_router.get("/.well-known/oauth-authorization-server")
@@ -2344,7 +2353,7 @@ def _uppercase_resource_url(request: Request) -> str:
 
 
 def _all_mcp_resource_urls(request: Request) -> list[str]:
-    return [_uppercase_resource_url(request), _resource_url(request)]
+    return [_resource_url(request)]
 
 
 def _metadata_resource_url(request: Request) -> str:

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260499"
+version = "1.0.260500"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_mcp_api.py
+++ b/api/aijuristiction-api/tests/test_mcp_api.py
@@ -153,6 +153,12 @@ def test_legacy_uppercase_mcp_allows_claude_web_public_law_search(monkeypatch, t
     _configure_env(monkeypatch, tmp_path)
     _create_laws_db(tmp_path / "laws.sqlite3")
 
+    legacy_protected_metadata = mcp_client.get(
+        "/.well-known/oauth-protected-resource/MCP",
+        headers={"user-agent": "python-httpx/0.28.1", "mcp-protocol-version": "2025-11-25"},
+    )
+    assert legacy_protected_metadata.status_code == 404
+
     lowercase_search = _mcp_call("searchLaws", {"query": "civil"})
     assert lowercase_search.status_code == 401
     assert "oauth-protected-resource" in lowercase_search.headers["www-authenticate"]
@@ -993,7 +999,6 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
     assert authorization_metadata.json()["registration_endpoint"].endswith("/oauth/register")
     assert authorization_metadata.json()["authorization_response_iss_parameter_supported"] is True
     assert authorization_metadata.json()["protected_resources"] == [
-        "https://mcp.jurisdigta.eu/MCP",
         "https://mcp.jurisdigta.eu/mcp",
     ]
 
@@ -1513,16 +1518,13 @@ def test_oauth_discovery_uses_public_base_url(monkeypatch, tmp_path: Path) -> No
     assert protected_metadata.status_code == 200
     assert protected_metadata.json()["resource"] == "https://mcp.jurisdigta.eu/mcp"
     assert protected_metadata.json()["authorization_servers"] == ["https://mcp.jurisdigta.eu"]
-    assert legacy_mcp_protected_metadata.status_code == 200
-    assert legacy_mcp_protected_metadata.json()["resource"] == "https://mcp.jurisdigta.eu/MCP"
-    assert legacy_mcp_protected_metadata.json()["authorization_servers"] == ["https://mcp.jurisdigta.eu"]
+    assert legacy_mcp_protected_metadata.status_code == 404
     assert authorization_metadata.status_code == 200
     assert authorization_metadata.json()["issuer"] == "https://mcp.jurisdigta.eu"
     assert authorization_metadata.json()["token_endpoint"] == "https://mcp.jurisdigta.eu/oauth/token"
     assert authorization_metadata.json()["registration_endpoint"] == "https://mcp.jurisdigta.eu/oauth/register"
     assert authorization_metadata.json()["client_id_metadata_document_supported"] is True
     assert authorization_metadata.json()["protected_resources"] == [
-        "https://mcp.jurisdigta.eu/MCP",
         "https://mcp.jurisdigta.eu/mcp",
     ]
     assert mcp_path_authorization_metadata.status_code == 200

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -16,9 +16,10 @@ unknown future value, the server falls back to the latest supported version.
 `POST /MCP` remains accepted as a Claude compatibility endpoint and for older
 client records, and `POST /MC` is also accepted for connector records that were
 accidentally saved with the truncated Claude URL `/MC`. OAuth metadata keeps
-`https://mcp.jurisdigta.eu/mcp` for lowercase clients and advertises
-`https://mcp.jurisdigta.eu/MCP` from the uppercase protected-resource metadata
-path because Claude web may store custom connector URLs with uppercase `/MCP`.
+`https://mcp.jurisdigta.eu/mcp` for lowercase clients. The uppercase
+`/.well-known/oauth-protected-resource/MCP` path intentionally returns `404`
+because Claude web may store custom connector URLs with uppercase `/MCP` and
+will force OAuth when that path is advertised as protected.
 Because Claude web can complete OAuth and then reject the issued credentials
 without making an authenticated MCP call, `/MCP` also acts as a public-law
 compatibility endpoint for Claude web: it allows `getVersion`, `getStatistics`,
@@ -71,12 +72,12 @@ or a preconfigured public OAuth Client ID. New dynamic registrations may return
 either `200 OK` or `201 Created` with the issued public client metadata.
 ChatGPT and other lowercase clients should pass the protected resource value
 `https://mcp.jurisdigta.eu/mcp` on the authorization, token, and refresh
-requests. Claude web custom connectors may omit `resource` and store the server
-URL as `https://mcp.jurisdigta.eu/MCP`; JurisDigta detects Claude OAuth clients
-from the public client id/redirect host and issues `/MCP`-audience access and
-refresh tokens for that flow. Protected-resource metadata includes a
-human-readable `resource_name`, and authorization-server metadata advertises
-both protected MCP resources, `client_id_metadata_document_supported=true`, and
+requests. Claude web custom connectors should store the server URL as
+`https://mcp.jurisdigta.eu/MCP`; that uppercase path is public for bounded
+public-law tools and is not advertised as an OAuth protected resource.
+Protected-resource metadata includes a human-readable `resource_name`, and
+authorization-server metadata advertises only the lowercase protected MCP
+resource, `client_id_metadata_document_supported=true`, and
 `authorization_response_iss_parameter_supported=true`. The authorization
 callback returns `iss=https://mcp.jurisdigta.eu` with the authorization code so
 strict OAuth clients can bind the response to the issuer.
@@ -143,7 +144,7 @@ Manual JWT generation remains useful for local VS Code setups that pass an `Auth
 Use `https://mcp.jurisdigta.eu/mcp` as the remote MCP server URL in clients that support custom HTTP MCP servers.
 
 - ChatGPT custom connectors: create a remote MCP connector and enter the MCP server URL. Prefer OAuth discovery when the connector supports it. Users may self-register during the browser authorization flow, but ChatGPT only receives the OAuth access token and tool results, not a raw API key.
-- Claude web custom connectors: use `https://mcp.jurisdigta.eu/MCP`. This uppercase path is intentionally a public-law compatibility endpoint because Claude web may complete OAuth and then reject the issued credentials before making any authenticated MCP request. Claude Desktop, Claude Code, and local OAuth proxies can use loopback callbacks such as `http://localhost/...`, `http://127.0.0.1/...`, or `http://[::1]/...`.
+- Claude web custom connectors: use `https://mcp.jurisdigta.eu/MCP`. This uppercase path is intentionally a public-law compatibility endpoint without OAuth protected-resource discovery because Claude web may complete OAuth and then reject the issued credentials before making any authenticated MCP request. Claude Desktop, Claude Code, and local OAuth proxies can use loopback callbacks such as `http://localhost/...`, `http://127.0.0.1/...`, or `http://[::1]/...`.
 - VS Code: add an HTTP MCP server in MCP settings. If OAuth is unavailable in the client, include `Authorization: Bearer <mcp_api_key>` after generating a key from `/mcp/login`.
 - Perplexity and other clients: use the MCP server URL where custom remote MCP servers are supported. Hosted OAuth callbacks include `https://vscode.dev/redirect`, `https://claude.ai/api/mcp/auth_callback`, and `https://www.perplexity.ai/rest/connections/oauth_callback` when their hosts are listed in `MCP_OAUTH_ALLOWED_REDIRECT_HOSTS`. If a product only exposes its own MCP server and does not support registering external MCP servers, use another MCP-compatible host.
 

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -34,7 +34,8 @@ print(
 )
 print(
     "mcp_endpoint_claude_compat => /MCP remains accepted for Claude web and existing clients; "
-    "it allows public-law tools without OAuth because Claude web can reject issued OAuth credentials."
+    "it allows public-law tools without OAuth and does not advertise protected-resource metadata "
+    "because Claude web can reject issued OAuth credentials."
 )
 print(
     "mcp_protocol_negotiation => initialize echoes supported client protocol versions "


### PR DESCRIPTION
## Summary
- stop advertising uppercase /MCP as an OAuth protected resource so Claude web does not force OAuth for the public compatibility endpoint
- keep lowercase /mcp in OAuth protected-resource and authorization-server metadata
- update MCP docs, minimal demo output, and API revision

## Validation
- .\\conda\\python.exe -m pytest api\\aijuristiction-api\\tests\\test_mcp_api.py -q
- ..\\..\\conda\\python.exe -m ruff check app tests
- ..\\..\\conda\\python.exe -m mypy app
- .\\scripts\\validate_api.ps1
- .\\conda\\python.exe -m pytest api\\aijuristiction-api\\tests -q --tb=short
- .\\conda\\python.exe examples\\minimal_demo.py