### PR TITLE
Add MCP legal source metadata search

### DIFF
--- a/api/aijuristiction-api/app/mcp_api.py
+++ b/api/aijuristiction-api/app/mcp_api.py
@@ -1503,6 +1503,7 @@ def _call_tool(name: str, arguments: dict[str, Any]) -> Any:
     handlers = {
         "getVersion": _tool_get_version,
         "getStatistics": _tool_get_statistics,
+        "searchLegalSources": _tool_search_legal_sources,
         "searchLaws": _tool_search_laws,
         "getLawText": _tool_get_law_text,
         "searchCourtDecisions": _tool_search_court_decisions,
@@ -1566,12 +1567,83 @@ def _tool_get_statistics(arguments: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _tool_search_legal_sources(arguments: dict[str, Any]) -> dict[str, Any]:
+    query = _required_search_query(arguments)
+    country_code = str(arguments.get("country_code", "SK")).strip().upper() or "SK"
+    source_types = _requested_source_types(arguments.get("source_types"))
+    limit_per_source = _bounded_int(arguments.get("limit_per_source"), default=10, minimum=1, maximum=50)
+    offset = _bounded_int(arguments.get("offset"), default=0, minimum=0, maximum=10_000)
+    published_year = _optional_positive_int(arguments.get("published_year"))
+    year_filter_mode = _year_filter_mode(arguments.get("year_filter_mode"))
+    logger.info(
+        (
+            "mcp_tool_search_legal_sources_query country_code=%s source_types=%s "
+            "published_year=%s year_filter_mode=%s limit_per_source=%d offset=%d query_length=%d"
+        ),
+        country_code,
+        ",".join(source_types),
+        published_year,
+        year_filter_mode,
+        limit_per_source,
+        offset,
+        len(query),
+    )
+    laws_payload: dict[str, Any] | None = None
+    court_decisions_payload: dict[str, Any] | None = None
+    if "laws" in source_types:
+        laws_payload = _search_laws(
+            query=query,
+            country_code=country_code,
+            limit=limit_per_source,
+            offset=offset,
+            published_year=published_year,
+            year_filter_mode=year_filter_mode,
+            law_year=None,
+            law_number=None,
+            metadata_only=True,
+        )
+    if "court_decisions" in source_types:
+        court_decisions_payload = _search_court_decisions(
+            query=query,
+            limit=limit_per_source,
+            offset=offset,
+            published_year=published_year,
+            year_filter_mode=year_filter_mode,
+            court_type=str(arguments.get("court_type", "")).strip(),
+            include_snippets=False,
+        )
+    result: dict[str, Any] = {
+        "query": query,
+        "country_code": country_code,
+        "source_types": source_types,
+        "year_filter_mode": year_filter_mode,
+        "published_year": published_year,
+        "limit_per_source": limit_per_source,
+        "offset": offset,
+        "laws": laws_payload["results"] if laws_payload else [],
+        "court_decisions": court_decisions_payload["results"] if court_decisions_payload else [],
+        "status": "ok",
+        "warnings": [],
+    }
+    if court_decisions_payload and court_decisions_payload.get("status") == "degraded":
+        result["status"] = "degraded"
+        result["warnings"].append(court_decisions_payload["error"])
+    logger.info(
+        "mcp_tool_search_legal_sources_result laws=%d court_decisions=%d status=%s",
+        len(result["laws"]),
+        len(result["court_decisions"]),
+        result["status"],
+    )
+    return result
+
+
 def _tool_search_laws(arguments: dict[str, Any]) -> dict[str, Any]:
-    query = str(arguments.get("query", "")).strip()
-    if len(query) < 2:
-        raise HTTPException(status_code=400, detail="query must contain at least 2 characters")
+    query = _required_search_query(arguments)
     country_code = str(arguments.get("country_code", "SK")).strip().upper() or "SK"
     limit = _bounded_int(arguments.get("limit"), default=10, minimum=1, maximum=50)
+    offset = _bounded_int(arguments.get("offset"), default=0, minimum=0, maximum=10_000)
+    published_year = _optional_positive_int(arguments.get("published_year"))
+    year_filter_mode = _year_filter_mode(arguments.get("year_filter_mode"))
     requested_law_year = _optional_positive_int(arguments.get("law_year"))
     requested_law_number = _optional_positive_int(arguments.get("law_number"))
     parsed_identifier = _parse_law_identifier(query)
@@ -1579,13 +1651,52 @@ def _tool_search_laws(arguments: dict[str, Any]) -> dict[str, Any]:
         requested_law_year = parsed_identifier[0]
     if requested_law_number is None and parsed_identifier is not None:
         requested_law_number = parsed_identifier[1]
+    return _search_laws(
+        query=query,
+        country_code=country_code,
+        limit=limit,
+        offset=offset,
+        published_year=published_year,
+        year_filter_mode=year_filter_mode,
+        law_year=requested_law_year,
+        law_number=requested_law_number,
+        metadata_only=True,
+    )
+
+
+def _search_laws(
+    *,
+    query: str,
+    country_code: str,
+    limit: int,
+    offset: int,
+    published_year: int | None,
+    year_filter_mode: str,
+    law_year: int | None,
+    law_number: int | None,
+    metadata_only: bool,
+) -> dict[str, Any]:
+    if year_filter_mode != "published_in":
+        raise HTTPException(status_code=400, detail="Only year_filter_mode=published_in is supported")
     pattern = f"%{query.lower()}%"
     exact = query.lower()
-    logger.info("mcp_tool_search_laws_query country_code=%s limit=%d query_length=%d", country_code, limit, len(query))
+    logger.info(
+        (
+            "mcp_tool_search_laws_query country_code=%s limit=%d offset=%d "
+            "published_year=%s year_filter_mode=%s query_length=%d"
+        ),
+        country_code,
+        limit,
+        offset,
+        published_year,
+        year_filter_mode,
+        len(query),
+    )
 
     with _LawsQuerySession() as laws:
         law_year_filter = ""
         law_number_filter = ""
+        published_year_filter = ""
         query_params: list[Any] = [
             country_code,
             pattern,
@@ -1593,23 +1704,43 @@ def _tool_search_laws(arguments: dict[str, Any]) -> dict[str, Any]:
             pattern,
             pattern,
         ]
-        if requested_law_year is not None:
+        if law_year is not None:
             law_year_filter = f" AND d.law_year = {laws.param}"
-            query_params.append(requested_law_year)
-        if requested_law_number is not None:
+            query_params.append(law_year)
+        if law_number is not None:
             law_number_filter = f" AND d.law_number = {laws.param}"
-            query_params.append(requested_law_number)
+            query_params.append(law_number)
+        if published_year is not None:
+            published_year_filter = f" AND d.law_year = {laws.param}"
+            query_params.append(published_year)
         query_params.extend(
             [
                 exact,
                 exact,
                 exact,
-                f"{requested_law_number}/{requested_law_year}%" if requested_law_year and requested_law_number else "",
+                f"{law_number}/{law_year}%" if law_year and law_number else "",
                 limit,
+                offset,
             ]
         )
         rows = laws.query_all(
             f"""
+            WITH latest_versions AS (
+                SELECT version_id, document_id, version_token, effective_from
+                FROM (
+                    SELECT
+                        v.version_id,
+                        v.document_id,
+                        v.version_token,
+                        v.effective_from,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY v.document_id
+                            ORDER BY v.effective_from DESC, v.version_token DESC
+                        ) AS row_number
+                    FROM law_versions AS v
+                ) AS ranked_versions
+                WHERE row_number = 1
+            )
             SELECT
                 d.document_id,
                 d.country_code,
@@ -1626,7 +1757,7 @@ def _tool_search_laws(arguments: dict[str, Any]) -> dict[str, Any]:
                 COALESCE(m.title, d.official_name) AS title,
                 COALESCE(m.law_type, '') AS law_type
             FROM law_documents AS d
-            JOIN law_versions AS v ON v.document_id = d.document_id
+            JOIN latest_versions AS v ON v.document_id = d.document_id
             LEFT JOIN law_metadata AS m ON m.version_id = v.version_id
             WHERE UPPER(d.country_code) = {laws.param}
               AND (
@@ -1637,6 +1768,7 @@ def _tool_search_laws(arguments: dict[str, Any]) -> dict[str, Any]:
               )
               {law_year_filter}
               {law_number_filter}
+              {published_year_filter}
             ORDER BY
                 CASE
                     WHEN LOWER(COALESCE(m.law_identifier_text, '')) = {laws.param} THEN 0
@@ -1649,12 +1781,22 @@ def _tool_search_laws(arguments: dict[str, Any]) -> dict[str, Any]:
                 d.law_number DESC,
                 v.effective_from DESC
             LIMIT {laws.param}
+            OFFSET {laws.param}
             """,
             tuple(query_params),
         )
     results = [_search_result_from_row(row) for row in rows]
     logger.info("mcp_tool_search_laws_result country_code=%s result_count=%d", country_code, len(results))
-    return {"query": query, "country_code": country_code, "results": results}
+    return {
+        "query": query,
+        "country_code": country_code,
+        "year_filter_mode": year_filter_mode,
+        "published_year": published_year,
+        "metadata_only": metadata_only,
+        "limit": limit,
+        "offset": offset,
+        "results": results,
+    }
 
 
 def _tool_get_law_text(arguments: dict[str, Any]) -> dict[str, Any]:
@@ -1768,15 +1910,49 @@ def _tool_get_law_text(arguments: dict[str, Any]) -> dict[str, Any]:
 
 
 def _tool_search_court_decisions(arguments: dict[str, Any]) -> dict[str, Any]:
-    query = str(arguments.get("query", "")).strip()
-    if len(query) < 2:
-        raise HTTPException(status_code=400, detail="query must contain at least 2 characters")
+    query = _required_search_query(arguments)
     limit = _bounded_int(arguments.get("limit"), default=10, minimum=1, maximum=50)
+    offset = _bounded_int(arguments.get("offset"), default=0, minimum=0, maximum=10_000)
+    published_year = _optional_positive_int(arguments.get("published_year"))
+    year_filter_mode = _year_filter_mode(arguments.get("year_filter_mode"))
+    court_type = str(arguments.get("court_type", "")).strip()
+    include_snippets = _bool_argument(arguments.get("include_snippets"), default=False)
+    return _search_court_decisions(
+        query=query,
+        limit=limit,
+        offset=offset,
+        published_year=published_year,
+        year_filter_mode=year_filter_mode,
+        court_type=court_type,
+        include_snippets=include_snippets,
+    )
+
+
+def _search_court_decisions(
+    *,
+    query: str,
+    limit: int,
+    offset: int,
+    published_year: int | None,
+    year_filter_mode: str,
+    court_type: str,
+    include_snippets: bool,
+) -> dict[str, Any]:
+    if year_filter_mode != "published_in":
+        raise HTTPException(status_code=400, detail="Only year_filter_mode=published_in is supported")
     started_at = time.perf_counter()
     logger.info(
-        "mcp_tool_search_court_decisions_query query_length=%d limit=%d timeout_ms=%d",
+        (
+            "mcp_tool_search_court_decisions_query query_length=%d limit=%d offset=%d "
+            "published_year=%s year_filter_mode=%s court_type_supplied=%s include_snippets=%s timeout_ms=%d"
+        ),
         len(query),
         limit,
+        offset,
+        published_year,
+        year_filter_mode,
+        bool(court_type),
+        include_snippets,
         _COURT_DECISION_MCP_SEARCH_TIMEOUT_MS,
     )
     try:
@@ -1797,11 +1973,18 @@ def _tool_search_court_decisions(arguments: dict[str, Any]) -> dict[str, Any]:
                 "ecli": item.ecli,
                 "issue_date": item.issue_date,
                 "source_url": item.source_url,
-                "snippet": item.snippet,
                 "score": item.score,
                 "output_mode": "public",
             }
-            for item in store.search(query=query, limit=limit)
+            | ({"snippet": item.snippet} if include_snippets else {})
+            for item in store.search(
+                query=query,
+                limit=limit,
+                offset=offset,
+                published_year=published_year,
+                year_filter_mode=year_filter_mode,
+                court_type=court_type,
+            )
         ]
     except Exception as exc:
         duration_ms = int((time.perf_counter() - started_at) * 1000)
