### PR TITLE
Show latest imported court decision info in Grafana

### DIFF
--- a/Deployment/monitoring/README.md
+++ b/Deployment/monitoring/README.md
@@ -18,7 +18,7 @@ GET /v1/system/status?minutes=60
 - Total imported laws over time, last imported law number/year, next law to check, latest laws collector run timestamps, and latest run duration.
 - Email sent counts, email queue counts, and aggregate email send duration from the outbox.
 - Document processor queue counts, processed document counts, latest run duration, and aggregate processing duration.
-- Court-decision collector status, imported decision/version counts, newest stored decision issue date, embedding-vector coverage, worker activity counts, activity timestamps, and sanitized recent errors.
+- Court-decision collector status, imported decision/version counts, latest imported decision safe short name and published date, newest stored decision issue date, embedding-vector coverage, worker activity counts, activity timestamps, and sanitized recent errors.
 - AI model token and cost telemetry: input tokens, cached input tokens, output tokens, total tokens, estimated EUR cost, request count, and fallback count by provider, model, task type, plan, route type, route class, and 1h/24h/7d/30d window.
 - Host CPU, memory, disk, filesystem, and kernel metrics through Node Exporter.
 - Docker container CPU, memory, filesystem, and restart behavior through cAdvisor.
@@ -47,7 +47,7 @@ http://127.0.0.1:3000
 - If Grafana must be reachable through `admin.jurisdigta.eu`, publish it through Cloudflare Tunnel and protect it with Cloudflare Access plus Grafana login.
 - Keep dashboard panels operational only. Do not display user chat text, generated legal documents, API keys, database connection strings, or legal-risk user outputs.
 - Email and document processor panels must stay aggregate-only: queue counts, sent/processed counts, and timing gauges. Do not add recipients, filenames, case titles, extracted document text, verification codes, embeddings, or raw connection strings as labels.
-- Court-decision panels must stay aggregate-only: status, counts, timestamps, and sanitized operational errors. Do not add raw decision text, party names, file content, source URLs, source GUIDs, ECLI values, file numbers, prompts, retrieved snippets, embeddings, or personal data as labels or table fields.
+- Court-decision panels must stay aggregate-only: status, counts, safe short names, dates, timestamps, and sanitized operational errors. Do not add raw decision text, party names, file content, source URLs, source GUIDs, ECLI values, file numbers, prompts, retrieved snippets, embeddings, or personal data as labels or table fields.
 - Shared AI model panels must stay aggregate-only. Allowed labels include categories such as plan code, provider, model, task type, route type, route class, status, fallback reason, and window. Do not add raw case IDs, user IDs, subscription IDs, prompts, answers, document text, filenames, party names, citations, emails, phone numbers, addresses, or other legal-case facts as metric labels. The top-case Grafana panel uses masked `case_ref` values only.
 
 ## AI Model Token And Cost Monitoring
@@ -518,7 +518,7 @@ Grafana loads JurisDigta dashboards from `grafana/dashboards` into the
 - `JurisDigta Application Performance`: API/MCP/web/Grafana HTTP probes, component status, email queue/sent/time, document queue/processed/time, laws processing cursor and runtime, and application error counts.
 - `JurisDigta Ollama And AI Models`: Ollama API health, configured model presence, installed/running model counts, model size, loaded model VRAM, probe latency, local/Ollama tokens, paid-model tokens, requests, estimated cost, and masked top cases by token volume.
 - `JurisDigta Laws Collector`: total imported laws over time, latest imported law identifier such as `179/2026`, execution time, imported laws per latest run, processed entries/documents, and recent sanitized collector errors.
-- `JurisDigta Court Decision Service`: current collector status, imported decisions, newest stored decision issue date, latest imported decision timestamp, stored versions, versions with embeddings, processing/processed/idle activity, storage totals, and recent sanitized collector errors.
+- `JurisDigta Court Decision Service`: current collector status, imported decisions, latest imported decision safe short name and published date, latest imported decision timestamp, stored versions, versions with embeddings, processing/processed/idle activity, storage totals, and recent sanitized collector errors.
 - `JurisDigta Errors`: total errors, error telemetry status, error counts by source, HTTP probe status codes, and scrape target health.
 - `JurisDigta System Logs`: Loki log stream with source, severity, stream, and regex search filters for Docker container logs and server job log files.
 
@@ -571,6 +571,7 @@ Useful starter queries:
 - `jurisdigta_court_decision_collector_events_total{event="processed"}`
 - `jurisdigta_court_decision_collector_last_activity_timestamp_seconds`
 - `jurisdigta_court_decision_latest_imported_timestamp_seconds`
+- `jurisdigta_court_decision_latest_imported_info`
 - `jurisdigta_court_decision_latest_stored_issue_date_timestamp_seconds`
 - `jurisdigta_court_decision_recent_error_info`
 - `jurisdigta_system_disk_used_percent`

--- a/Deployment/monitoring/grafana/dashboards/jurisdigta-court-decision-service.json
+++ b/Deployment/monitoring/grafana/dashboards/jurisdigta-court-decision-service.json
@@ -174,123 +174,82 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "blue",
-                "value": null
-              },
-              {
                 "color": "green",
-                "value": 1
+                "value": null
               }
             ]
