### PR TITLE
Fix laws collector last imported law panel

### DIFF
--- a/Deployment/monitoring/README.md
+++ b/Deployment/monitoring/README.md
@@ -517,7 +517,7 @@ Grafana loads JurisDigta dashboards from `grafana/dashboards` into the
 - `JurisDigta Server Performance`: CPU, RAM, disk, load, network, disk I/O, and container memory.
 - `JurisDigta Application Performance`: API/MCP/web/Grafana HTTP probes, component status, email queue/sent/time, document queue/processed/time, laws processing cursor and runtime, and application error counts.
 - `JurisDigta Ollama And AI Models`: Ollama API health, configured model presence, installed/running model counts, model size, loaded model VRAM, probe latency, local/Ollama tokens, paid-model tokens, requests, estimated cost, and masked top cases by token volume.
-- `JurisDigta Laws Collector`: total imported laws over time, latest imported law identifier, execution time, imported laws per latest run, processed entries/documents, and recent sanitized collector errors.
+- `JurisDigta Laws Collector`: total imported laws over time, latest imported law identifier such as `179/2026`, execution time, imported laws per latest run, processed entries/documents, and recent sanitized collector errors.
 - `JurisDigta Court Decision Service`: current collector status, imported decisions, newest stored decision issue date, latest imported decision timestamp, stored versions, versions with embeddings, processing/processed/idle activity, storage totals, and recent sanitized collector errors.
 - `JurisDigta Errors`: total errors, error telemetry status, error counts by source, HTTP probe status codes, and scrape target health.
 - `JurisDigta System Logs`: Loki log stream with source, severity, stream, and regex search filters for Docker container logs and server job log files.
@@ -604,6 +604,10 @@ Useful starter queries:
 - `jurisdigta_ai_model_top_case_estimated_cost_eur_window{case_ref="case-....",route_class="...",window_minutes="..."}`
 - `up{job="node-exporter"}`
 - `up{job="cadvisor"}`
+
+The laws collector `Last Imported Law` stat panel uses the `law` label from
+`jurisdigta_laws_last_processed_info` as its display name, so Grafana shows the
+full identifier (`number/year`) instead of the Prometheus sample value `1`.
 
 Suggested alert rules:
 

--- a/Deployment/monitoring/grafana/dashboards/jurisdigta-laws-collector.json
+++ b/Deployment/monitoring/grafana/dashboards/jurisdigta-laws-collector.json
@@ -381,6 +381,7 @@
           "color": {
             "mode": "thresholds"
           },
+          "displayName": "${__field.labels.law}",
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -426,8 +427,9 @@
         {
           "editorMode": "code",
           "expr": "jurisdigta_laws_last_processed_info",
+          "instant": true,
           "legendFormat": "{{law}}",
-          "range": true,
+          "range": false,
           "refId": "A"
         }
       ],

--- a/docs/SYSTEM_STATUS_MONITORING.md
+++ b/docs/SYSTEM_STATUS_MONITORING.md
@@ -275,6 +275,11 @@ Useful Grafana panels:
 - `jurisdigta_ai_model_top_case_total_tokens_window`
 - `jurisdigta_ai_model_top_case_estimated_cost_eur_window`
 
+The laws collector dashboard renders `jurisdigta_laws_last_processed_info` with
+the `law` label as the stat display name, so the latest imported law appears as
+`number/year` such as `179/2026`. Use the numeric number/year metrics for
+charts and alert thresholds.
+
 The provisioned `JurisDigta Application Performance` dashboard includes
 aggregate AI model panels for usage status, EUR cost, requests by route, and
 tokens by provider/model/route for 1h, 24h, 7d, and 30d windows. The provisioned

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -202,6 +202,10 @@ print(
     "emails, phone numbers, or legal-case facts in labels."
 )
 print(
+    "laws_collector_grafana_monitoring => JurisDigta Laws Collector displays the "
+    "latest imported law from the aggregate law label, for example 179/2026."
+)
+print(
     "service_healthchecks => HTTP services expose privacy-minimized /health; "
     "worker services report supervisor state, freshness, latest run result, "
     "and sanitized errors through protected operational status."

--- a/examples/monitoring_scrape_demo.py
+++ b/examples/monitoring_scrape_demo.py
@@ -51,6 +51,7 @@ def main() -> int:
             "jurisdigta_ai_model_total_tokens_window",
             "jurisdigta_ai_model_top_case_total_tokens_window",
             'jurisdigta_laws_total{name="laws_imported"}',
+            "jurisdigta_laws_last_processed_info",
             "jurisdigta_laws_last_processed_number",
             "jurisdigta_laws_last_processed_year",
             "jurisdigta_component_status{component=\"court_decision_collector\"}",

--- a/tests/test_server_monitoring.py
+++ b/tests/test_server_monitoring.py
@@ -122,6 +122,14 @@ def test_monitoring_dashboards_include_laws_collector_corpus_panels() -> None:
     assert 'jurisdigta_laws_total{name="laws_imported"}' in target_queries
     assert "jurisdigta_laws_last_processed_info" in target_queries
 
+    last_imported_law_panel = next(
+        panel for panel in dashboard["panels"] if panel.get("title") == "Last Imported Law"
+    )
+    assert last_imported_law_panel["fieldConfig"]["defaults"]["displayName"] == "${__field.labels.law}"
+    assert last_imported_law_panel["options"]["textMode"] == "name"
+    assert last_imported_law_panel["targets"][0]["instant"] is True
+    assert last_imported_law_panel["targets"][0]["range"] is False
+
 
 def test_monitoring_stack_loads_ai_model_alert_rules() -> None:
     compose = (MONITORING_DIR / "docker-compose.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Fix the JurisDigta Laws Collector Grafana stat panel so Last Imported Law displays the law label, for example 179/2026, instead of an empty stat body.
- Add regression coverage for the dashboard JSON contract and include the label metric in the monitoring scrape example.
- Update monitoring docs and the default minimal demo note.

## Compliance
- GDPR/EU AI Act review: this remains aggregate operational telemetry and exposes only public law identifiers such as number/year. It does not expose user data, prompts, case facts, legal document contents, secrets, or raw collector logs.

## Validation
- python -m pytest tests/test_server_monitoring.py
- PYTHONPATH=src;api\\aijuristiction-api python examples/minimal_demo.py