@@ -1822,6 +2005,9 @@ def _tool_search_court_decisions(arguments: dict[str, Any]) -> dict[str, Any]:
         return _court_decision_search_degraded_result(
             query=query,
             limit=limit,
+            offset=offset,
+            published_year=published_year,
+            year_filter_mode=year_filter_mode,
             duration_ms=duration_ms,
             error_kind=error_kind,
         )
@@ -1835,6 +2021,12 @@ def _tool_search_court_decisions(arguments: dict[str, Any]) -> dict[str, Any]:
         "query": query,
         "results": results,
         "output_mode": "public",
+        "metadata_only": not include_snippets,
+        "include_snippets": include_snippets,
+        "year_filter_mode": year_filter_mode,
+        "published_year": published_year,
+        "limit": limit,
+        "offset": offset,
         "status": "ok",
         "duration_ms": duration_ms,
         "timeout_ms": _COURT_DECISION_MCP_SEARCH_TIMEOUT_MS,
@@ -1849,24 +2041,39 @@ def _tool_get_court_decision(arguments: dict[str, Any]) -> dict[str, Any]:
     raw = output_mode == "internal_raw"
     if raw and os.getenv("COURT_DECISIONS_ALLOW_INTERNAL_RAW_MCP", "").strip().lower() not in {"1", "true", "yes"}:
         raise HTTPException(status_code=403, detail="internal_raw court-decision output is not enabled")
