### PR TITLE
Support MCP SSE GET probes

### DIFF
--- a/api/aijuristiction-api/app/mcp_api.py
+++ b/api/aijuristiction-api/app/mcp_api.py
@@ -12,7 +12,7 @@ import os
 import re
 import secrets
 import time
-from typing import Any, Callable, Sequence, cast
+from typing import Any, AsyncIterator, Callable, Sequence, cast
 from datetime import datetime, timedelta, timezone
 from ipaddress import ip_address
 from urllib.parse import urlparse
@@ -21,7 +21,7 @@ from urllib.request import Request as UrlRequest
 from urllib.request import urlopen
 
 from fastapi import APIRouter, Body, Depends, Form, Header, HTTPException, Request, status
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response, StreamingResponse
 
 from app.laws_api import _laws_db_config, _read_laws_statistics
 from app.mcp_tokens import (
@@ -249,10 +249,39 @@ def require_mcp_api_key(
     return str(user.user_id)
 
 
-@router.get("", response_class=JSONResponse)
-@legacy_uppercase_router.get("", response_class=JSONResponse)
-def mcp_status() -> JSONResponse:
-    return JSONResponse(status_code=405, content={"detail": "Use POST /mcp for Streamable HTTP JSON-RPC."})
+@router.get("")
+@compat_router.get("")
+@legacy_uppercase_router.get("")
+async def mcp_status(request: Request) -> Response:
+    accept = request.headers.get("accept", "").lower()
+    if "text/event-stream" not in accept:
+        return JSONResponse(
+            status_code=405,
+            content={"detail": "Use POST /mcp for Streamable HTTP JSON-RPC."},
+            headers={"Allow": "GET, POST"},
+        )
+
+    request_id = getattr(request.state, "request_id", None)
+    correlation_id = getattr(request.state, "correlation_id", None)
+    logger.info(
+        "mcp_sse_stream_opened request_path=%s request_id=%s correlation_id=%s user_agent=%s",
+        request.url.path,
+        request_id,
+        correlation_id,
+        _oauth_user_agent_family(request),
+    )
+
+    async def events() -> AsyncIterator[str]:
+        yield ": jurisdigta-mcp-ready\n\n"
+
+    return StreamingResponse(
+        events(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 @router.get("/status", response_class=JSONResponse)

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260501"
+version = "1.0.260502"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_mcp_api.py
+++ b/api/aijuristiction-api/tests/test_mcp_api.py
@@ -134,6 +134,32 @@ def test_mcp_accepts_claude_backend_probe_without_bearer_token() -> None:
     assert initialize_response.json()["result"]["serverInfo"]["name"] == "aijurisdiction-laws-mcp"
 
 
+def test_mcp_plain_get_keeps_method_guidance() -> None:
+    response = mcp_client.get("/MCP")
+
+    assert response.status_code == 405
+    assert response.headers["allow"] == "GET, POST"
+    assert response.json()["detail"] == "Use POST /mcp for Streamable HTTP JSON-RPC."
+
+
+def test_mcp_accepts_sse_get_probe_for_streamable_http_clients(caplog) -> None:
+    caplog.set_level(logging.INFO, logger="aijuristiction-api.mcp")
+
+    response = mcp_client.get(
+        "/MCP",
+        headers={
+            "accept": "text/event-stream",
+            "user-agent": "python-httpx/0.28.1",
+            "mcp-protocol-version": "2025-11-25",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert response.text == ": jurisdigta-mcp-ready\n\n"
+    assert any("mcp_sse_stream_opened request_path=/MCP" in record.getMessage() for record in caplog.records)
+
+
 def test_mcp_initialize_defaults_to_latest_for_unknown_protocol() -> None:
     initialize_response = mcp_client.post(
         "/mcp",

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -5,6 +5,9 @@ The local default is `http://127.0.0.1:8070`, and production routing should map
 `https://mcp.jurisdigta.eu` to the MCP service, not to `api.jurisdigta.eu`.
 
 The MCP service exposes a Streamable HTTP-style MCP JSON-RPC endpoint at `POST /mcp`.
+Clients that probe the MCP endpoint with `GET /mcp` or `GET /MCP` and
+`Accept: text/event-stream` receive a minimal SSE-ready stream; plain browser
+GET requests still return `405` with guidance to use POST.
 It is intended for AI assistants that can connect to remote MCP servers over HTTP.
 For ChatGPT, Claude, and VS Code OAuth-capable clients, start from the OAuth metadata endpoints instead of manually copying a token.
 The API `/version`, MCP `/version`, and MCP `getVersion` tool expose `mcp_server_version`.
@@ -106,10 +109,10 @@ Production settings:
 - `MCP_OAUTH_TEST_MFA_BYPASS_ENABLED=false` by default. For controlled Claude/E2E validation only, operators may temporarily enable it for the synthetic emails `mcp-claude-test-free@jurisdigta.eu` and `mcp-claude-test-paid@jurisdigta.eu` with `MCP_OAUTH_TEST_MFA_BYPASS_EXPIRES_AT=2030-01-01T00:00:00Z`. The bypass is hard-limited to MCP OAuth authorization and still requires the correct password.
 - `JURISDIGTA_E2E_TEST_USER_PASSWORD=<secret>` is used by `python scripts/provision_e2e_users.py` to create or update the synthetic free/paid E2E accounts. Keep it in runtime secret storage only.
 
-Do not hide OAuth discovery from Claude web custom connector probes. Claude web
-uses `python-httpx` while validating custom connectors and must receive the
-protected-resource metadata, authorization-server metadata, and dynamic client
-registration response before it can start the browser authorization flow.
+Root OAuth discovery is hidden from Claude web custom connector probes that use
+`python-httpx` with the MCP protocol header. Claude web should validate the
+uppercase `/MCP` compatibility endpoint as a bounded public-law MCP endpoint
+instead of starting OAuth for that saved connector URL.
 Claude and other clients may send Dynamic Client Registration metadata that includes `client_credentials`; JurisDigta accepts that compatibility shape only when `authorization_code` is also requested, returns the public-client grants `authorization_code` and `refresh_token`, and continues to reject actual `grant_type=client_credentials` token exchanges.
 
 ## Authentication


### PR DESCRIPTION
## Summary
- Add a minimal Streamable HTTP SSE GET response for `/mcp`, `/MCP`, and `/MC` when clients send `Accept: text/event-stream`.
- Keep plain browser GET requests returning 405 with POST guidance.
- Document Claude web compatibility behavior and bump API revision to 1.0.260502.

## Validation
- `./conda/python.exe -m pytest api/aijuristiction-api/tests/test_mcp_api.py -q`
- `./conda/python.exe examples/minimal_demo.py`
- `python -m ruff check app tests` from `api/aijuristiction-api`
- `python -m mypy app` from `api/aijuristiction-api`
- `./scripts/validate_api.ps1`

Full `pytest api/aijuristiction-api/tests -q` was attempted but timed out after 5 minutes in the local shell without a failure summary; GitHub CI should provide the full-suite result.