-          },
-          "unit": "dateTimeAsIso"
+          }
         },
         "overrides": []
       },
       "gridPos": {
         "h": 7,
-        "w": 4,
+        "w": 8,
         "x": 8,
-        "y": 0
-      },
-      "id": 9,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "13.0.2",
-      "targets": [
-        {
-          "editorMode": "code",
-          "expr": "jurisdigta_court_decision_latest_stored_issue_date_timestamp_seconds * 1000",
-          "legendFormat": "Decision issue date",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Najnovší uložený dátum rozhodnutia",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "jurisdigta-prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "dateTimeAsIso"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 4,
-        "x": 12,
         "y": 0
       },
       "id": 8,
       "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
           "fields": "",
-          "values": false
+          "reducer": [
+            "sum"
+          ],
+          "show": false
         },
-        "textMode": "auto",
-        "wideLayout": true
+        "showHeader": true
       },
       "pluginVersion": "13.0.2",
       "targets": [
         {
           "editorMode": "code",
-          "expr": "jurisdigta_court_decision_latest_imported_timestamp_seconds * 1000",
-          "legendFormat": "Latest import",
-          "range": true,
+          "exemplar": false,
+          "expr": "jurisdigta_court_decision_latest_imported_info",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{short_name}}",
+          "range": false,
           "refId": "A"
         }
       ],
       "title": "Latest Imported Decision",
-      "type": "stat"
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "instance": true,
+              "job": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "published_date": "Published date",
+              "short_name": "Decision",
+              "stored_at": "Stored at"
+            }
+          }
+        }
+      ],
+      "type": "table"
     },
     {
       "datasource": {
@@ -714,5 +673,5 @@
   "timezone": "browser",
   "title": "JurisDigta Court Decision Service",
   "uid": "jurisdigta-court-decision-service",
-  "version": 2
+  "version": 3
 }

--- a/docs/COURT_DECISION_COLLECTOR.md
+++ b/docs/COURT_DECISION_COLLECTOR.md
@@ -57,13 +57,16 @@ The dashboard uses aggregate Prometheus metrics from
 - `jurisdigta_court_decision_collector_events_total`
 - `jurisdigta_court_decision_collector_last_activity_timestamp_seconds`
 - `jurisdigta_court_decision_latest_imported_timestamp_seconds`
+- `jurisdigta_court_decision_latest_imported_info`
 - `jurisdigta_court_decision_latest_stored_issue_date_timestamp_seconds`
 - `jurisdigta_court_decision_recent_error_info`
 
 These metrics must remain operational and aggregate-only. Do not expose raw
 decision text, source URLs, source GUIDs, ECLI values, file numbers, party
 names, retrieved snippets, embeddings, prompts, or other personal/legal-risk
-content in Grafana labels or tables.
+content in Grafana labels or tables. The latest imported decision panel may
+show only a safe short name from decision form plus court type and the published
+date.
 
 ## Service loop and restart test
 

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -218,6 +218,6 @@ print(
 )
 print(
     "court_decision_grafana => JurisDigta Court Decision Service shows the aggregate "
-    "Najnovší uložený dátum rozhodnutia date without exposing court decision text, "
-    "parties, file numbers, ECLI values, or source identifiers."
+    "latest imported court decision short name and published date without exposing "
+    "court decision text, parties, file numbers, ECLI values, or source identifiers."
 )

--- a/examples/monitoring_scrape_demo.py
+++ b/examples/monitoring_scrape_demo.py
@@ -56,6 +56,7 @@ def main() -> int:
             "jurisdigta_laws_last_processed_year",
             "jurisdigta_component_status{component=\"court_decision_collector\"}",
             "jurisdigta_court_decisions_total",
+            "jurisdigta_court_decision_latest_imported_info",
             "jurisdigta_court_decision_latest_stored_issue_date_timestamp_seconds",
         )
         if not _query(expression)

