### PR TITLE
Gate email scheduler Azure deploy

### DIFF
--- a/.github/workflows/email_build_deploy.yml
+++ b/.github/workflows/email_build_deploy.yml
@@ -24,7 +24,7 @@ on:
         description: "Deploy the email scheduler ACA job"
         required: false
         type: boolean
-        default: true
+        default: false
       github_environment:
         description: "GitHub Environment that contains Azure variables"
         required: true
@@ -63,7 +63,7 @@ jobs:
   deploy_to_azure:
     runs-on: windows-latest
     needs: test_and_build
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.deploy)
+    if: github.event_name == 'workflow_dispatch' && inputs.deploy
     environment: ${{ github.event_name == 'workflow_dispatch' && inputs.github_environment || 'dev' }}
     permissions:
       id-token: write

--- a/docs/EMAIL_SETUP.md
+++ b/docs/EMAIL_SETUP.md
@@ -141,7 +141,7 @@ Recommended GitHub Environment variables:
 - `AZURE_EMAIL_SCHEDULER_JOB_NAME=email-scheduler`
 - `AZURE_EMAIL_SCHEDULER_CRON_EXPRESSION=*/5 * * * *`
 
-`infra_deploy` now provisions the initial ACA job shell for this scheduler in the selected GitHub Environment. That shell uses a no-op placeholder container so the job can exist before the real image is published. Run `Email Scheduler Build and Deploy` afterward to publish the real image, apply migrations, and inject SMTP secrets.
+`infra_deploy` now provisions the initial ACA job shell for this scheduler in the selected GitHub Environment. That shell uses a no-op placeholder container so the job can exist before the real image is published. Run `Email Scheduler Build and Deploy` afterward with the manual `deploy=true` input to publish the real image, apply migrations, and inject SMTP secrets. Pull requests and pushes to `main` only run the scheduler tests and image build by default.
 Legacy values such as `email_scheduler` are normalized to `email-scheduler` during deployment.
 
 The deploy path applies the PostgreSQL email schema migrations from `databases/api/email` before it updates the ACA Job, and the job runs `python -m app.email_scheduler_job_main` once per trigger.

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -547,7 +547,7 @@ Typical order:
 3. `API Build and Deploy` with `deploy=true`
 4. `Document Processor Build and Deploy`
 5. `Laws Collector Build and Deploy`
-6. `Email Scheduler Build and Deploy`
+6. `Email Scheduler Build and Deploy` with `deploy=true`
 7. `web_build_deploy`
 8. `mobile_flutter_build`
 
@@ -570,7 +570,7 @@ Observability note:
 
 ## 14. Current Workflow Defaults
 
-Some workflows default to `dev` for push-based execution. The API workflow is build/test by default and deploys only when manually dispatched with `deploy=true`.
+Some workflows default to `dev` for push-based execution. The API and email scheduler workflows are build/test by default and deploy only when manually dispatched with `deploy=true`.
 
 That means:
 
@@ -582,7 +582,8 @@ That means:
 - `API Build and Deploy` injects SMTP settings and vehicle validation settings into the API Container App; `EMAIL_SMTP_PASSWORD` and `CAR_VALIDATION_API_KEY` are stored as Container App secrets.
 - `API Build and Deploy` fails during environment validation when `EMAIL_TRANSPORT=smtp` and `EMAIL_SMTP_PASSWORD` is empty.
 - `Laws Collector Build and Deploy` now deploys automatically to `dev` on `push` to `main` after its tests/build pass
-- `Email Scheduler Build and Deploy` deploys the dedicated ACA Job to `dev` on `push` to `main` when API/email scheduler files change
+- `Email Scheduler Build and Deploy` runs tests and builds the scheduler API image on pull requests and pushes to `main`, but does not deploy by default.
+- `Email Scheduler Build and Deploy` has a manual `workflow_dispatch` input `deploy` with default `false`; set `deploy=true` and choose `github_environment` to deploy the dedicated ACA Job.
 - `test` and `prod` remain manual `workflow_dispatch` targets unless a workflow is explicitly changed to auto-deploy them
 - `Self-Managed Prod Deploy` is manual-only and always uses the protected `prod` GitHub Environment
 - `Self-Managed Prod Deploy` builds `jurisdigta-document-processor:local`, starts API with `DOCUMENT_PROCESSOR_OPTION=azure`, and installs `/srv/jurisdigta/ops/run_document_processor.sh` when `JURISDIGTA_INSTALL_DOCUMENT_PROCESSOR_CRON=1`


### PR DESCRIPTION
﻿## Summary
- make Email Scheduler Build and Deploy deployment manual-only by default
- keep pull request and main push runs limited to scheduler tests and Docker image build
- update email scheduler and GitHub Environment docs to require manual deploy=true for Azure scheduler deployment

## Validation
- git diff --check
- inspected failed Actions run 28879832441; build passed and automatic Azure deploy failed on PostgreSQL firewall setup
