### PR TITLE
Make laws collector deploy opt-in

### DIFF
--- a/.github/workflows/laws_collector_build_deploy.yml
+++ b/.github/workflows/laws_collector_build_deploy.yml
@@ -32,7 +32,7 @@ on:
         description: "Deploy the laws collector ACA job"
         required: false
         type: boolean
-        default: true
+        default: false
       github_environment:
         description: "GitHub Environment that contains Azure variables"
         required: true
@@ -66,7 +66,7 @@ jobs:
   deploy_to_azure:
     runs-on: windows-latest
     needs: test_and_build
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.deploy)
+    if: github.event_name == 'workflow_dispatch' && inputs.deploy
     environment: ${{ github.event_name == 'workflow_dispatch' && inputs.github_environment || 'dev' }}
     permissions:
       id-token: write

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -546,7 +546,7 @@ Typical order:
 2. `Database Schema Upgrade` if needed
 3. `API Build and Deploy` with `deploy=true`
 4. `Document Processor Build and Deploy`
-5. `Laws Collector Build and Deploy`
+5. `Laws Collector Build and Deploy` with `deploy=true`
 6. `Email Scheduler Build and Deploy` with `deploy=true`
 7. `web_build_deploy`
 8. `mobile_flutter_build`
@@ -570,7 +570,7 @@ Observability note:
 
 ## 14. Current Workflow Defaults
 
-Some workflows default to `dev` for push-based execution. The API and email scheduler workflows are build/test by default and deploy only when manually dispatched with `deploy=true`.
+Some workflows default to `dev` for push-based execution. The laws collector and email scheduler workflows are build/test by default and deploy only when manually dispatched with `deploy=true`.
 
 That means:
 
@@ -581,7 +581,8 @@ That means:
 - `API Build and Deploy` injects `EMAIL_DB_OPTION=azure`, `EMAIL_DB_CLOUD=secretref:db-cloud`, and `EMAIL_DB_LOCAL=/tmp/email.sqlite3` automatically, so email outbox storage follows the API PostgreSQL deployment.
 - `API Build and Deploy` injects SMTP settings and vehicle validation settings into the API Container App; `EMAIL_SMTP_PASSWORD` and `CAR_VALIDATION_API_KEY` are stored as Container App secrets.
 - `API Build and Deploy` fails during environment validation when `EMAIL_TRANSPORT=smtp` and `EMAIL_SMTP_PASSWORD` is empty.
-- `Laws Collector Build and Deploy` now deploys automatically to `dev` on `push` to `main` after its tests/build pass
+- `Laws Collector Build and Deploy` runs tests and builds the laws collector image on pull requests and pushes to `main`, but does not deploy by default.
+- `Laws Collector Build and Deploy` has a manual `workflow_dispatch` input `deploy` with default `false`; set `deploy=true` and choose `github_environment` to deploy the ACA Job.
 - `Email Scheduler Build and Deploy` runs tests and builds the scheduler API image on pull requests and pushes to `main`, but does not deploy by default.
 - `Email Scheduler Build and Deploy` has a manual `workflow_dispatch` input `deploy` with default `false`; set `deploy=true` and choose `github_environment` to deploy the dedicated ACA Job.
 - `test` and `prod` remain manual `workflow_dispatch` targets unless a workflow is explicitly changed to auto-deploy them


### PR DESCRIPTION
## Summary
- Set the Laws Collector Build and Deploy workflow dispatch deploy input default to false.
- Skip the Azure deploy job on push events unless a manual workflow dispatch explicitly sets deploy=true.
- Update GitHub Environment setup docs to describe the new opt-in deploy behavior.

## Context
- Addresses failed Actions run https://github.com/mmaideveloper/aijurisdictionagents/actions/runs/28884722831 where build/test passed but the automatic Azure deploy failed because the subscription was disabled/read-only.

## Validation
- git diff --check
- PowerShell assertions confirmed deploy default=false, push deploy condition removed, and docs mention manual deploy=true.