--- a/scripts/server/export_system_status_metrics.py
+++ b/scripts/server/export_system_status_metrics.py
@@ -483,6 +483,23 @@ def _append_court_decision_collector_metrics(lines: list[str], system: dict[str,
         f"{_number(collector.get('versions_with_embeddings'), 0)}"
     )
 
+    latest_imported_decision = collector.get("latest_imported_decision")
+    if isinstance(latest_imported_decision, dict):
+        short_name = str(latest_imported_decision.get("short_name") or "Court decision")
+        published_date = str(latest_imported_decision.get("published_date") or "")
+        stored_at = str(latest_imported_decision.get("stored_at") or "")
+        _append_help(
+            lines,
+            "jurisdigta_court_decision_latest_imported_info",
+            "Privacy-safe display metadata for the latest imported court decision.",
+            "gauge",
+        )
+        lines.append(
+            "jurisdigta_court_decision_latest_imported_info"
+            f'{{short_name="{_label(short_name)}",published_date="{_label(published_date)}",'
+            f'stored_at="{_label(stored_at)}"}} 1'
+        )
+
     _append_help(
         lines,
         "jurisdigta_court_decision_collector_events_total",

--- a/scripts/server/write_system_status.py
+++ b/scripts/server/write_system_status.py
@@ -373,6 +373,19 @@ def _court_decision_db_status(postgres_container: str) -> dict[str, Any]:
       'latest_imported_at', (
         SELECT MAX(last_stored_at) FROM court_decision_documents
       ),
+      'latest_imported_decision', COALESCE((
+        SELECT json_build_object(
+          'short_name', COALESCE(
+            NULLIF(BTRIM(CONCAT_WS(' - ', NULLIF(decision_form, ''), NULLIF(court_type, ''))), ''),
+            'Court decision'
+          ),
+          'published_date', COALESCE(NULLIF(issue_date, ''), ''),
+          'stored_at', last_stored_at
+        )
+        FROM court_decision_documents
+        ORDER BY last_stored_at DESC NULLS LAST, updated_at DESC
+        LIMIT 1
+      ), '{}'::json),
       'latest_stored_issue_date', (
         SELECT MAX(NULLIF(issue_date, '')) FROM court_decision_documents
       ),

--- a/tests/test_server_monitoring.py
+++ b/tests/test_server_monitoring.py
@@ -89,19 +89,22 @@ def test_monitoring_dashboards_include_court_decision_service_dashboard() -> Non
     assert dashboard["uid"] == "jurisdigta-court-decision-service"
     assert "Collector Status" in panel_titles
     assert "Imported Decisions" in panel_titles
-    assert "Najnovší uložený dátum rozhodnutia" in panel_titles
     assert "Latest Imported Decision" in panel_titles
     assert "Versions With Embeddings" in panel_titles
     assert "Recent Sanitized Error List" in panel_titles
+    assert "Najnovší uložený dátum rozhodnutia" not in panel_titles
     assert (
         'max without(status) (last_over_time(jurisdigta_component_status{component="court_decision_collector"}[15m]))'
         in target_queries
     )
-    assert "jurisdigta_court_decision_latest_imported_timestamp_seconds * 1000" in target_queries
-    assert (
-        "jurisdigta_court_decision_latest_stored_issue_date_timestamp_seconds * 1000"
-        in target_queries
+    assert "jurisdigta_court_decision_latest_imported_info" in target_queries
+
+    latest_imported_panel = next(
+        panel for panel in dashboard["panels"] if panel.get("title") == "Latest Imported Decision"
     )
+    assert latest_imported_panel["type"] == "table"
+    assert latest_imported_panel["targets"][0]["instant"] is True
+    assert latest_imported_panel["targets"][0]["range"] is False
 
 
 def test_monitoring_dashboards_include_laws_collector_corpus_panels() -> None:
@@ -503,6 +506,11 @@ def test_exporter_renders_court_decision_metrics() -> None:
                         "idle_events": 2,
                         "last_activity_at": "2026-06-20T01:06:00Z",
                         "latest_imported_at": "2026-06-20T01:00:01Z",
+                        "latest_imported_decision": {
+                            "short_name": "uznesenie - Krajsky sud",
+                            "published_date": "2026-06-29",
+                            "stored_at": "2026-06-20T01:00:01Z",
+                        },
                         "latest_stored_issue_date": "2026-06-29",
                         "latest_update_event_at": "2026-06-20T01:00:02Z",
                         "recent_errors": [
@@ -531,6 +539,11 @@ def test_exporter_renders_court_decision_metrics() -> None:
     )
     assert "jurisdigta_court_decision_collector_last_activity_timestamp_seconds" in metrics
     assert "jurisdigta_court_decision_latest_stored_issue_date_timestamp_seconds" in metrics
+    assert (
+        'jurisdigta_court_decision_latest_imported_info{short_name="uznesenie - Krajsky sud",'
+        'published_date="2026-06-29",stored_at="2026-06-20T01:00:01Z"} 1'
+        in metrics
+    )
     assert (
         'jurisdigta_court_decision_recent_error_info{index="1",'
         'timestamp="2026-06-20T01:06:00Z",message="failed import_key=live_loop"} 1'


### PR DESCRIPTION
## Summary
- keep the English `Latest Imported Decision` panel title
- replace the Slovak date-only stat panel with a table showing safe decision short name, published date, and stored-at time
- export `jurisdigta_court_decision_latest_imported_info` from privacy-safe metadata only
- update monitoring docs and runnable examples

## Compliance
- latest decision short name is derived from `decision_form` and `court_type` only
- dashboard labels do not expose raw decision text, parties, file numbers, ECLI values, case numbers, source GUIDs, source URLs, snippets, prompts, or embeddings

## Validation
- .\conda\python.exe -m json.tool Deployment\monitoring\grafana\dashboards\jurisdigta-court-decision-service.json > $null
- .\conda\python.exe -m pytest tests\test_server_monitoring.py
- .\conda\python.exe -m ruff check scripts\server\write_system_status.py scripts\server\export_system_status_metrics.py tests\test_server_monitoring.py examples\monitoring_scrape_demo.py examples\minimal_demo.py
- .\conda\python.exe examples\minimal_demo.py