+    full_version = _bool_argument(
+        arguments.get("full_version", arguments.get("fullVersion", arguments.get("fullversion"))),
+        default=False,
+    )
     max_chars = _bounded_int(arguments.get("max_chars"), default=12_000, minimum=1, maximum=50_000)
     logger.info(
-        "mcp_tool_get_court_decision_query decision_id_hash=%s output_mode=%s max_chars=%d",
+        "mcp_tool_get_court_decision_query decision_id_hash=%s output_mode=%s full_version=%s max_chars=%d",
         _stable_hash(decision_id),
         "internal_raw" if raw else "public",
+        full_version,
         max_chars,
     )
     record = _court_decision_store().get_decision(decision_id=decision_id, raw=raw)
     if record is None:
         raise HTTPException(status_code=404, detail="Court decision not found")
     text = str(record["text"])
-    record["text"] = text[:max_chars]
-    record["content_truncated"] = len(text) > max_chars
+    if full_version:
+        record["text"] = text[:max_chars]
+        record["content_truncated"] = len(text) > max_chars
+    else:
+        record.pop("text", None)
+        record["content_truncated"] = False
+    record["full_version"] = full_version
+    record["metadata_only"] = not full_version
     logger.info(
-        "mcp_tool_get_court_decision_result decision_id_hash=%s output_mode=%s content_length=%d truncated=%s",
+        (
+            "mcp_tool_get_court_decision_result decision_id_hash=%s output_mode=%s "
+            "full_version=%s content_length=%d truncated=%s"
+        ),
         _stable_hash(decision_id),
         record["output_mode"],
-        len(str(record["text"])),
+        full_version,
+        len(str(record.get("text", ""))),
         record["content_truncated"],
     )
     return cast(dict[str, Any], record)
@@ -2044,6 +2251,9 @@ def _court_decision_search_degraded_result(
     *,
     query: str,
     limit: int,
+    offset: int,
+    published_year: int | None,
+    year_filter_mode: str,
     duration_ms: int,
     error_kind: str,
 ) -> dict[str, Any]:
@@ -2067,6 +2277,9 @@ def _court_decision_search_degraded_result(
             "request_id": _CURRENT_MCP_REQUEST_ID.get(),
         },
         "limit": limit,
+        "offset": offset,
+        "published_year": published_year,
+        "year_filter_mode": year_filter_mode,
         "duration_ms": duration_ms,
         "timeout_ms": _COURT_DECISION_MCP_SEARCH_TIMEOUT_MS,
     }
@@ -2103,9 +2316,42 @@ def _mcp_tools() -> list[dict[str, Any]]:
             },
         },
         {
+            "name": "searchLegalSources",
+            "description": (
+                "Protected combined metadata search for Slovak legal sources. Use this for user questions "
+                "that ask for both laws and court decisions. The MCP server is model-free: clients parse "
+                "natural-language questions and pass structured filters such as published_year. Results are "
+                "grouped into laws and court_decisions and return metadata only by default."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "required": ["query"],
+                "properties": {
+                    "query": {"type": "string", "minLength": 2},
+                    "country_code": {"type": "string", "default": "SK"},
+                    "source_types": {
+                        "type": "array",
+                        "items": {"type": "string", "enum": ["laws", "court_decisions"]},
+                        "default": ["laws", "court_decisions"],
+                    },
+                    "published_year": {"type": "integer", "minimum": 1},
+                    "year_filter_mode": {
+                        "type": "string",
+                        "enum": ["published_in"],
+                        "default": "published_in",
+                    },
+                    "court_type": {"type": "string"},
+                    "limit_per_source": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10},
+                    "offset": {"type": "integer", "minimum": 0, "default": 0},
+                },
+                "additionalProperties": False,
+            },
+        },
+        {
             "name": "searchLaws",
             "description": (
                 "Search JurisDigta imported Slovak laws by title, identifier, and lawyer-facing title. "
+                "Returns metadata for the current consolidated version by default. "
                 "Use exact law_number and law_year when the user cites a legal identifier such as 40/1964; "
                 "otherwise prefer exact title matches over amendment acts. Use this first for Slovak legal "
                 "questions instead of relying on model memory."
@@ -2118,7 +2364,14 @@ def _mcp_tools() -> list[dict[str, Any]]:
                     "country_code": {"type": "string", "default": "SK"},
                     "law_year": {"type": "integer", "minimum": 1},
                     "law_number": {"type": "integer", "minimum": 1},
+                    "published_year": {"type": "integer", "minimum": 1},
+                    "year_filter_mode": {
+                        "type": "string",
+                        "enum": ["published_in"],
+                        "default": "published_in",
+                    },
                     "limit": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10},
+                    "offset": {"type": "integer", "minimum": 0, "default": 0},
                 },
                 "additionalProperties": False,
             },
