### PR TITLE
Hide root OAuth discovery for Claude web MCP

### DIFF
--- a/api/aijuristiction-api/app/mcp_api.py
+++ b/api/aijuristiction-api/app/mcp_api.py
@@ -346,7 +346,17 @@ def mcp_sign_up_page(request: Request) -> HTMLResponse:
 
 
 @oauth_router.get("/.well-known/oauth-protected-resource")
-def oauth_protected_resource_metadata(request: Request) -> dict[str, Any]:
+def oauth_protected_resource_metadata(request: Request) -> Any:
+    if _is_claude_web_root_oauth_discovery(request):
+        logger.info(
+            "mcp_oauth_root_discovery_hidden_for_claude_web request_path=%s user_agent=%s",
+            request.url.path,
+            _oauth_user_agent_family(request),
+        )
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"detail": "Root OAuth protected-resource discovery is not available for Claude web"},
+        )
     base_url = _base_url(request)
     resource = _metadata_resource_url(request)
     logger.info(
@@ -367,7 +377,7 @@ def oauth_protected_resource_metadata(request: Request) -> dict[str, Any]:
 
 
 @oauth_router.get("/.well-known/oauth-protected-resource/mcp")
-def oauth_mcp_protected_resource_metadata(request: Request) -> dict[str, Any]:
+def oauth_mcp_protected_resource_metadata(request: Request) -> Any:
     return oauth_protected_resource_metadata(request)
 
 
@@ -384,7 +394,17 @@ def oauth_legacy_public_mcp_protected_resource_metadata() -> JSONResponse:
 @oauth_router.get("/.well-known/oauth-authorization-server")
 @oauth_router.get("/.well-known/oauth-authorization-server/MCP")
 @oauth_router.get("/.well-known/oauth-authorization-server/mcp")
-def oauth_authorization_server_metadata(request: Request) -> dict[str, Any]:
+def oauth_authorization_server_metadata(request: Request) -> Any:
+    if _is_claude_web_root_oauth_discovery(request):
+        logger.info(
+            "mcp_oauth_root_discovery_hidden_for_claude_web request_path=%s user_agent=%s",
+            request.url.path,
+            _oauth_user_agent_family(request),
+        )
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"detail": "Root OAuth authorization-server discovery is not available for Claude web"},
+        )
     base_url = _base_url(request)
     protected_resources = _all_mcp_resource_urls(request)
     logger.info(
@@ -2675,6 +2695,19 @@ def _oauth_user_agent_family(request: Request) -> str:
     if "mozilla" in user_agent or "chrome" in user_agent or "safari" in user_agent:
         return "browser"
     return "unknown"
+
+
+def _is_claude_web_root_oauth_discovery(request: Request) -> bool:
+    path = request.url.path.rstrip("/")
+    if path not in {
+        "/.well-known/oauth-protected-resource",
+        "/.well-known/oauth-authorization-server",
+        "/.well-known/oauth-authorization-server/MCP",
+    }:
+        return False
+    user_agent = request.headers.get("user-agent", "").lower()
+    protocol_version = request.headers.get("mcp-protocol-version", "").strip()
+    return "python-httpx" in user_agent and protocol_version == MCP_PROTOCOL_VERSION
 
 
 def _http_exception_detail(exc: HTTPException) -> str:

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260500"
+version = "1.0.260501"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_mcp_api.py
+++ b/api/aijuristiction-api/tests/test_mcp_api.py
@@ -964,19 +964,30 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
         headers={"user-agent": "python-httpx/0.28.1", "mcp-protocol-version": "2025-11-25"},
     )
     assert claude_web_protected_metadata.status_code == 200
