### PR TITLE
Add court decision latest date Grafana panel

### DIFF
--- a/Deployment/monitoring/README.md
+++ b/Deployment/monitoring/README.md
@@ -18,7 +18,7 @@ GET /v1/system/status?minutes=60
 - Total imported laws over time, last imported law number/year, next law to check, latest laws collector run timestamps, and latest run duration.
 - Email sent counts, email queue counts, and aggregate email send duration from the outbox.
 - Document processor queue counts, processed document counts, latest run duration, and aggregate processing duration.
-- Court-decision collector status, imported decision/version counts, embedding-vector coverage, worker activity counts, activity timestamps, and sanitized recent errors.
+- Court-decision collector status, imported decision/version counts, newest stored decision issue date, embedding-vector coverage, worker activity counts, activity timestamps, and sanitized recent errors.
 - AI model token and cost telemetry: input tokens, cached input tokens, output tokens, total tokens, estimated EUR cost, request count, and fallback count by provider, model, task type, plan, route type, route class, and 1h/24h/7d/30d window.
 - Host CPU, memory, disk, filesystem, and kernel metrics through Node Exporter.
 - Docker container CPU, memory, filesystem, and restart behavior through cAdvisor.
@@ -518,7 +518,7 @@ Grafana loads JurisDigta dashboards from `grafana/dashboards` into the
 - `JurisDigta Application Performance`: API/MCP/web/Grafana HTTP probes, component status, email queue/sent/time, document queue/processed/time, laws processing cursor and runtime, and application error counts.
 - `JurisDigta Ollama And AI Models`: Ollama API health, configured model presence, installed/running model counts, model size, loaded model VRAM, probe latency, local/Ollama tokens, paid-model tokens, requests, estimated cost, and masked top cases by token volume.
 - `JurisDigta Laws Collector`: total imported laws over time, latest imported law identifier, execution time, imported laws per latest run, processed entries/documents, and recent sanitized collector errors.
-- `JurisDigta Court Decision Service`: current collector status, imported decisions, latest imported decision timestamp, stored versions, versions with embeddings, processing/processed/idle activity, storage totals, and recent sanitized collector errors.
+- `JurisDigta Court Decision Service`: current collector status, imported decisions, newest stored decision issue date, latest imported decision timestamp, stored versions, versions with embeddings, processing/processed/idle activity, storage totals, and recent sanitized collector errors.
 - `JurisDigta Errors`: total errors, error telemetry status, error counts by source, HTTP probe status codes, and scrape target health.
 - `JurisDigta System Logs`: Loki log stream with source, severity, stream, and regex search filters for Docker container logs and server job log files.
 
@@ -571,6 +571,7 @@ Useful starter queries:
 - `jurisdigta_court_decision_collector_events_total{event="processed"}`
 - `jurisdigta_court_decision_collector_last_activity_timestamp_seconds`
 - `jurisdigta_court_decision_latest_imported_timestamp_seconds`
+- `jurisdigta_court_decision_latest_stored_issue_date_timestamp_seconds`
 - `jurisdigta_court_decision_recent_error_info`
 - `jurisdigta_system_disk_used_percent`
 - `jurisdigta_system_memory_used_percent`

--- a/Deployment/monitoring/grafana/dashboards/jurisdigta-court-decision-service.json
+++ b/Deployment/monitoring/grafana/dashboards/jurisdigta-court-decision-service.json
@@ -70,7 +70,7 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 5,
+        "w": 4,
         "x": 0,
         "y": 0
       },
@@ -133,8 +133,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 5,
-        "x": 5,
+        "w": 4,
+        "x": 4,
         "y": 0
       },
       "id": 2,
@@ -197,7 +197,70 @@
       "gridPos": {
         "h": 7,
         "w": 4,
-        "x": 10,
+        "x": 8,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "jurisdigta_court_decision_latest_stored_issue_date_timestamp_seconds * 1000",
+          "legendFormat": "Decision issue date",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Najnovší uložený dátum rozhodnutia",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "jurisdigta-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "dateTimeAsIso"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 12,
         "y": 0
       },
       "id": 8,
@@ -259,8 +322,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 5,
-        "x": 14,
+        "w": 4,
+        "x": 16,
         "y": 0
       },
       "id": 3,
@@ -322,8 +385,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 5,
-        "x": 19,
+        "w": 4,
+        "x": 20,
         "y": 0
       },
       "id": 4,
@@ -651,5 +714,5 @@
   "timezone": "browser",
   "title": "JurisDigta Court Decision Service",
   "uid": "jurisdigta-court-decision-service",
-  "version": 1
+  "version": 2
 }

--- a/docs/COURT_DECISION_COLLECTOR.md
+++ b/docs/COURT_DECISION_COLLECTOR.md
@@ -57,6 +57,7 @@ The dashboard uses aggregate Prometheus metrics from
 - `jurisdigta_court_decision_collector_events_total`
 - `jurisdigta_court_decision_collector_last_activity_timestamp_seconds`
 - `jurisdigta_court_decision_latest_imported_timestamp_seconds`
