### PR TITLE
Implement MCP-first legal RAG fallback warnings

### DIFF
--- a/api/aijuristiction-api/app/chat/api.py
+++ b/api/aijuristiction-api/app/chat/api.py
@@ -1760,7 +1760,7 @@ def reply_to_session(session_id: UUID, payload: ReplyRequest) -> Message:
     if not content:
         raise HTTPException(status_code=400, detail="Reply content is required")
 
-    _persisted_user, persisted_lawyer, visible_lawyer_content, _processing_events, routed_llm = (
+    _persisted_user, persisted_lawyer, visible_lawyer_content, processing_events, routed_llm = (
         _run_direct_lawyer_turn(
             session_id=session_id,
             session=session,
@@ -1774,6 +1774,7 @@ def reply_to_session(session_id: UUID, payload: ReplyRequest) -> Message:
         messages=_repository.list_messages(session_id),
         lawyer_message=visible_lawyer_content,
         route=routed_llm,
+        legal_source_citations=_legal_source_citations_from_processing_events(processing_events),
     )
     _repository.set_result(session_id, session_result)
     persisted_citations = _persist_case_citations_for_answer(
@@ -2174,7 +2175,7 @@ def _stream_read_user_session(
                 return
             if session.state == SessionState.COMPLETED:
                 _repository.reactivate_session(session_id)
-            _persisted_user, persisted_lawyer, visible_lawyer_content, _processing_events, routed_llm = (
+            _persisted_user, persisted_lawyer, visible_lawyer_content, processing_events, routed_llm = (
                 _run_direct_lawyer_turn(
                     session_id=session_id,
                     session=session,
@@ -2217,6 +2218,7 @@ def _stream_read_user_session(
                     messages=current_messages,
                     lawyer_message=visible_lawyer_content,
                     route=routed_llm,
+                    legal_source_citations=_legal_source_citations_from_processing_events(processing_events),
                 )
                 _persist_session_history_document_if_needed(session=session, session_id=session_id)
                 _repository.set_result(session_id, session_result)
@@ -2933,6 +2935,7 @@ def _build_direct_reply_result(
     messages: list[Message],
     lawyer_message: str,
     route: RoutedLLMClient | None = None,
+    legal_source_citations: list[dict[str, object]] | None = None,
 ) -> SessionResult:
     visible_text = _user_visible_text(lawyer_message)
     document_requested = _document_generation_requested(messages)
@@ -2955,6 +2958,7 @@ def _build_direct_reply_result(
             "document_requested": document_requested,
             "document_confirmed": document_confirmed,
             "document_ready": document_ready,
+            "legal_source_citations": legal_source_citations or [],
         },
         routed_model_name=route.model if route is not None else None,
     )
@@ -3043,6 +3047,33 @@ def _document_completion_processing_events(
             },
         }
     ]
+
+
+def _legal_source_citations_from_processing_events(events: list[dict[str, object]]) -> list[dict[str, object]]:
+    citations: list[dict[str, object]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for event in events:
+        details = event.get("details")
+        if not isinstance(details, dict):
+            continue
+        raw_citations = details.get("citations")
+        if not isinstance(raw_citations, list):
+            continue
+        for raw_item in raw_citations:
+            if not isinstance(raw_item, dict):
+                continue
+            source_type = str(raw_item.get("source_type") or "other").strip() or "other"
+            source_id = str(raw_item.get("source_id") or "").strip()
+            source_url = str(raw_item.get("source_url") or "").strip()
+            title = str(raw_item.get("title") or raw_item.get("citation_label") or source_id or source_url).strip()
+            if not title:
+                continue
+            key = (source_type, source_id, source_url or title)
+            if key in seen:
+                continue
+            seen.add(key)
+            citations.append({**raw_item, "source_type": source_type, "title": title})
+    return citations
 
 
 def _document_generation_requested(messages: list[Message]) -> bool:
@@ -3978,10 +4009,10 @@ def _persist_case_citations_for_answer(
 
 def _case_citation_inputs_from_result(*, case_id: str, result: SessionResult) -> list[dict[str, object]]:
     metadata = result.metadata if isinstance(result.metadata, dict) else {}
+    citations: list[dict[str, object]] = _legal_source_citation_inputs(metadata=metadata)
     raw_law_citations = metadata.get("law_citations")
     if not isinstance(raw_law_citations, list):
-        return []
-    citations: list[dict[str, object]] = []
+        return citations
     seen: set[tuple[str, str]] = set()
     for raw_item in raw_law_citations:
         if not isinstance(raw_item, dict):
@@ -4032,6 +4063,49 @@ def _case_citation_inputs_from_result(*, case_id: str, result: SessionResult) ->
                 "snippet": _bounded_optional_text(snippet, max_chars=500),
                 "retrieval_tool": "JurisDigta laws collector",
                 "relevance_score": None,
+            }
+        )
+    return citations
+
+
+def _legal_source_citation_inputs(*, metadata: dict[str, object]) -> list[dict[str, object]]:
+    raw_citations = metadata.get("legal_source_citations")
+    if not isinstance(raw_citations, list):
+        return []
+    citations: list[dict[str, object]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for raw_item in raw_citations:
+        if not isinstance(raw_item, dict):
+            continue
+        source_type = str(raw_item.get("source_type") or "other").strip()
+        if source_type not in {"law", "court_decision", "case_document", "web", "other"}:
+            source_type = "other"
+        source_id = _optional_str(raw_item.get("source_id"))
+        source_url = _optional_str(raw_item.get("source_url"))
+        title = str(raw_item.get("title") or raw_item.get("citation_label") or source_id or source_url or "").strip()
+        if not title:
+            continue
+        key = (source_type, source_id or "", source_url or title)
+        if key in seen:
+            continue
+        seen.add(key)
+        citations.append(
+            {
+                "source_type": source_type,
+                "source_id": source_id,
+                "source_url": source_url,
+                "title": title,
+                "citation_label": _optional_str(raw_item.get("citation_label")) or title,
+                "law_number": _optional_str(raw_item.get("law_number")),
+                "section": _optional_str(raw_item.get("section")),
+                "effective_from": _optional_str(raw_item.get("effective_from")),
+                "court": _optional_str(raw_item.get("court")),
+                "ecli": _optional_str(raw_item.get("ecli")),
+                "file_number": _optional_str(raw_item.get("file_number")),
+                "decision_date": _optional_str(raw_item.get("decision_date")),
+                "snippet": _bounded_optional_text(raw_item.get("snippet"), max_chars=500),
+                "retrieval_tool": _optional_str(raw_item.get("retrieval_tool")),
+                "relevance_score": _optional_float(raw_item.get("relevance_score")),
             }
         )
     return citations
@@ -5736,10 +5810,33 @@ def _merge_session_citations(
     metadata: dict[str, object],
 ) -> list[dict[str, str]]:
     merged = list(generic_citations)
+    for citation in _legal_source_session_citations(metadata):
+        if citation not in merged:
+            merged.append(citation)
     for citation in _law_citation_session_citations(metadata):
         if citation not in merged:
             merged.append(citation)
     return merged
+
+
+def _legal_source_session_citations(metadata: dict[str, object]) -> list[dict[str, str]]:
+    citations: list[dict[str, str]] = []
+    raw_citations = metadata.get("legal_source_citations")
+    if not isinstance(raw_citations, list):
+        return citations
+    for raw_item in raw_citations:
+        if not isinstance(raw_item, dict):
+            continue
+        label = str(raw_item.get("citation_label") or raw_item.get("title") or "").strip()
+        if not label:
+            continue
+        source_type = str(raw_item.get("source_type") or "source").strip()
+        source_url = str(raw_item.get("source_url") or "").strip()
+        date = str(raw_item.get("decision_date") or raw_item.get("effective_from") or "").strip()
+        retrieval_tool = str(raw_item.get("retrieval_tool") or "").strip()
+        snippet_parts = [part for part in (source_type, date, retrieval_tool, source_url) if part]
+        citations.append({"filename": label, "snippet": ", ".join(snippet_parts)})
+    return citations
 
 
 def _law_citation_session_citations(metadata: dict[str, object]) -> list[dict[str, str]]:

--- a/api/aijuristiction-api/app/chat/mcp_law_context.py
+++ b/api/aijuristiction-api/app/chat/mcp_law_context.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import httpx
 
+from aijurisdictionagents.agents import AIWebSearchAgent
 from aijurisdictionagents.schemas import Document as CoreDocument
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,6 +43,25 @@ _LEGAL_QUERY_MARKERS = (
     "statute",
     "section",
 )
+_COURT_QUERY_MARKERS = (
+    "sudne rozhodnut",
+    "súdne rozhodnut",
+    "sudnych rozhodnut",
+    "súdnych rozhodnut",
+    "rozhodnutia",
+    "judikat",
+    "judikát",
+    "case law",
+    "court decision",
+    "court decisions",
+)
+_OFFICIAL_LEGAL_SOURCE_HOSTS = (
+    "slov-lex.sk",
+    "obcan.justice.sk",
+    "justice.gov.sk",
+    "nsud.sk",
+    "ustavnysud.sk",
+)
 
 
 @dataclass(frozen=True)
@@ -65,31 +85,53 @@ def build_mcp_law_context(
     if not _should_use_mcp_law_context(query=query, country=country, language=language):
         return None
 
+    if _should_search_court_decisions(query):
+        return _build_combined_legal_context(
+            query=query,
+            search_limit=max(search_limit, 5),
+            text_limit=text_limit,
+            max_chars_per_law=max_chars_per_law,
+        )
+    return _build_laws_only_context(
+        query=query,
+        search_limit=search_limit,
+        text_limit=text_limit,
+        max_chars_per_law=max_chars_per_law,
+    )
+
+
+def _build_laws_only_context(
+    *,
+    query: str,
+    search_limit: int,
+    text_limit: int,
+    max_chars_per_law: int,
+) -> McpLawContext:
     try:
         search_arguments = _search_arguments(query=query, limit=search_limit)
         search_payload = _call_mcp_tool("searchLaws", search_arguments)
-        results = _tool_results(search_payload)
-        law_texts = [
-            _law_text_payload(result=result, max_chars=max_chars_per_law)
-            for result in results[:text_limit]
-        ]
+        laws = _tool_results(search_payload)
+        law_texts = [_law_text_payload(result=result, max_chars=max_chars_per_law) for result in laws[:text_limit]]
     except Exception:  # noqa: BLE001
         _LOGGER.warning("Internal MCP law context lookup failed", exc_info=True)
-        return _unavailable_context()
+        return _unavailable_context(tool_calls=["searchLaws"])
 
-    if not results:
-        return _empty_context(query=query)
+    if not laws:
+        fallback = _official_web_fallback_context(query=query, reason="mcp_laws_empty")
+        return fallback or _empty_context(query=query, tool_calls=["searchLaws"])
 
     prompt_note = _prompt_note(
         query=query,
         search_arguments=search_arguments,
-        results=results,
+        laws=laws,
         law_texts=law_texts,
+        court_decisions=[],
+        fallback_records=[],
     )
     document = CoreDocument(
         doc_id="internal-mcp-law-context",
         path="internal-mcp-law-context.txt",
-        content=_document_content(results=results, law_texts=law_texts),
+        content=_document_content(laws=laws, law_texts=law_texts, court_decisions=[], fallback_records=[]),
     )
     return McpLawContext(
         prompt_note=prompt_note,
@@ -99,8 +141,72 @@ def build_mcp_law_context(
             "message": "JurisDigta MCP law tools searched current Slovak law context.",
             "details": {
                 "tool_calls": ["searchLaws", *("getLawText" for _item in law_texts)],
-                "result_count": len(results),
-                "document_ids": [str(result.get("document_id", "")) for result in results],
+                "result_count": len(laws),
+                "document_ids": [str(result.get("document_id", "")) for result in laws],
+                "source_origin": "system_vector_db",
+                "citations": _law_citations(laws),
+            },
+        },
+    )
+
+
+def _build_combined_legal_context(
+    *,
+    query: str,
+    search_limit: int,
+    text_limit: int,
+    max_chars_per_law: int,
+) -> McpLawContext:
+    try:
+        search_arguments = {
+            "query": query.strip(),
+            "country_code": "SK",
+            "source_types": ["laws", "court_decisions"],
+            "limit_per_source": search_limit,
+        }
+        search_payload = _call_mcp_tool("searchLegalSources", search_arguments)
+        laws = _tool_results_from_key(search_payload, "laws")
+        court_decisions = _tool_results_from_key(search_payload, "court_decisions")[:search_limit]
+        law_texts = [_law_text_payload(result=result, max_chars=max_chars_per_law) for result in laws[:text_limit]]
+    except Exception:  # noqa: BLE001
+        _LOGGER.warning("Internal MCP combined legal source lookup failed", exc_info=True)
+        return _unavailable_context(tool_calls=["searchLegalSources"])
+
+    if not laws and not court_decisions:
+        fallback = _official_web_fallback_context(query=query, reason="mcp_legal_sources_empty")
+        return fallback or _empty_context(query=query, tool_calls=["searchLegalSources"])
+
+    prompt_note = _prompt_note(
+        query=query,
+        search_arguments=search_arguments,
+        laws=laws,
+        law_texts=law_texts,
+        court_decisions=court_decisions,
+        fallback_records=[],
+    )
+    document = CoreDocument(
+        doc_id="internal-mcp-legal-source-context",
+        path="internal-mcp-legal-source-context.txt",
+        content=_document_content(
+            laws=laws,
+            law_texts=law_texts,
+            court_decisions=court_decisions,
+            fallback_records=[],
+        ),
+    )
+    return McpLawContext(
+        prompt_note=prompt_note,
+        document=document,
+        processing_event={
+            "stage": "mcp_law_context",
+            "message": "JurisDigta MCP searched laws and court decisions for this legal turn.",
+            "details": {
+                "tool_calls": ["searchLegalSources", *("getLawText" for _item in law_texts)],
+                "result_count": len(laws) + len(court_decisions),
+                "law_count": len(laws),
+                "court_decision_count": len(court_decisions),
+                "source_origin": "system_vector_db",
+                "citations": [*_law_citations(laws), *_court_decision_citations(court_decisions)],
             },
         },
     )
@@ -114,7 +220,12 @@ def _should_use_mcp_law_context(*, query: str, country: str, language: str | Non
     normalized_query = _canonical(query)
     if _LAW_IDENTIFIER_RE.search(query):
         return True
-    return any(marker in normalized_query for marker in _LEGAL_QUERY_MARKERS)
+    return any(marker in normalized_query for marker in (*_LEGAL_QUERY_MARKERS, *_COURT_QUERY_MARKERS))
+
+
+def _should_search_court_decisions(query: str) -> bool:
+    normalized_query = _canonical(query)
+    return any(marker in normalized_query for marker in _COURT_QUERY_MARKERS)
 
 
 def _search_arguments(*, query: str, limit: int) -> dict[str, Any]:
@@ -216,31 +327,45 @@ def _tool_results(payload: dict[str, Any]) -> list[dict[str, Any]]:
     return [item for item in raw_results if isinstance(item, dict)]
 
 
+def _tool_results_from_key(payload: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    raw_results = payload.get(key, [])
+    if not isinstance(raw_results, list):
+        return []
+    return [item for item in raw_results if isinstance(item, dict)]
+
+
 def _prompt_note(
     *,
     query: str,
     search_arguments: dict[str, Any],
-    results: list[dict[str, Any]],
+    laws: list[dict[str, Any]],
     law_texts: list[dict[str, Any]],
+    court_decisions: list[dict[str, Any]],
+    fallback_records: list[dict[str, str]],
 ) -> str:
     lines = [
         "INTERNAL MCP LAW TOOL CONTEXT:",
-        "- The assistant backend has already queried JurisDigta MCP tools for this Slovak legal turn.",
-        "- Treat these results as the mandatory current-law source before answering from model memory.",
-        "- Cite the law identifier and relevant section/paragraph when available.",
+        "- The assistant backend has already queried JurisDigta MCP tools for this Slovak legal turn whenever system data was available.",
+        "- Treat JurisDigta MCP results as the mandatory current-law and case-law source before answering from model memory.",
+        "- Cite the law identifier and relevant section/paragraph when available; cite court decisions as case-law support, not binding statutory text.",
         "- If the legal conclusion depends on effective wording, amendment status, or missing facts, say so explicitly.",
-        "- Do not invent legal citations that are not present in the MCP results.",
-        f"- MCP searchLaws arguments: {_compact_json(search_arguments)}",
+        "- Do not invent legal citations that are not present in the MCP or official-source fallback results.",
+        f"- Tool path: {_tool_path_label(search_arguments)}.",
+        f"- MCP search arguments: {_compact_json(search_arguments)}",
         f"- User query: {query.strip()}",
         "",
-        "MCP searchLaws results:",
+        "MCP law results:",
     ]
-    for index, result in enumerate(results, start=1):
+    for index, result in enumerate(laws, start=1):
         lines.append(
             f"{index}. document_id={result.get('document_id', '')}; "
             f"identifier={result.get('law_identifier_text', '')}; "
             f"title={result.get('title') or result.get('lawyer_title') or result.get('official_name') or ''}"
         )
+    if court_decisions:
+        lines.extend(["", "MCP court-decision results:"])
+    for index, decision in enumerate(court_decisions, start=1):
+        lines.append(f"{index}. {_court_decision_label(decision)}")
     if law_texts:
         lines.extend(["", "MCP getLawText excerpts:"])
     for index, text_payload in enumerate(law_texts, start=1):
@@ -249,17 +374,38 @@ def _prompt_note(
             f"title={text_payload.get('title') or text_payload.get('official_name') or ''}; "
             f"content={str(text_payload.get('content_text', '')).strip()}"
         )
+    if fallback_records:
+        lines.extend(
+            [
+                "",
+                "OFFICIAL WEB FALLBACK RESULTS:",
+                "- WARNING: These sources came from AIWebSearchAgent official web fallback, not from JurisDigta system vector DB.",
+                "- Tell the user that human legal review is required before relying on these fallback sources.",
+            ]
+        )
+    for index, record in enumerate(fallback_records, start=1):
+        lines.append(f"{index}. title={record.get('title', '')}; url={record.get('url', '')}; snippet={record.get('snippet', '')}")
     return "\n".join(lines).strip()
 
 
-def _document_content(*, results: list[dict[str, Any]], law_texts: list[dict[str, Any]]) -> str:
-    lines = ["JurisDigta MCP law context", "", "Search results:"]
-    for result in results:
+def _document_content(
+    *,
+    laws: list[dict[str, Any]],
+    law_texts: list[dict[str, Any]],
+    court_decisions: list[dict[str, Any]],
+    fallback_records: list[dict[str, str]],
+) -> str:
+    lines = ["JurisDigta legal retrieval context", "", "Law search results:"]
+    for result in laws:
         lines.append(
             f"- {result.get('law_identifier_text', '')}: "
             f"{result.get('title') or result.get('lawyer_title') or result.get('official_name') or ''} "
             f"(document_id={result.get('document_id', '')})"
         )
+    if court_decisions:
+        lines.extend(["", "Court-decision search results:"])
+    for decision in court_decisions:
+        lines.append(f"- {_court_decision_label(decision)}")
     if law_texts:
         lines.extend(["", "Law text excerpts:"])
     for payload in law_texts:
@@ -268,27 +414,31 @@ def _document_content(*, results: list[dict[str, Any]], law_texts: list[dict[str
             f"{payload.get('title') or payload.get('official_name') or ''}\n"
             f"{str(payload.get('content_text', '')).strip()}"
         )
+    if fallback_records:
+        lines.extend(["", "Official web fallback results:"])
+    for record in fallback_records:
+        lines.append(f"- {record.get('title', '')}: {record.get('url', '')} - {record.get('snippet', '')}")
     return "\n".join(lines).strip()
 
 
-def _empty_context(*, query: str) -> McpLawContext:
+def _empty_context(*, query: str, tool_calls: list[str]) -> McpLawContext:
     return McpLawContext(
         prompt_note=(
             "INTERNAL MCP LAW TOOL CONTEXT:\n"
-            "- JurisDigta MCP searchLaws was called for this Slovak legal turn but returned no matching law.\n"
+            "- JurisDigta MCP legal-source search was called for this Slovak legal turn but returned no matching source.\n"
             f"- User query: {query.strip()}\n"
             "- Tell the user that current-law lookup did not find a matching source and avoid exact legal citations."
         ),
         document=None,
         processing_event={
             "stage": "mcp_law_context",
-            "message": "JurisDigta MCP law search returned no matching law context.",
-            "details": {"tool_calls": ["searchLaws"], "result_count": 0},
+            "message": "JurisDigta MCP legal-source search returned no matching context.",
+            "details": {"tool_calls": tool_calls, "result_count": 0, "source_origin": "system_vector_db"},
         },
     )
 
 
-def _unavailable_context() -> McpLawContext:
+def _unavailable_context(*, tool_calls: list[str]) -> McpLawContext:
     return McpLawContext(
         prompt_note=(
             "INTERNAL MCP LAW TOOL CONTEXT:\n"
@@ -300,7 +450,7 @@ def _unavailable_context() -> McpLawContext:
         processing_event={
             "stage": "mcp_law_context",
             "message": "JurisDigta MCP law lookup is temporarily unavailable.",
-            "details": {"tool_calls": ["searchLaws"], "status": "unavailable"},
+            "details": {"tool_calls": tool_calls, "status": "unavailable"},
         },
     )
 
@@ -309,9 +459,165 @@ def _compact_json(value: dict[str, Any]) -> str:
     return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
 
 
+def _tool_path_label(search_arguments: dict[str, Any]) -> str:
+    if str(search_arguments.get("fallback") or "") == "AIWebSearchAgent":
+        return "AIWebSearchAgent"
+    if search_arguments.get("source_types"):
+        return "searchLegalSources"
+    return "searchLaws -> getLawText"
+
+
 def _canonical(value: str) -> str:
     import unicodedata
 
     normalized = unicodedata.normalize("NFKD", value.casefold())
     ascii_only = "".join(char for char in normalized if not unicodedata.combining(char))
     return re.sub(r"\s+", " ", ascii_only).strip()
+
+
+def _official_web_fallback_context(*, query: str, reason: str) -> McpLawContext | None:
+    records = _official_web_fallback_records(query=query)
+    if not records:
+        return None
+    prompt_note = _prompt_note(
+        query=query,
+        search_arguments={"query": query.strip(), "fallback": "AIWebSearchAgent", "official_sources_only": True},
+        laws=[],
+        law_texts=[],
+        court_decisions=[],
+        fallback_records=records,
+    )
+    return McpLawContext(
+        prompt_note=prompt_note,
+        document=CoreDocument(
+            doc_id="official-web-legal-fallback-context",
+            path="official-web-legal-fallback-context.txt",
+            content=_document_content(laws=[], law_texts=[], court_decisions=[], fallback_records=records),
+        ),
+        processing_event={
+            "stage": "mcp_law_context",
+            "message": "Official web fallback used because JurisDigta MCP returned no legal source.",
+            "details": {
+                "tool_calls": ["searchLegalSources", "AIWebSearchAgent"],
+                "result_count": len(records),
+                "fallback_reason": reason,
+                "source_origin": "official_web_fallback",
+                "warning_required": True,
+                "human_review_required": True,
+                "warning": (
+                    "Legal sources were retrieved from AIWebSearchAgent official web fallback, "
+                    "not from the JurisDigta system vector database."
+                ),
+                "citations": _web_citations(records),
+            },
+        },
+    )
+
+
+def _official_web_fallback_records(*, query: str) -> list[dict[str, str]]:
+    try:
+        records = AIWebSearchAgent().search(
+            query=f"{query.strip()} site:slov-lex.sk OR site:obcan.justice.sk OR site:justice.gov.sk",
+            max_results=5,
+        )
+    except Exception:  # noqa: BLE001
+        _LOGGER.warning("AIWebSearchAgent official legal fallback failed", exc_info=True)
+        return []
+    fallback_records: list[dict[str, str]] = []
+    for record in records:
+        url = str(record.url).strip()
+        if not _is_official_legal_source_url(url):
+            continue
+        fallback_records.append(
+            {
+                "title": str(record.title).strip(),
+                "url": url,
+                "snippet": str(record.snippet).strip(),
+            }
+        )
+    return fallback_records
+
+
+def _is_official_legal_source_url(url: str) -> bool:
+    normalized = url.strip().lower()
+    return any(host in normalized for host in _OFFICIAL_LEGAL_SOURCE_HOSTS)
+
+
+def _law_citations(laws: list[dict[str, Any]]) -> list[dict[str, object]]:
+    citations: list[dict[str, object]] = []
+    for result in laws:
+        label = str(result.get("law_identifier_text") or "").strip()
+        title = str(result.get("title") or result.get("lawyer_title") or result.get("official_name") or label).strip()
+        citations.append(
+            {
+                "source_type": "law",
+                "source_id": str(result.get("document_id") or "").strip() or None,
+                "source_url": str(result.get("source_url") or "").strip() or None,
+                "title": title or "Law",
+                "citation_label": label or title or "Law",
+                "law_number": label or None,
+                "effective_from": str(result.get("effective_from") or "").strip() or None,
+                "retrieval_tool": "JurisDigta MCP searchLaws",
+                "relevance_score": 1.0,
+            }
+        )
+    return citations
+
+
+def _court_decision_citations(court_decisions: list[dict[str, Any]]) -> list[dict[str, object]]:
+    citations: list[dict[str, object]] = []
+    for decision in court_decisions:
+        label = _court_decision_label(decision)
+        citations.append(
+            {
+                "source_type": "court_decision",
+                "source_id": str(decision.get("decision_id") or "").strip() or None,
+                "source_url": str(decision.get("source_url") or "").strip() or None,
+                "title": label,
+                "citation_label": label,
+                "court": str(decision.get("court_name") or "").strip() or None,
+                "ecli": str(decision.get("ecli") or "").strip() or None,
+                "file_number": str(decision.get("file_number") or decision.get("case_number") or "").strip() or None,
+                "decision_date": str(decision.get("issue_date") or "").strip() or None,
+                "snippet": str(decision.get("snippet") or "").strip() or None,
+                "retrieval_tool": "JurisDigta MCP searchCourtDecisions",
+                "relevance_score": _optional_score(decision.get("score"), default=1.0),
+            }
+        )
+    return citations
+
+
+def _web_citations(records: list[dict[str, str]]) -> list[dict[str, object]]:
+    return [
+        {
+            "source_type": "web",
+            "source_id": record["url"],
+            "source_url": record["url"],
+            "title": record["title"] or record["url"],
+            "citation_label": record["title"] or record["url"],
+            "snippet": record["snippet"],
+            "retrieval_tool": "AIWebSearchAgent official web fallback",
+            "relevance_score": 0.9,
+        }
+        for record in records
+    ]
+
+
+def _court_decision_label(decision: dict[str, Any]) -> str:
+    court = str(decision.get("court_name") or "").strip()
+    file_number = str(decision.get("file_number") or decision.get("case_number") or "").strip()
+    ecli = str(decision.get("ecli") or "").strip()
+    issue_date = str(decision.get("issue_date") or "").strip()
+    year = issue_date[:4] if len(issue_date) >= 4 else ""
+    reference = ecli or file_number or str(decision.get("decision_id") or "").strip()
+    parts = [part for part in (court, reference, year or issue_date) if part]
+    return " - ".join(parts) if parts else "Court decision"
+
+
+def _optional_score(value: object, *, default: float) -> float:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        return default

--- a/api/aijuristiction-api/e2e-playwright/e2e-test-catalog.json
+++ b/api/aijuristiction-api/e2e-playwright/e2e-test-catalog.json
@@ -178,5 +178,15 @@
     "area": "Frontend document preview",
     "scheduled": false,
     "prerequisite": "Requires FRONTEND_BASE_URL with a running frontend."
+  },
+  {
+    "id": "frontend-mcp-court-decisions",
+    "file": "tests/frontend-mcp-court-decisions.spec.ts",
+    "title": "assistant asks MCP for top five court decisions and renders provenance",
+    "name": "Frontend MCP court-decision retrieval",
+    "description": "Drives the assistant workspace with a Slovak court-decision prompt and verifies MCP retrieval status, five decision results, citation provenance, and official web fallback warning rendering.",
+    "area": "Frontend legal RAG",
+    "scheduled": false,
+    "prerequisite": "Requires FRONTEND_BASE_URL with a running frontend."
   }
 ]

--- a/api/aijuristiction-api/e2e-playwright/tests/frontend-mcp-court-decisions.spec.ts
+++ b/api/aijuristiction-api/e2e-playwright/tests/frontend-mcp-court-decisions.spec.ts
@@ -1,0 +1,191 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+const frontendBaseURL = process.env.FRONTEND_BASE_URL;
+const authSessionKey = 'jurisdigta.web.auth.user.v1';
+const prompt = 'Daj mi top 5 sudnych rozhodnuti ohladom podnajmu?';
+const userId = 'legal-rag-e2e-user';
+const caseId = 'legal-rag-case';
+const now = '2026-07-07T07:00:00.000Z';
+
+const decisionCitations = Array.from({ length: 5 }, (_, index) => {
+  const number = index + 1;
+  const year = 2020 + number;
+  return {
+    id: `citation-decision-${number}`,
+    case_id: caseId,
+    question_message_id: 'msg-user-1',
+    answer_message_id: 'msg-assistant-1',
+    source_type: 'court_decision',
+    source_id: `decision-${number}`,
+    source_url: `https://obcan.justice.sk/infosud/-/detail/decision-${number}`,
+    title: `Najvyssi sud SR - ${number}Cdo/${year} - ${year}`,
+    citation_label: `Najvyssi sud SR - ${number}Cdo/${year} - ${year}`,
+    law_number: null,
+    section: null,
+    effective_from: null,
+    court: 'Najvyssi sud SR',
+    ecli: null,
+    file_number: `${number}Cdo/${year}`,
+    decision_date: `${year}-03-01`,
+    snippet: `Pseudonymizovany verejny metadatovy vysledok k podnajmu ${number}.`,
+    retrieval_tool: 'JurisDigta MCP searchCourtDecisions',
+    relevance_score: 0.99 - index / 100,
+    created_at: now,
+  };
+});
+
+const webFallbackCitation = {
+  id: 'citation-web-fallback',
+  case_id: caseId,
+  question_message_id: 'msg-user-1',
+  answer_message_id: 'msg-assistant-1',
+  source_type: 'web',
+  source_id: 'https://obcan.justice.sk/infosud/-/detail/fallback',
+  source_url: 'https://obcan.justice.sk/infosud/-/detail/fallback',
+  title: 'Fallback rozhodnutie z oficialneho webu',
+  citation_label: 'Fallback rozhodnutie z oficialneho webu',
+  law_number: null,
+  section: null,
+  effective_from: null,
+  court: null,
+  ecli: null,
+  file_number: null,
+  decision_date: '2026-01-15',
+  snippet: 'Official web fallback citation.',
+  retrieval_tool: 'AIWebSearchAgent official web fallback',
+  relevance_score: 0.9,
+  created_at: now,
+};
+
+const assistantAnswer = [
+  'Nasiel som 5 sudnych rozhodnuti k podnajmu cez JurisDigta MCP:',
+  ...decisionCitations.map((citation, index) => `${index + 1}. ${citation.title}`),
+].join('\n');
+
+async function authenticate(page: Page) {
+  await page.addInitScript(
+    ({ key }) => {
+      window.localStorage.setItem('aj_frontend_lang', 'en');
+      window.sessionStorage.setItem(
+        key,
+        JSON.stringify({
+          userId: 'legal-rag-e2e-user',
+          email: 'legal-rag@example.test',
+          name: 'Legal RAG E2E User',
+          role: 'JurisDigta user',
+        }),
+      );
+    },
+    { key: authSessionKey },
+  );
+}
+
+async function fulfillJson(route: Route, body: unknown) {
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
+test('assistant asks MCP for top five court decisions and renders provenance', async ({ page }) => {
+  test.skip(!frontendBaseURL, 'Set FRONTEND_BASE_URL to run frontend assistant checks.');
+
+  let streamedPrompt = '';
+  let streamCompleted = false;
+
+  await authenticate(page);
+  await page.route('**/v1/model-routing/effective**', async (route) => {
+    await fulfillJson(route, { provider: 'azurefoundry', model: 'gpt-4o-mini', route_type: 'paid_case' });
+  });
+  await page.route('**/v1/cases?**', async (route) => {
+    await fulfillJson(route, [
+      {
+        case_id: caseId,
+        user_id: userId,
+        company_id: null,
+        title: 'Legal RAG court-decision case',
+        status: 'open',
+        created_at: now,
+        updated_at: now,
+      },
+    ]);
+  });
+  await page.route(`**/v1/cases/${caseId}/history?**`, async (route) => {
+    await fulfillJson(route, {
+      messages: streamCompleted
+        ? [
+            {
+              communication_id: 'msg-user-1',
+              role: 'user',
+              content: prompt,
+              agent_name: null,
+              created_at: now,
+              citations: [],
+            },
+            {
+              communication_id: 'msg-assistant-1',
+              role: 'assistant',
+              content: assistantAnswer,
+              agent_name: 'LawyerSlovakia',
+              created_at: now,
+              citations: decisionCitations,
+            },
+          ]
+        : [],
+      documents: [],
+      citations: streamCompleted ? [...decisionCitations, webFallbackCitation] : [],
+      has_more: false,
+    });
+  });
+  await page.route('**/v1/chat/sessions', async (route) => {
+    expect(route.request().method()).toBe('POST');
+    await fulfillJson(route, {
+      id: '11111111-1111-4111-8111-111111111111',
+      user_id: userId,
+      case_id: caseId,
+      country: 'SK',
+      language: 'en',
+      discussion_type: 'advice',
+      state: 'active',
+      created_at: now,
+    });
+  });
+  await page.route('**/v1/chat/sessions/11111111-1111-4111-8111-111111111111/stream', async (route) => {
+    const body = route.request().postDataJSON() as { instruction?: string; user_simulation_mode?: string };
+    streamedPrompt = body.instruction ?? '';
+    expect(body.user_simulation_mode).toBe('ReadUser');
+    streamCompleted = true;
+    const streamBody = [
+      'event: processing',
+      'data: {"stage":"mcp_law_context","message":"JurisDigta MCP searched laws and court decisions for this legal turn.","details":{"tool_calls":["searchLegalSources"],"court_decision_count":5,"source_origin":"system_vector_db"}}',
+      '',
+      'event: message',
+      `data: ${JSON.stringify({ role: 'assistant', content: assistantAnswer, agent_name: 'LawyerSlovakia' })}`,
+      '',
+      'event: done',
+      'data: {"status":"completed"}',
+      '',
+    ].join('\n');
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body: streamBody,
+    });
+  });
+
+  await page.goto(`${frontendBaseURL}/app/assistant`);
+  await page.getByText('Legal RAG court-decision case').click();
+  await page.locator('.assistant-composer__input').fill(prompt);
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByText('Nasiel som 5 sudnych rozhodnuti')).toBeVisible({ timeout: 20_000 });
+  for (const citation of decisionCitations) {
+    await expect(page.locator('.assistant-main').getByText(citation.title).first()).toBeVisible();
+  }
+  await expect(page.locator('.assistant-tool-panel').getByText('JurisDigta MCP searchCourtDecisions')).toHaveCount(5);
+  await expect(page.locator('.assistant-tool-panel').getByText('Fallback rozhodnutie z oficialneho webu')).toBeVisible();
+  await expect(page.getByText('official web-search fallback, not from JurisDigta system vector DB')).toBeVisible();
+  expect(streamedPrompt).toBe(prompt);
+  expect(streamCompleted).toBe(true);
+});

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260511"
+version = "1.0.260512"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -1696,6 +1696,111 @@ def test_mcp_law_context_uses_search_and_law_text_tools(monkeypatch) -> None:
     assert "§ 588" in context.document.content
 
 
+def test_mcp_law_context_uses_combined_legal_sources_for_court_decision_query(monkeypatch) -> None:
+    from app.chat.mcp_law_context import build_mcp_law_context
+
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_call_tool(name: str, arguments: dict[str, object]) -> dict[str, object]:
+        calls.append((name, arguments))
+        if name == "searchLegalSources":
+            return {
+                "laws": [],
+                "court_decisions": [
+                    {
+                        "decision_id": f"decision-{index}",
+                        "court_name": "Najvyssi sud SR",
+                        "file_number": f"{index}Cdo/{2020 + index}",
+                        "issue_date": f"{2020 + index}-03-01",
+                        "source_url": f"https://obcan.justice.sk/infosud/-/detail/decision-{index}",
+                        "score": 0.99 - index / 100,
+                    }
+                    for index in range(1, 6)
+                ],
+            }
+        raise AssertionError(name)
+
+    monkeypatch.setattr("app.chat.mcp_law_context._call_mcp_tool", fake_call_tool)
+
+    context = build_mcp_law_context(
+        query="Daj mi top 5 sudnych rozhodnuti ohladom podnajmu?",
+        country="SK",
+        language="sk-SK",
+    )
+
+    assert context is not None
+    assert calls == [
+        (
+            "searchLegalSources",
+            {
+                "query": "Daj mi top 5 sudnych rozhodnuti ohladom podnajmu?",
+                "country_code": "SK",
+                "source_types": ["laws", "court_decisions"],
+                "limit_per_source": 5,
+            },
+        )
+    ]
+    assert "MCP court-decision results" in context.prompt_note
+    assert context.prompt_note.count("Najvyssi sud SR") == 5
+    details = context.processing_event["details"]
+    assert isinstance(details, dict)
+    assert details["source_origin"] == "system_vector_db"
+    assert details["court_decision_count"] == 5
+    citations = details["citations"]
+    assert isinstance(citations, list)
+    assert len(citations) == 5
+    assert citations[0]["source_type"] == "court_decision"
+    assert citations[0]["decision_date"] == "2021-03-01"
+    assert citations[0]["retrieval_tool"] == "JurisDigta MCP searchCourtDecisions"
+
+
+def test_mcp_law_context_warns_when_official_web_fallback_is_used(monkeypatch) -> None:
+    from app.chat.mcp_law_context import build_mcp_law_context
+
+    def fake_call_tool(name: str, arguments: dict[str, object]) -> dict[str, object]:
+        assert name == "searchLegalSources"
+        return {"laws": [], "court_decisions": []}
+
+    monkeypatch.setattr("app.chat.mcp_law_context._call_mcp_tool", fake_call_tool)
+    monkeypatch.setattr(
+        "app.chat.mcp_law_context.AIWebSearchAgent",
+        lambda: SimpleNamespace(
+            search=lambda **_kwargs: [
+                SimpleNamespace(
+                    title="Rozhodnutie o podnajme",
+                    url="https://obcan.justice.sk/infosud/-/detail/fallback-decision",
+                    snippet="Oficialny zdroj sudneho rozhodnutia.",
+                ),
+                SimpleNamespace(
+                    title="Neoficialny blog",
+                    url="https://example.com/blog",
+                    snippet="Ignored unofficial source.",
+                ),
+            ]
+        ),
+    )
+
+    context = build_mcp_law_context(
+        query="Daj mi top 5 sudnych rozhodnuti ohladom podnajmu?",
+        country="SK",
+        language="sk-SK",
+    )
+
+    assert context is not None
+    assert "OFFICIAL WEB FALLBACK RESULTS" in context.prompt_note
+    assert "not from JurisDigta system vector DB" in context.prompt_note
+    details = context.processing_event["details"]
+    assert isinstance(details, dict)
+    assert details["source_origin"] == "official_web_fallback"
+    assert details["warning_required"] is True
+    citations = details["citations"]
+    assert isinstance(citations, list)
+    assert len(citations) == 1
+    assert citations[0]["source_type"] == "web"
+    assert citations[0]["retrieval_tool"] == "AIWebSearchAgent official web fallback"
+    assert citations[0]["relevance_score"] == 0.9
+
+
 def test_mcp_law_context_prefers_remote_mcp_endpoint(monkeypatch) -> None:
     from app.chat.mcp_law_context import build_mcp_law_context
 
@@ -6391,6 +6496,77 @@ def test_direct_reply_result_includes_structured_law_citations(monkeypatch) -> N
     assert result.metadata["law_citations"][0]["law_identifier"] == "1/1993 Z. z."
     assert result.citations[0]["filename"] == "1/1993 Z. z."
     assert "effective from 1993-01-01" in result.citations[0]["snippet"]
+
+
+def test_direct_reply_result_includes_mcp_court_and_web_source_citations(monkeypatch) -> None:
+    from app.chat.api import _build_direct_reply_result, _case_citation_inputs_from_result
+    from app.chat.models import Message, MessageRole, Session
+    import app.chat.result_metadata as result_metadata
+
+    monkeypatch.setattr(result_metadata, "resolve_session_law_citations", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        result_metadata,
+        "get_law_knowledge_snapshot",
+        lambda _country, **_kwargs: result_metadata.LawKnowledgeSnapshot(
+            last_law_update_date=None,
+            last_law_update_source="unavailable",
+            model_knowledge_cutoff_date="2023-10-01",
+            model_knowledge_cutoff_source="https://platform.openai.com/docs/models/gpt-4o-mini",
+        ),
+    )
+
+    class _FakeValidator:
+        def evaluate(self, **_kwargs):
+            return SimpleNamespace(weighted_accuracy=91.0, summary="Validated.", scores=[])
+
+    monkeypatch.setattr(result_metadata, "AIAgentsValidator", lambda **_kwargs: _FakeValidator())
+
+    session_id = uuid4()
+    session = Session(id=session_id, country="SK", language="SK")
+    messages = [
+        Message(session_id=session_id, role=MessageRole.USER, content="Daj mi top 5 sudnych rozhodnuti ohladom podnajmu?"),
+        Message(session_id=session_id, role=MessageRole.ASSISTANT, content="Nasiel som relevantne rozhodnutia."),
+    ]
+
+    result = _build_direct_reply_result(
+        session_id=session_id,
+        session=session,
+        messages=messages,
+        lawyer_message=messages[-1].content,
+        legal_source_citations=[
+            {
+                "source_type": "court_decision",
+                "source_id": "decision-1",
+                "source_url": "https://obcan.justice.sk/infosud/-/detail/decision-1",
+                "title": "Najvyssi sud SR - 1Cdo/2021 - 2021",
+                "citation_label": "Najvyssi sud SR - 1Cdo/2021 - 2021",
+                "court": "Najvyssi sud SR",
+                "file_number": "1Cdo/2021",
+                "decision_date": "2021-03-01",
+                "retrieval_tool": "JurisDigta MCP searchCourtDecisions",
+                "relevance_score": 1.0,
+            },
+            {
+                "source_type": "web",
+                "source_id": "https://obcan.justice.sk/infosud/-/detail/fallback",
+                "source_url": "https://obcan.justice.sk/infosud/-/detail/fallback",
+                "title": "Fallback rozhodnutie",
+                "citation_label": "Fallback rozhodnutie",
+                "snippet": "Official web fallback.",
+                "retrieval_tool": "AIWebSearchAgent official web fallback",
+                "relevance_score": 0.9,
+            },
+        ],
+    )
+
+    assert result.metadata["legal_source_citations"][0]["source_type"] == "court_decision"
+    assert result.citations[0]["filename"] == "Najvyssi sud SR - 1Cdo/2021 - 2021"
+    assert "JurisDigta MCP searchCourtDecisions" in result.citations[0]["snippet"]
+    persisted_inputs = _case_citation_inputs_from_result(case_id="case-1", result=result)
+    assert [item["source_type"] for item in persisted_inputs] == ["court_decision", "web"]
+    assert persisted_inputs[0]["decision_date"] == "2021-03-01"
+    assert persisted_inputs[1]["retrieval_tool"] == "AIWebSearchAgent official web fallback"
+    assert persisted_inputs[1]["relevance_score"] == 0.9
 
 
 def test_law_snapshot_falls_back_to_model_cutoff_and_writes_cache(monkeypatch, tmp_path) -> None:

--- a/docs/assistant_architecture.md
+++ b/docs/assistant_architecture.md
@@ -6,8 +6,8 @@ The internal JurisDigta assistant should use JurisDigta MCP as its source-of-tru
 
 1. The frontend starts or resumes a `/v1/chat` session.
 2. The chat API records the user turn and gathers case history, uploaded documents, and processed document chunks.
-3. For Slovak legal turns, the chat API builds an internal MCP law context by calling `searchLaws` and `getLawText` over the configured MCP endpoint (`INTERNAL_MCP_BASE_URL` in production, with an in-process fallback for local tests).
-4. When a Slovak legal turn needs case-law support, the chat API or MCP client may call `searchCourtDecisions` and `getCourtDecision`. Court-decision context must default to pseudonymized public text for UI and external model routes.
+3. For Slovak legal turns, the chat API builds an internal MCP legal context over the configured MCP endpoint (`INTERNAL_MCP_BASE_URL` in production, with an in-process fallback for local tests). Law-only turns call `searchLaws` and focused `getLawText`; court-decision turns call `searchLegalSources` with `source_types=["laws","court_decisions"]` so laws and case-law use the same governed tool surface.
+4. When a Slovak legal turn needs case-law support, the chat API or MCP client may call `searchCourtDecisions` and `getCourtDecision`. Court-decision context must default to metadata or pseudonymized public text for UI and external model routes.
 5. The lawyer model receives the user conversation, case documents, uploaded documents, internal MCP law context, and optional court-decision context.
 6. The model must cite MCP law identifiers and relevant sections when the MCP context contains them, and must say when current-law lookup was unavailable or inconclusive. Court decisions must be cited as case-law support with court, date, ECLI or file number when available, not as binding statutory text.
 7. Document drafting remains a separate validated workflow: ask for missing facts, require explicit user confirmation before final drafting, then export generated assets through the document export endpoints.
@@ -19,6 +19,8 @@ Chat result metadata now normalizes JurisDigta law lookup results into durable c
 `POST /v1/chat/sessions/{session_id}/reply` returns assistant messages with `citations[]` when structured legal sources are available. `GET /v1/cases/{case_id}/history` returns the same answer-level `citations[]` on each assistant/system history message plus a case-level aggregate list. `GET /v1/cases/{case_id}/citations` returns the authorized aggregate list for the active case citation panel.
 
 The frontend renders per-answer citations below assistant answers and a deduplicated case citation list in the right configuration panel. Empty states stay explicit when no reliable citation exists or lookup was inconclusive.
+
+Legal-source citations carry retrieval provenance. JurisDigta MCP/vector results use source score `1.0` and retrieval tools such as `JurisDigta MCP searchLaws` or `JurisDigta MCP searchCourtDecisions`. If the system vector DB has no reliable legal source, the backend may use `AIWebSearchAgent` only for official legal sources such as Slov-Lex or official court-decision pages; these fallback citations use source score `0.9`, `source_type=web`, and must render a visible warning that the source came from official web search rather than the JurisDigta system vector DB.
 
 ## Quality Target
 

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -134,6 +134,35 @@ with tempfile.TemporaryDirectory(prefix="jurisdigta-minimal-", ignore_cleanup_er
         snippet="Privacy-minimized citation metadata for review.",
         retrieval_tool="JurisDigta laws collector",
     )
+    demo_store.add_case_citation(
+        case_id=demo_case.case_id,
+        question_message_id=demo_question_id,
+        answer_message_id=demo_answer_id,
+        source_type="court_decision",
+        source_id="decision-demo-1",
+        source_url="https://obcan.justice.sk/infosud/-/detail/decision-demo-1",
+        title="Najvyssi sud SR - 1Cdo/2021 - 2021",
+        citation_label="Najvyssi sud SR - 1Cdo/2021 - 2021",
+        court="Najvyssi sud SR",
+        file_number="1Cdo/2021",
+        decision_date="2021-03-01",
+        snippet="Pseudonymized court-decision metadata for case-law support.",
+        retrieval_tool="JurisDigta MCP searchCourtDecisions",
+        relevance_score=1.0,
+    )
+    demo_store.add_case_citation(
+        case_id=demo_case.case_id,
+        question_message_id=demo_question_id,
+        answer_message_id=demo_answer_id,
+        source_type="web",
+        source_id="https://obcan.justice.sk/infosud/-/detail/fallback-demo",
+        source_url="https://obcan.justice.sk/infosud/-/detail/fallback-demo",
+        title="Official web fallback source",
+        citation_label="Official web fallback source",
+        snippet="Warning source: official web fallback, not JurisDigta system vector DB.",
+        retrieval_tool="AIWebSearchAgent official web fallback",
+        relevance_score=0.9,
+    )
     print(
         "case_citations => "
         f"{len(demo_store.list_case_citations(case_id=demo_case.case_id))} persisted citation"

--- a/frontend/aijurisdictionfronend/src/pages/AssistantWorkspace.tsx
+++ b/frontend/aijurisdictionfronend/src/pages/AssistantWorkspace.tsx
@@ -73,6 +73,9 @@ const citationTypeLabel = (citation: CaseCitation): string => {
   }
 };
 
+const isFallbackCitation = (citation: CaseCitation): boolean =>
+  citation.sourceType === "web" || /AIWebSearchAgent/i.test(citation.retrievalTool ?? "");
+
 const dedupeCaseCitations = (citations: CaseCitation[]): CaseCitation[] => {
   const seen = new Set<string>();
   return citations.filter((citation) => {
@@ -107,6 +110,13 @@ const CitationList: React.FC<{ citations: CaseCitation[]; emptyLabel: string; ti
               <strong>{citationDisplayLabel(citation)}</strong>
             )}
             {citation.effectiveFrom ? <span>{citation.effectiveFrom}</span> : null}
+            {citation.decisionDate ? <span>{citation.decisionDate}</span> : null}
+            {citation.retrievalTool ? <span>{citation.retrievalTool}</span> : null}
+            {isFallbackCitation(citation) ? (
+              <p className="citation-list__warning">
+                Warning: this source came from official web-search fallback, not from JurisDigta system vector DB. Human legal review is required.
+              </p>
+            ) : null}
             {citation.snippet ? <p>{citation.snippet}</p> : null}
           </li>
         ))}

--- a/frontend/aijurisdictionfronend/src/pages/Home.tsx
+++ b/frontend/aijurisdictionfronend/src/pages/Home.tsx
@@ -56,6 +56,9 @@ const citationTypeLabel = (citation: CaseCitation): string => {
   }
 };
 
+const isFallbackCitation = (citation: CaseCitation): boolean =>
+  citation.sourceType === "web" || /AIWebSearchAgent/i.test(citation.retrievalTool ?? "");
+
 const dedupeCaseCitations = (citations: CaseCitation[]): CaseCitation[] => {
   const seen = new Set<string>();
   return citations.filter((citation) => {
@@ -90,6 +93,13 @@ const CitationList: React.FC<{ citations: CaseCitation[]; emptyLabel: string; ti
               <strong>{citationDisplayLabel(citation)}</strong>
             )}
             {citation.effectiveFrom ? <span>{citation.effectiveFrom}</span> : null}
+            {citation.decisionDate ? <span>{citation.decisionDate}</span> : null}
+            {citation.retrievalTool ? <span>{citation.retrievalTool}</span> : null}
+            {isFallbackCitation(citation) ? (
+              <p className="citation-list__warning">
+                Warning: this source came from official web-search fallback, not from JurisDigta system vector DB. Human legal review is required.
+              </p>
+            ) : null}
             {citation.snippet ? <p>{citation.snippet}</p> : null}
           </li>
         ))}

--- a/frontend/aijurisdictionfronend/src/styles/app.css
+++ b/frontend/aijurisdictionfronend/src/styles/app.css
@@ -968,6 +968,13 @@
   line-height: 1.4;
 }
 
+.citation-list__warning {
+  border-left: 3px solid #b7791f;
+  padding-left: 0.55rem;
+  color: #6f3f05 !important;
+  font-weight: 700;
+}
+
 .citation-list__type {
   width: fit-content;
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- Implements MCP-first legal retrieval for Slovak legal turns, including `searchLegalSources` for court-decision questions and structured provenance for laws, court decisions, and official web fallback sources.
- Adds official-source `AIWebSearchAgent` fallback only when MCP/system vector results are empty, with warning metadata and UI warning rendering.
- Adds frontend E2E coverage for `Daj mi top 5 sudnych rozhodnuti ohladom podnajmu?` and documents the retrieval policy.

## Validation
- `./scripts/validate_api.ps1`
- `./conda/python.exe -m pytest api/aijuristiction-api/tests`
- `./conda/python.exe examples/minimal_demo.py`
- `npm run build` in `frontend/aijurisdictionfronend`
- `FRONTEND_BASE_URL=http://127.0.0.1:5175 API_BASE_URL=http://127.0.0.1:8080 npm exec playwright -- test tests/frontend-mcp-court-decisions.spec.ts --reporter=list` in `api/aijuristiction-api/e2e-playwright`

Closes #486