-    claude_web_authorization_metadata = mcp_client.get(
+    claude_web_root_protected_metadata = mcp_client.get(
+        "/.well-known/oauth-protected-resource",
+        headers={"user-agent": "python-httpx/0.28.1", "mcp-protocol-version": "2025-11-25"},
+    )
+    assert claude_web_root_protected_metadata.status_code == 404
+    claude_web_root_authorization_metadata = mcp_client.get(
+        "/.well-known/oauth-authorization-server",
+        headers={"user-agent": "python-httpx/0.28.1", "mcp-protocol-version": "2025-11-25"},
+    )
+    assert claude_web_root_authorization_metadata.status_code == 404
+    claude_web_authorization_metadata_without_protocol_header = mcp_client.get(
         "/.well-known/oauth-authorization-server",
         headers={"user-agent": "python-httpx/0.28.1"},
     )
-    assert claude_web_authorization_metadata.status_code == 200
-    assert claude_web_authorization_metadata.json()["registration_endpoint"].endswith("/oauth/register")
-    assert claude_web_authorization_metadata.json()["authorization_response_iss_parameter_supported"] is True
-    monkeypatch.setenv("MCP_CLAUDE_WEB_PUBLIC_DISCOVERY", "true")
-    claude_web_authorization_metadata_with_legacy_flag = mcp_client.get(
-        "/.well-known/oauth-authorization-server",
-        headers={"user-agent": "python-httpx/0.28.1"},
+    assert claude_web_authorization_metadata_without_protocol_header.status_code == 200
+    assert claude_web_authorization_metadata_without_protocol_header.json()["registration_endpoint"].endswith(
+        "/oauth/register"
     )
-    assert claude_web_authorization_metadata_with_legacy_flag.status_code == 200
+    assert (
+        claude_web_authorization_metadata_without_protocol_header.json()[
+            "authorization_response_iss_parameter_supported"
+        ]
+        is True
+    )
     claude_web_registration_with_legacy_flag = mcp_client.post(
         "/oauth/register",
         headers={"user-agent": "python-httpx/0.28.1"},
@@ -990,7 +1001,6 @@ def test_oauth_discovery_and_authorization_code_flow(monkeypatch, tmp_path: Path
         },
     )
     assert claude_web_registration_with_legacy_flag.status_code == 201
-    monkeypatch.delenv("MCP_CLAUDE_WEB_PUBLIC_DISCOVERY")
     authorization_metadata = mcp_client.get("/.well-known/oauth-authorization-server")
     assert authorization_metadata.status_code == 200
     assert authorization_metadata.json()["code_challenge_methods_supported"] == ["S256"]

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -20,6 +20,9 @@ accidentally saved with the truncated Claude URL `/MC`. OAuth metadata keeps
 `/.well-known/oauth-protected-resource/MCP` path intentionally returns `404`
 because Claude web may store custom connector URLs with uppercase `/MCP` and
 will force OAuth when that path is advertised as protected.
+Claude web backend discovery at the root OAuth metadata URLs is also hidden
+when the request uses Claude's `python-httpx` MCP client headers, because Claude
+falls back to root discovery after uppercase path discovery returns `404`.
 Because Claude web can complete OAuth and then reject the issued credentials
 without making an authenticated MCP call, `/MCP` also acts as a public-law
 compatibility endpoint for Claude web: it allows `getVersion`, `getStatistics`,

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -35,7 +35,7 @@ print(
 print(
     "mcp_endpoint_claude_compat => /MCP remains accepted for Claude web and existing clients; "
     "it allows public-law tools without OAuth and does not advertise protected-resource metadata "
-    "because Claude web can reject issued OAuth credentials."
+    "or Claude-web root OAuth discovery because Claude web can reject issued OAuth credentials."
 )
 print(
     "mcp_protocol_negotiation => initialize echoes supported client protocol versions "


### PR DESCRIPTION
## Summary
- hide root OAuth protected-resource and authorization-server discovery for Claude web backend MCP probes
- keep lowercase /mcp OAuth discovery and dynamic registration available for normal OAuth clients
- update MCP tests, docs, minimal demo, and API revision

## Validation
- .\\conda\\python.exe -m pytest api\\aijuristiction-api\\tests\\test_mcp_api.py -q
- ..\\..\\conda\\python.exe -m ruff check app tests
- ..\\..\\conda\\python.exe -m mypy app
- .\\scripts\\validate_api.ps1
- .\\conda\\python.exe examples\\minimal_demo.py
- .\\conda\\python.exe -m pytest api\\aijuristiction-api\\tests\\test_chat.py::test_stream_share_transfer_with_labeled_company_name_uses_registry_first -vv --tb=long --capture=no

Note: full API suite was retried but the shell run stopped without a failure summary after long execution; the last visible chat test passes standalone and the focused MCP/API validation gates are clean.