@@ -2158,16 +2411,26 @@ def _mcp_tools() -> list[dict[str, Any]]:
             "name": "searchCourtDecisions",
             "description": (
                 "Search imported Slovak court decisions (sudne rozhodnutia / case law) by semantic "
-                "and metadata relevance. Returns pseudonymized public snippets by default; use this "
-                "to cite court, date, ECLI, file number, and source URL while distinguishing case-law "
-                "support from binding statutory law."
+                "and metadata relevance. Returns metadata only by default; set include_snippets=true "
+                "to include pseudonymized public snippets. Use this to cite court, date, ECLI, "
+                "file number, and source URL while distinguishing case-law support from binding "
+                "statutory law."
             ),
             "inputSchema": {
                 "type": "object",
                 "required": ["query"],
                 "properties": {
                     "query": {"type": "string", "minLength": 2},
+                    "published_year": {"type": "integer", "minimum": 1},
+                    "year_filter_mode": {
+                        "type": "string",
+                        "enum": ["published_in"],
+                        "default": "published_in",
+                    },
+                    "court_type": {"type": "string"},
                     "limit": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10},
+                    "offset": {"type": "integer", "minimum": 0, "default": 0},
+                    "include_snippets": {"type": "boolean", "default": False},
                 },
                 "additionalProperties": False,
             },