+- `jurisdigta_court_decision_latest_stored_issue_date_timestamp_seconds`
 - `jurisdigta_court_decision_recent_error_info`
 
 These metrics must remain operational and aggregate-only. Do not expose raw

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -212,3 +212,8 @@ print(
     "pseudonymized MCP search output; run "
     "`python examples/court_decision_collector_minimal_demo.py` for the focused fixture demo."
 )
+print(
+    "court_decision_grafana => JurisDigta Court Decision Service shows the aggregate "
+    "Najnovší uložený dátum rozhodnutia date without exposing court decision text, "
+    "parties, file numbers, ECLI values, or source identifiers."
+)

--- a/examples/monitoring_scrape_demo.py
+++ b/examples/monitoring_scrape_demo.py
@@ -55,6 +55,7 @@ def main() -> int:
             "jurisdigta_laws_last_processed_year",
             "jurisdigta_component_status{component=\"court_decision_collector\"}",
             "jurisdigta_court_decisions_total",
+            "jurisdigta_court_decision_latest_stored_issue_date_timestamp_seconds",
         )
         if not _query(expression)
     ]

--- a/scripts/server/export_system_status_metrics.py
+++ b/scripts/server/export_system_status_metrics.py
@@ -511,6 +511,11 @@ def _append_court_decision_collector_metrics(lines: list[str], system: dict[str,
             "Unix timestamp for latest imported court decision.",
         ),
         (
+            "latest_stored_issue_date",
+            "jurisdigta_court_decision_latest_stored_issue_date_timestamp_seconds",
+            "Unix timestamp for newest stored court decision issue date.",
+        ),
+        (
             "latest_update_event_at",
             "jurisdigta_court_decision_latest_update_event_timestamp_seconds",
             "Unix timestamp for latest court decision update event.",

--- a/scripts/server/write_system_status.py
+++ b/scripts/server/write_system_status.py
@@ -373,6 +373,9 @@ def _court_decision_db_status(postgres_container: str) -> dict[str, Any]:
       'latest_imported_at', (
         SELECT MAX(last_stored_at) FROM court_decision_documents
       ),
+      'latest_stored_issue_date', (
+        SELECT MAX(NULLIF(issue_date, '')) FROM court_decision_documents
+      ),
       'latest_update_event_at', (
         SELECT MAX(created_at) FROM court_decision_update_events
       ),

--- a/tests/test_server_monitoring.py
+++ b/tests/test_server_monitoring.py
@@ -89,6 +89,7 @@ def test_monitoring_dashboards_include_court_decision_service_dashboard() -> Non
     assert dashboard["uid"] == "jurisdigta-court-decision-service"
     assert "Collector Status" in panel_titles
     assert "Imported Decisions" in panel_titles
+    assert "Najnovší uložený dátum rozhodnutia" in panel_titles
     assert "Latest Imported Decision" in panel_titles
     assert "Versions With Embeddings" in panel_titles
     assert "Recent Sanitized Error List" in panel_titles
@@ -97,6 +98,10 @@ def test_monitoring_dashboards_include_court_decision_service_dashboard() -> Non
         in target_queries
     )
     assert "jurisdigta_court_decision_latest_imported_timestamp_seconds * 1000" in target_queries
+    assert (
+        "jurisdigta_court_decision_latest_stored_issue_date_timestamp_seconds * 1000"
+        in target_queries
+    )
 
 
 def test_monitoring_dashboards_include_laws_collector_corpus_panels() -> None:
@@ -490,6 +495,7 @@ def test_exporter_renders_court_decision_metrics() -> None:
                         "idle_events": 2,
                         "last_activity_at": "2026-06-20T01:06:00Z",
                         "latest_imported_at": "2026-06-20T01:00:01Z",
+                        "latest_stored_issue_date": "2026-06-29",
                         "latest_update_event_at": "2026-06-20T01:00:02Z",
                         "recent_errors": [
                             {
@@ -516,6 +522,7 @@ def test_exporter_renders_court_decision_metrics() -> None:
         in metrics
     )
     assert "jurisdigta_court_decision_collector_last_activity_timestamp_seconds" in metrics
+    assert "jurisdigta_court_decision_latest_stored_issue_date_timestamp_seconds" in metrics
     assert (
         'jurisdigta_court_decision_recent_error_info{index="1",'
         'timestamp="2026-06-20T01:06:00Z",message="failed import_key=live_loop"} 1'


### PR DESCRIPTION
## Summary
- add an aggregate latest stored court decision issue-date metric
- add the Grafana panel titled "Najnovší uložený dátum rozhodnutia"
- update monitoring docs and runnable examples

## Compliance
- dashboard remains aggregate-only and does not expose decision text, parties, file numbers, ECLI values, source identifiers, prompts, snippets, or embeddings

## Validation
- python -m json.tool Deployment\monitoring\grafana\dashboards\jurisdigta-court-decision-service.json > $null
- python -m pytest tests\test_server_monitoring.py
- $env:PYTHONPATH='src'; python -m ruff check scripts\server\write_system_status.py scripts\server\export_system_status_metrics.py tests\test_server_monitoring.py examples\monitoring_scrape_demo.py examples\minimal_demo.py
- $env:PYTHONPATH='src'; python examples\minimal_demo.py

Note: this worktree did not contain .\conda, so validation used the available Python 3.13.5 runtime.