@@ -2175,15 +2438,17 @@ def _mcp_tools() -> list[dict[str, Any]]:
         {
             "name": "getCourtDecision",
             "description": (
-                "Return one imported Slovak court decision. The default outputMode=public returns "
-                "pseudonymized text. outputMode=internal_raw is restricted to controlled internal use "
-                "and must not be used for normal external model prompts or UI display."
+                "Return one imported Slovak court decision. Defaults to metadata only. Set "
+                "full_version=true to return bounded pseudonymized public text. "
+                "outputMode=internal_raw is restricted to controlled internal use and must not be used "
+                "for normal external model prompts or UI display."
             ),
             "inputSchema": {
                 "type": "object",
                 "required": ["decision_id"],
                 "properties": {
                     "decision_id": {"type": "string", "minLength": 1},
+                    "full_version": {"type": "boolean", "default": False},
                     "outputMode": {
                         "type": "string",
                         "enum": ["public", "internal_raw"],
@@ -2869,6 +3134,12 @@ def _tool_result_summary(*, tool_name: str, result: Any) -> str:
         results = result.get("results")
         result_count = len(results) if isinstance(results, list) else 0
         return f"country_code={result.get('country_code')} result_count={result_count}"
+    if tool_name == "searchLegalSources":
+        laws = result.get("laws")
+        court_decisions = result.get("court_decisions")
+        laws_count = len(laws) if isinstance(laws, list) else 0
+        court_count = len(court_decisions) if isinstance(court_decisions, list) else 0
+        return f"country_code={result.get('country_code')} laws={laws_count} court_decisions={court_count}"
     if tool_name == "getLawText":
         content_text = result.get("content_text")
         content_length = len(content_text) if isinstance(content_text, str) else 0
@@ -2919,6 +3190,47 @@ def _bounded_int(value: Any, *, default: int, minimum: int, maximum: int) -> int
     if resolved > maximum:
         return maximum
     return resolved
+
+
+def _required_search_query(arguments: dict[str, Any]) -> str:
+    query = str(arguments.get("query", "")).strip()
+    if len(query) < 2:
+        raise HTTPException(status_code=400, detail="query must contain at least 2 characters")
+    return query
+
+
+def _year_filter_mode(value: Any) -> str:
+    mode = str(value or "published_in").strip() or "published_in"
+    if mode != "published_in":
+        raise HTTPException(status_code=400, detail="Only year_filter_mode=published_in is supported")
+    return mode
+
+
+def _bool_argument(value: Any, *, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value != 0
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off", ""}:
+        return False
+    raise HTTPException(status_code=400, detail="Expected a boolean value")
+
+
+def _requested_source_types(value: Any) -> list[str]:
+    if value is None:
+        return ["laws", "court_decisions"]
+    if not isinstance(value, list):
+        raise HTTPException(status_code=400, detail="source_types must be an array")
+    requested = [str(item).strip() for item in value if str(item).strip()]
+    allowed = {"laws", "court_decisions"}
+    if not requested or any(item not in allowed for item in requested):
+        raise HTTPException(status_code=400, detail="source_types must contain laws and/or court_decisions")
+    return list(dict.fromkeys(requested))
 
 
 def _mcp_locale(request: Request) -> str:

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260502"
+version = "1.0.260503"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_mcp_api.py
+++ b/api/aijuristiction-api/tests/test_mcp_api.py
@@ -58,10 +58,11 @@ def test_mcp_initialize_instructs_assistants_to_use_jurisdigta_for_slovak_law() 
 
     assert tools_response.status_code == 200
     tools = {tool["name"]: tool for tool in tools_response.json()["result"]["tools"]}
+    assert "metadata search for Slovak legal sources" in tools["searchLegalSources"]["description"]
     assert "Use this first for Slovak legal questions" in tools["searchLaws"]["description"]
     assert "Use after searchLaws to cite exact Slovak legal text" in tools["getLawText"]["description"]
-    assert "pseudonymized public snippets" in tools["searchCourtDecisions"]["description"]
-    assert "outputMode=public" in tools["getCourtDecision"]["description"]
+    assert "metadata only by default" in tools["searchCourtDecisions"]["description"]
+    assert "full_version=true" in tools["getCourtDecision"]["description"]
 
 
 def test_mcp_accepts_mc_path_compatibility_alias_for_claude_connector_typo() -> None:
@@ -317,11 +318,92 @@ def test_mcp_public_tools_and_authenticated_law_search(monkeypatch, tmp_path: Pa
 
 
 def test_mcp_court_decision_tools_require_auth() -> None:
+    unauthenticated_legal_sources = _mcp_call(
+        "searchLegalSources",
+        {"query": "prenajom bytu", "published_year": 2026},
+        path="/MCP",
+    )
+    assert unauthenticated_legal_sources.status_code == 401
+
     unauthenticated_search = _mcp_call("searchCourtDecisions", {"query": "najomna zmluva"})
     assert unauthenticated_search.status_code == 401
 
     unauthenticated_detail = _mcp_call("getCourtDecision", {"decision_id": "decision-1"})
     assert unauthenticated_detail.status_code == 401
+
+
+def test_mcp_search_legal_sources_returns_grouped_metadata_only(monkeypatch, tmp_path: Path) -> None:
+    _configure_env(monkeypatch, tmp_path)
+    db_path = tmp_path / "laws.sqlite3"
+    _create_laws_db(db_path)
+    mcp_key = _create_mcp_key(tmp_path)
+    _insert_law_search_fixture(
+        db_path,
+        document_id="doc-10-2026",
+        version_id="ver-10-2026",
+        metadata_id="meta-10-2026",
+        artifact_id="artifact-10-2026",
+        law_year=2026,
+        law_number=10,
+        official_name="Zakon o prenajme bytu",
+        lawyer_title="Prenajom bytu",
+        law_identifier_text="10/2026 Z. z.",
+        title="Zakon o prenajme bytu",
+        content_text="Konsolidovane znenie o prenajme bytu.",
+    )
+
+    class FakeCourtDecisionStore:
+        def search(
+            self,
+            *,
+            query: str,
+            limit: int,
+            offset: int,
+            published_year: int | None,
+            year_filter_mode: str,
+            court_type: str,
+        ) -> list[CourtDecisionSearchResult]:
+            assert query == "prenajom bytu"
+            assert limit == 2
+            assert offset == 0
+            assert published_year == 2026
+            assert year_filter_mode == "published_in"
+            assert court_type == ""
+            return [
+                CourtDecisionSearchResult(
+                    decision_id="decision-lease-2026",
+                    version_id="version-lease-2026",
+                    source_guid="infosud-lease-2026",
+                    court_name="Okresny sud Bratislava I",
+                    court_type="Okresny sud",
+                    file_number="12C/10/2026",
+                    case_number="12C/10/2026",
+                    ecli="ECLI:SK:OSBA1:2026:10.1",
+                    issue_date="2026-02-03",
+                    source_url="https://example.test/decision/lease-2026",
+                    snippet="Pseudonymizovany text o prenajme bytu.",
+                    score=0.88,
+                )
+            ]
+
+    monkeypatch.setattr(mcp_api, "_court_decision_store", lambda **_kwargs: FakeCourtDecisionStore())
+
+    response = _mcp_call(
+        "searchLegalSources",
+        {"query": "prenajom bytu", "published_year": 2026, "limit_per_source": 2},
+        headers={"authorization": f"Bearer {mcp_key}"},
+    )
+
+    assert response.status_code == 200
+    payload = _tool_payload(response)
+    assert payload["status"] == "ok"
+    assert payload["year_filter_mode"] == "published_in"
+    assert payload["published_year"] == 2026
+    assert payload["laws"][0]["document_id"] == "doc-10-2026"
+    assert payload["laws"][0]["law_year"] == 2026
+    assert payload["court_decisions"][0]["decision_id"] == "decision-lease-2026"
+    assert "snippet" not in payload["court_decisions"][0]
+    assert "content_text" not in payload["laws"][0]
 
 
 def test_mcp_search_court_decisions_returns_bounded_results_and_privacy_safe_logs(
@@ -333,9 +415,22 @@ def test_mcp_search_court_decisions_returns_bounded_results_and_privacy_safe_log
     mcp_key = _create_mcp_key(tmp_path)
 
     class FakeCourtDecisionStore:
-        def search(self, *, query: str, limit: int) -> list[CourtDecisionSearchResult]:
+        def search(
+            self,
+            *,
+            query: str,
+            limit: int,
+            offset: int,
+            published_year: int | None,
+            year_filter_mode: str,
+            court_type: str,
+        ) -> list[CourtDecisionSearchResult]:
             assert query == "zobraz mi posledne sudne rozhodnutie ktore sa tykalo rozdelenia pozemku podla podielu"
             assert limit == 1
+            assert offset == 0
+            assert published_year == 2026
+            assert year_filter_mode == "published_in"
+            assert court_type == "Okresny sud"
             return [
                 CourtDecisionSearchResult(
                     decision_id="decision-1",
@@ -365,7 +460,12 @@ def test_mcp_search_court_decisions_returns_bounded_results_and_privacy_safe_log
 
     response = _mcp_call(
         "searchCourtDecisions",
-        {"query": secret_query, "limit": 1},
+        {
+            "query": secret_query,
+            "limit": 1,
+            "published_year": 2026,
+            "court_type": "Okresny sud",
+        },
         headers={"authorization": f"Bearer {mcp_key}", "x-request-id": "court-search-request"},
     )
 
@@ -373,9 +473,25 @@ def test_mcp_search_court_decisions_returns_bounded_results_and_privacy_safe_log
     payload = _tool_payload(response)
     assert payload["status"] == "ok"
     assert payload["output_mode"] == "public"
+    assert payload["metadata_only"] is True
     assert payload["timeout_ms"] == 8000
     assert payload["results"][0]["decision_id"] == "decision-1"
     assert payload["results"][0]["issue_date"] == "2026-06-29"
+    assert "snippet" not in payload["results"][0]
+    snippet_response = _mcp_call(
+        "searchCourtDecisions",
+        {
+            "query": secret_query,
+            "limit": 1,
+            "published_year": 2026,
+            "court_type": "Okresny sud",
+            "include_snippets": True,
+        },
+        headers={"authorization": f"Bearer {mcp_key}"},
+    )
+    snippet_payload = _tool_payload(snippet_response)
+    assert snippet_payload["metadata_only"] is False
+    assert "Pseudonymizovane rozhodnutie" in snippet_payload["results"][0]["snippet"]
     mcp_log_messages = [
         record.getMessage() for record in caplog.records if record.name == "aijuristiction-api.mcp"
     ]
@@ -384,6 +500,56 @@ def test_mcp_search_court_decisions_returns_bounded_results_and_privacy_safe_log
     assert secret_query not in joined_logs
     assert "Pseudonymizovane rozhodnutie" not in joined_logs
     assert mcp_key not in joined_logs
+
+
+def test_mcp_get_court_decision_defaults_to_metadata_only(monkeypatch, tmp_path: Path) -> None:
+    _configure_env(monkeypatch, tmp_path)
+    mcp_key = _create_mcp_key(tmp_path)
+
+    class FakeCourtDecisionStore:
+        def get_decision(self, *, decision_id: str, raw: bool = False) -> dict[str, object] | None:
+            assert decision_id == "decision-1"
+            assert raw is False
+            return {
+                "decision_id": "decision-1",
+                "version_id": "version-1",
+                "source_guid": "infosud-1",
+                "court_name": "Okresny sud Bratislava I",
+                "court_type": "Okresny sud",
+                "file_number": "12C/34/2026",
+                "case_number": "12C/34/2026",
+                "ecli": "ECLI:SK:OSBA1:2026:1234567890.1",
+                "issue_date": "2026-06-29",
+                "source_url": "https://example.test/decision/1",
+                "output_mode": "public",
+                "text": "Pseudonymizovane plne znenie rozhodnutia o prenajme bytu.",
+            }
+
+    monkeypatch.setattr(mcp_api, "_court_decision_store", lambda **_kwargs: FakeCourtDecisionStore())
+
+    metadata_response = _mcp_call(
+        "getCourtDecision",
+        {"decision_id": "decision-1"},
+        headers={"authorization": f"Bearer {mcp_key}"},
+    )
+    full_response = _mcp_call(
+        "getCourtDecision",
+        {"decision_id": "decision-1", "fullversion": True, "max_chars": 20},
+        headers={"authorization": f"Bearer {mcp_key}"},
+    )
+
+    assert metadata_response.status_code == 200
+    metadata_payload = _tool_payload(metadata_response)
+    assert metadata_payload["metadata_only"] is True
+    assert metadata_payload["full_version"] is False
+    assert "text" not in metadata_payload
+
+    assert full_response.status_code == 200
+    full_payload = _tool_payload(full_response)
+    assert full_payload["metadata_only"] is False
+    assert full_payload["full_version"] is True
+    assert full_payload["text"] == "Pseudonymizovane pln"
+    assert full_payload["content_truncated"] is True
 
 
 def test_mcp_search_court_decisions_timeout_returns_structured_degraded_result(
@@ -395,7 +561,16 @@ def test_mcp_search_court_decisions_timeout_returns_structured_degraded_result(
     mcp_key = _create_mcp_key(tmp_path)
 
     class TimeoutCourtDecisionStore:
-        def search(self, *, query: str, limit: int) -> list[CourtDecisionSearchResult]:
+        def search(
+            self,
+            *,
+            query: str,
+            limit: int,
+            offset: int,
+            published_year: int | None,
+            year_filter_mode: str,
+            court_type: str,
+        ) -> list[CourtDecisionSearchResult]:
             raise TimeoutError("statement timeout")
 
     monkeypatch.setattr(mcp_api, "_court_decision_store", lambda **_kwargs: TimeoutCourtDecisionStore())
@@ -490,6 +665,54 @@ def test_mcp_search_prefers_base_law_over_newer_amendment(monkeypatch, tmp_path:
     assert _tool_payload(identifier_search)["results"][0]["document_id"] == "doc-40-1964"
     explicit_results = _tool_payload(explicit_identifier_search)["results"]
     assert [result["document_id"] for result in explicit_results] == ["doc-40-1964"]
+
+
+def test_mcp_search_laws_supports_published_year_metadata_filter(monkeypatch, tmp_path: Path) -> None:
+    _configure_env(monkeypatch, tmp_path)
+    db_path = tmp_path / "laws.sqlite3"
+    _create_laws_db(db_path)
+    mcp_key = _create_mcp_key(tmp_path)
+    _insert_law_search_fixture(
+        db_path,
+        document_id="doc-lease-2025",
+        version_id="ver-lease-2025",
+        metadata_id="meta-lease-2025",
+        artifact_id="artifact-lease-2025",
+        law_year=2025,
+        law_number=30,
+        official_name="Zakon o prenajme bytu 2025",
+        lawyer_title="Prenajom bytu",
+        law_identifier_text="30/2025 Z. z.",
+        title="Prenajom bytu",
+        content_text="Starsi zakon o prenajme bytu.",
+    )
+    _insert_law_search_fixture(
+        db_path,
+        document_id="doc-lease-2026",
+        version_id="ver-lease-2026",
+        metadata_id="meta-lease-2026",
+        artifact_id="artifact-lease-2026",
+        law_year=2026,
+        law_number=11,
+        official_name="Zakon o prenajme bytu 2026",
+        lawyer_title="Prenajom bytu",
+        law_identifier_text="11/2026 Z. z.",
+        title="Prenajom bytu",
+        content_text="Aktualne konsolidovane znenie o prenajme bytu.",
+    )
+
+    response = _mcp_call(
+        "searchLaws",
+        {"query": "prenajom bytu", "published_year": 2026},
+        headers={"authorization": f"Bearer {mcp_key}"},
+    )
+
+    assert response.status_code == 200
+    payload = _tool_payload(response)
+    assert payload["metadata_only"] is True
+    assert payload["published_year"] == 2026
+    assert [result["document_id"] for result in payload["results"]] == ["doc-lease-2026"]
+    assert "content_text" not in payload["results"][0]
 
 
 def test_mcp_get_law_text_caps_large_default_payload(monkeypatch, tmp_path: Path) -> None:

--- a/docs/COURT_DECISION_COLLECTOR.md
+++ b/docs/COURT_DECISION_COLLECTOR.md
@@ -139,7 +139,8 @@ The MCP server exposes:
 
 - `getVersion()` includes court-decision collector version, status, latest imported decision/source GUID, and latest import time.
 - `getStatistics(country_code)` includes court-decision collector version, total court decisions, published decisions, total versions, latest imported decision/source GUID, latest import time, court metadata, ECLI/file number, issue date, and collector cursor status.
-- `searchCourtDecisions(query, limit)` for pseudonymized metadata/snippet search.
-- `getCourtDecision(decision_id, outputMode)` where `outputMode=public` is the default and returns pseudonymized text.
+- `searchCourtDecisions(query, limit, offset, published_year, year_filter_mode, court_type, include_snippets)` for metadata-first search. The default `year_filter_mode` is `published_in`, and snippets are omitted unless `include_snippets=true`.
+- `getCourtDecision(decision_id, full_version, outputMode)` where the default response is metadata-only. `full_version=true` returns bounded pseudonymized public text. `outputMode=internal_raw` remains restricted to controlled internal runtimes.
+- `searchLegalSources(query, source_types, published_year, year_filter_mode, limit_per_source)` for protected combined metadata search across current consolidated laws and court decisions. The MCP server is model-free; clients parse natural-language questions and pass structured filters.
 
 `outputMode=internal_raw` is reserved for controlled internal callers and is blocked unless `COURT_DECISIONS_ALLOW_INTERNAL_RAW_MCP=true` is set in that controlled runtime. Keep it disabled for normal external MCP clients.

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -247,10 +247,11 @@ These tools do not require an MCP API key:
 
 These tools require an MCP API key:
 
-- `searchLaws`: searches imported laws by title, identifier, and lawyer-facing title.
+- `searchLegalSources`: protected combined metadata search for questions that need both laws and court decisions, for example `Daj mi vsetky rozhodnutia a zakony ktore sa tykaju prenajmu bytu za rok 2026?`. The MCP server does not use an LLM to answer; clients such as Codex, VS Code, Claude, or ChatGPT parse the natural-language question and pass structured filters such as `query`, `published_year`, and `source_types`. The default `year_filter_mode` is `published_in`, so `published_year=2026` means laws or decisions published in 2026.
+- `searchLaws`: searches imported laws by title, identifier, and lawyer-facing title. Results return metadata for the current consolidated version by default and support `published_year`, `year_filter_mode=published_in`, `limit`, and `offset`.
 - `getLawText`: returns bounded latest imported text for a law document id. For large codes, pass `section_number` or `section_start`/`section_end` to retrieve only the relevant sections; use `offset` and `max_chars` when pagination is needed.
-- `searchCourtDecisions`: searches the dedicated court-decision vector store and returns pseudonymized public snippets with court/date/ECLI/file-number metadata. MCP court-decision search is bounded by a server-side PostgreSQL connect timeout and statement timeout so slow database calls return a structured `status=degraded`, `retryable=true` payload with request/correlation identifiers instead of hanging until the MCP client times out. Logs record query length, limit, duration, error kind, request ID, and correlation ID, but not the raw query, credentials, tokens, snippets, or court-decision text.
-- `getCourtDecision`: returns one imported court decision. `outputMode=public` is the default and returns pseudonymized text. `outputMode=internal_raw` is blocked unless `COURT_DECISIONS_ALLOW_INTERNAL_RAW_MCP=true` is enabled for a controlled internal runtime; it must not be used for normal external model prompts or UI display.
+- `searchCourtDecisions`: searches the dedicated court-decision vector store and returns court/date/ECLI/file-number metadata by default. Set `include_snippets=true` to include pseudonymized public snippets. MCP court-decision search is bounded by a server-side PostgreSQL connect timeout and statement timeout so slow database calls return a structured `status=degraded`, `retryable=true` payload with request/correlation identifiers instead of hanging until the MCP client times out. Logs record query length, limit, duration, error kind, request ID, and correlation ID, but not the raw query, credentials, tokens, snippets, or court-decision text.
+- `getCourtDecision`: returns one imported court decision. The default response is metadata-only. Set `full_version=true` to return bounded pseudonymized public text. `outputMode=internal_raw` is blocked unless `COURT_DECISIONS_ALLOW_INTERNAL_RAW_MCP=true` is enabled for a controlled internal runtime; it must not be used for normal external model prompts or UI display.
 
 ## Minimal JSON-RPC Example
 
@@ -260,15 +261,20 @@ These tools require an MCP API key:
   "id": 1,
   "method": "tools/call",
   "params": {
-    "name": "searchLaws",
+    "name": "searchLegalSources",
     "arguments": {
-      "query": "civil",
+      "query": "prenajom bytu",
       "country_code": "SK",
-      "limit": 10
+      "source_types": ["laws", "court_decisions"],
+      "published_year": 2026,
+      "year_filter_mode": "published_in",
+      "limit_per_source": 10
     }
   }
 }
 ```
+
+For a natural-language question such as `Daj mi vsetky rozhodnutia a zakony ktore sa tykaju prenajmu bytu za rok 2026?`, the MCP client should call `searchLegalSources` with a normalized query such as `prenajom bytu`, `published_year=2026`, and `source_types=["laws","court_decisions"]`. The MCP server returns grouped source metadata only; the client formats the answer and may call `getCourtDecision(full_version=true)` or `getLawText(...)` only if the user asks for full text or a specific citation.
 
 For Civil Code style questions, call `searchLaws` with the exact identifier first, for example `{"query": "40/1964", "law_number": 40, "law_year": 1964}`. Then call `getLawText` with the returned `document_id` and a focused range, for example `{"document_id": "...", "section_start": 685, "section_end": 716}`. Avoid asking for the full law text unless the law is small or pagination is explicitly required.
 

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -34,6 +34,13 @@ print(
     "https://mcp.jurisdigta.eu/mcp."
 )
 print(
+    "mcp_legal_source_search => MCP remains model-free; clients parse natural-language legal "
+    "questions and call protected searchLegalSources with structured filters such as "
+    "query='prenajom bytu', source_types=['laws','court_decisions'], published_year=2026, "
+    "year_filter_mode='published_in'. Search defaults to metadata only; court-decision text "
+    "requires getCourtDecision(full_version=True)."
+)
+print(
     "mcp_endpoint_claude_compat => /MCP remains accepted for Claude web and existing clients; "
     "it allows public-law tools without OAuth and does not advertise protected-resource metadata "
     "or Claude-web root OAuth discovery because Claude web can reject issued OAuth credentials."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aijurisdictionagents"
-version = "1.0.260413"
+version = "1.0.260414"
 description = "Multi-agent legal discussion scaffold."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260413"
+__version__ = "1.0.260414"

--- a/src/services/court_decision_collector/postgres_store.py
+++ b/src/services/court_decision_collector/postgres_store.py
@@ -202,15 +202,38 @@ class PostgresCourtDecisionStore:
             conn.commit()
             return StoredCourtDecision(decision_id=decision_id, version_id=version_id, state=state)
 
-    def search(self, *, query: str, limit: int = 10) -> list[CourtDecisionSearchResult]:
+    def search(
+        self,
+        *,
+        query: str,
+        limit: int = 10,
+        offset: int = 0,
+        published_year: int | None = None,
+        year_filter_mode: str = "published_in",
+        court_type: str = "",
+    ) -> list[CourtDecisionSearchResult]:
+        if year_filter_mode != "published_in":
+            raise ValueError("Only year_filter_mode=published_in is supported.")
         query_vector = parse_embedding_vector(
             build_embedding_vector(query, dimensions=self.embedding_dimensions)
         )
-        candidate_limit = max(limit * 10, 100)
+        candidate_limit = max((limit + offset) * 10, 100)
         pattern = f"%{query.lower()}%"
+        filters = ""
+        params: dict[str, object] = {
+            "query": query,
+            "pattern": pattern,
+            "candidate_limit": candidate_limit,
+        }
+        if published_year is not None:
+            filters += " AND LEFT(COALESCE(d.issue_date, ''), 4) = %(published_year)s"
+            params["published_year"] = str(published_year)
+        if court_type.strip():
+            filters += " AND LOWER(d.court_type) = %(court_type)s"
+            params["court_type"] = court_type.strip().lower()
         with self._connect() as conn:
             rows = conn.execute(
-                """
+                f"""
                 WITH search_query AS (
                     SELECT websearch_to_tsquery('simple', %(query)s) AS tsq
                 )
@@ -262,10 +285,11 @@ class PostgresCourtDecisionStore:
                       OR LOWER(d.ecli) LIKE %(pattern)s
                       OR LOWER(v.pseudonymized_text) LIKE %(pattern)s
                   )
+                  {filters}
                 ORDER BY lexical_rank DESC, d.issue_date DESC NULLS LAST, d.updated_at DESC
                 LIMIT %(candidate_limit)s
                 """,
-                {"query": query, "pattern": pattern, "candidate_limit": candidate_limit},
+                params,
             ).fetchall()
         scored: list[CourtDecisionSearchResult] = []
         for row in rows:
@@ -291,7 +315,7 @@ class PostgresCourtDecisionStore:
                     score=round(score, 6),
                 )
             )
-        return sorted(scored, key=lambda item: item.score, reverse=True)[:limit]
+        return sorted(scored, key=lambda item: item.score, reverse=True)[offset : offset + limit]
 
     def get_decision(self, *, decision_id: str, raw: bool = False) -> dict[str, object] | None:
         with self._connect() as conn:


### PR DESCRIPTION
## Summary
- Add protected MCP `searchLegalSources` for grouped metadata search across laws and court decisions.
- Add published-year, offset, and metadata-only defaults for law/court search; court snippets and full decision text are now explicit opt-ins.
- Update MCP docs, court-decision collector docs, minimal demo, and API/core versions.

## Validation
- `./scripts/validate_api.ps1`
- `./conda/python.exe -m pytest api/aijuristiction-api/tests/test_mcp_api.py`
- `./conda/python.exe -m pytest api/aijuristiction-api/tests/test_chat.py -q`
- API test files passed individually post-rebase; `test_chat.py` takes ~11.5 minutes locally.
- `./conda/python.exe -m pytest tests/test_court_decision_collector.py`
- `./conda/python.exe examples/minimal_demo.py`

Closes #483