### PR TITLE
Fix Aktuality bullets and add model routing news

### DIFF
--- a/docs/FRONTEND_NEWS.md
+++ b/docs/FRONTEND_NEWS.md
@@ -1,0 +1,14 @@
+# Frontend News Page
+
+The React frontend exposes public product updates at `/aktuality` through `frontend/aijurisdictionfronend/src/pages/News.tsx`.
+
+News copy is translation-driven in `frontend/aijurisdictionfronend/src/data/translations.ts`. Each new item should include Slovak, English, and German text so the language switcher never renders a raw translation key.
+
+Compliance-oriented updates must stay informational: do not expose user identifiers, provider credentials, prompts, or model secrets in news copy. For AI model and routing announcements, mention governance, data minimization, auditability, and human oversight when the feature can affect legal-risk outputs.
+
+Run the focused news-page regression after changes:
+
+```powershell
+cd frontend\aijurisdictionfronend
+npm test -- --run src/__tests__/newsPage.test.tsx
+```

--- a/frontend/aijurisdictionfronend/src/__tests__/newsPage.test.tsx
+++ b/frontend/aijurisdictionfronend/src/__tests__/newsPage.test.tsx
@@ -9,10 +9,13 @@ const labels: Record<string, string> = {
   newsEyebrow: "Product updates",
   navNews: "News",
   newsSubtitle: "Dated mini-blogs.",
+  newsAudioModelsDate: "7 July 2026",
   newsMcpDate: "22 June 2026",
   newsLocalModelsDate: "7 July 2026",
   newsApprovalDate: "21 June 2026",
   newsMetadataDate: "20 June 2026",
+  newsAudioModelsTitle: "STT/TTS improves communication between the client and the AI Lawyer",
+  newsAudioModelsBody: "Audio models can record a client consultation.",
   newsLocalModelsTitle: "Local models for free users subscriptions with model routing.",
   newsLocalModelsBody: "Free users can be routed to local Ollama models.",
   newsMetadataBody: "Outputs keep visible metadata.",
@@ -42,7 +45,11 @@ describe("News", () => {
     render(<News />);
 
     expect(screen.getByRole("heading", { name: "News" })).toBeDefined();
-    expect(screen.getByText("7 July 2026")).toBeDefined();
+    expect(screen.getAllByText("7 July 2026")).toHaveLength(2);
+    expect(
+      screen.getByRole("heading", { name: "STT/TTS improves communication between the client and the AI Lawyer" })
+    ).toBeDefined();
+    expect(screen.getByText("Audio models can record a client consultation.")).toBeDefined();
     expect(
       screen.getByRole("heading", { name: "Local models for free users subscriptions with model routing." })
     ).toBeDefined();

--- a/frontend/aijurisdictionfronend/src/__tests__/newsPage.test.tsx
+++ b/frontend/aijurisdictionfronend/src/__tests__/newsPage.test.tsx
@@ -10,8 +10,11 @@ const labels: Record<string, string> = {
   navNews: "News",
   newsSubtitle: "Dated mini-blogs.",
   newsMcpDate: "22 June 2026",
+  newsLocalModelsDate: "7 July 2026",
   newsApprovalDate: "21 June 2026",
   newsMetadataDate: "20 June 2026",
+  newsLocalModelsTitle: "Local models for free users subscriptions with model routing.",
+  newsLocalModelsBody: "Free users can be routed to local Ollama models.",
   newsMetadataBody: "Outputs keep visible metadata.",
   assistantMandatoryMcpTitle: "JurisDigta MCP",
   assistantMandatoryMcpBody: "JurisDigta API and MCP are always attached.",
@@ -39,9 +42,16 @@ describe("News", () => {
     render(<News />);
 
     expect(screen.getByRole("heading", { name: "News" })).toBeDefined();
+    expect(screen.getByText("7 July 2026")).toBeDefined();
+    expect(
+      screen.getByRole("heading", { name: "Local models for free users subscriptions with model routing." })
+    ).toBeDefined();
+    expect(screen.getByText("Free users can be routed to local Ollama models.")).toBeDefined();
     expect(screen.getByText("22 June 2026")).toBeDefined();
     expect(screen.getByRole("heading", { name: "JurisDigta MCP" })).toBeDefined();
     expect(screen.getByText("Locked on")).toBeDefined();
+    expect(screen.getByRole("list")).toBeDefined();
+    expect(screen.getByText("Law search and law text")).toBeDefined();
     expect(screen.getByText("20 June 2026")).toBeDefined();
     expect(screen.queryByRole("button", { name: "Current matter" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Document preparation" })).toBeNull();

--- a/frontend/aijurisdictionfronend/src/data/translations.ts
+++ b/frontend/aijurisdictionfronend/src/data/translations.ts
@@ -156,8 +156,12 @@ export const translations = {
     newsEyebrow: "Product updates",
     newsSubtitle: "Read dated JurisDigta assistant notes, compliance updates, and operational mini-blogs.",
     newsMcpDate: "22 June 2026",
+    newsLocalModelsDate: "7 July 2026",
     newsApprovalDate: "21 June 2026",
     newsMetadataDate: "20 June 2026",
+    newsLocalModelsTitle: "Local models for free users subscriptions with model routing.",
+    newsLocalModelsBody:
+      "Free users can be routed to local Ollama models for low-cost drafting while JurisDigta MCP stays mandatory for legal grounding. Administrators can upgrade a user or subscription to approved external models when quality, capacity, or case risk requires it. Model routing keeps provider choice, user assignment, and fallback rules governed centrally instead of hidden in the chat UI. External providers and models are added through controlled administration with auditability, data-minimization checks, and human oversight for legal-risk outputs.",
     newsMetadataBody:
       "Assistant outputs keep visible metadata about AI drafting, legal-risk level, and required human oversight.",
     assistantThreadsTitle: "Conversations",
@@ -833,8 +837,12 @@ export const translations = {
     newsEyebrow: "Produktové aktuality",
     newsSubtitle: "Prečítajte si dátumované poznámky asistenta JurisDigta, compliance novinky a operačné mini-blogy.",
     newsMcpDate: "22. jún 2026",
+    newsLocalModelsDate: "7. júl 2026",
     newsApprovalDate: "21. jún 2026",
     newsMetadataDate: "20. jún 2026",
+    newsLocalModelsTitle: "Lokálne modely pre bezplatné používateľské predplatné s routingom modelov",
+    newsLocalModelsBody:
+      "Bezplatných používateľov možno smerovať na lokálne modely Ollama pre nízkonákladové návrhy, pričom JurisDigta MCP zostáva povinný pre právne ukotvenie. Administrátor môže používateľa alebo predplatné povýšiť na schválené externé modely, keď to vyžaduje kvalita, kapacita alebo riziko prípadu. Routing modelov udržiava výber poskytovateľa, priradenie používateľov a fallback pravidlá pod centrálnou správou namiesto skrytia v chatovom UI. Externí poskytovatelia a modely sa pridávajú cez riadenú administráciu s auditovateľnosťou, kontrolou minimalizácie údajov a ľudským dohľadom pri právne rizikových výstupoch.",
     newsMetadataBody:
       "Výstupy asistenta zachovávajú viditeľné metadáta o AI návrhu, úrovni právneho rizika a potrebnom ľudskom dohľade.",
     assistantThreadsTitle: "Konverzácie",
@@ -1510,8 +1518,12 @@ export const translations = {
     newsEyebrow: "Produktneuigkeiten",
     newsSubtitle: "Lesen Sie datierte JurisDigta-Assistentennotizen, Compliance-Updates und operative Mini-Blogs.",
     newsMcpDate: "22. Juni 2026",
+    newsLocalModelsDate: "7. Juli 2026",
     newsApprovalDate: "21. Juni 2026",
     newsMetadataDate: "20. Juni 2026",
+    newsLocalModelsTitle: "Lokale Modelle für kostenlose Benutzerabos mit Modellrouting",
+    newsLocalModelsBody:
+      "Kostenlose Benutzer können für kostengünstige Entwürfe auf lokale Ollama-Modelle geroutet werden, während JurisDigta MCP für die rechtliche Fundierung verpflichtend bleibt. Administratoren können Benutzer oder Abos auf freigegebene externe Modelle hochstufen, wenn Qualität, Kapazität oder Fallrisiko es erfordern. Das Modellrouting hält Provider-Auswahl, Benutzerzuordnung und Fallback-Regeln zentral gesteuert statt verborgen im Chat-UI. Externe Provider und Modelle werden über kontrollierte Administration mit Auditierbarkeit, Datenminimierungsprüfung und menschlicher Aufsicht für rechtlich riskante Ausgaben hinzugefügt.",
     newsMetadataBody:
       "Assistentenausgaben behalten sichtbare Metadaten zu KI-Entwurf, Rechtsrisiko und erforderlicher menschlicher Aufsicht.",
     assistantThreadsTitle: "Konversationen",

--- a/frontend/aijurisdictionfronend/src/data/translations.ts
+++ b/frontend/aijurisdictionfronend/src/data/translations.ts
@@ -155,10 +155,14 @@ export const translations = {
       "Open the assistant workspace for legal search, document preparation, verification planning, and approval-gated tool calls.",
     newsEyebrow: "Product updates",
     newsSubtitle: "Read dated JurisDigta assistant notes, compliance updates, and operational mini-blogs.",
+    newsAudioModelsDate: "7 July 2026",
     newsMcpDate: "22 June 2026",
     newsLocalModelsDate: "7 July 2026",
     newsApprovalDate: "21 June 2026",
     newsMetadataDate: "20 June 2026",
+    newsAudioModelsTitle: "STT/TTS improves communication between the client and the AI Lawyer",
+    newsAudioModelsBody:
+      "Audio models can record a client consultation, convert speech to text, and prepare a structured conversation record. This helps the lawyer review facts faster because the system preserves the full dialogue instead of relying only on handwritten notes. Text-to-speech can read back summaries, missing questions, or next steps so the client can confirm meaning immediately. Clear transcripts improve the quality of follow-up analysis and reduce the risk that an important fact is missed before a legal decision. For legal-risk work, recording must stay consent-based, auditable, and under human lawyer oversight. Work on this capability has already started.",
     newsLocalModelsTitle: "Local models for free users subscriptions with model routing.",
     newsLocalModelsBody:
       "Free users can be routed to local Ollama models for low-cost drafting while JurisDigta MCP stays mandatory for legal grounding. Administrators can upgrade a user or subscription to approved external models when quality, capacity, or case risk requires it. Model routing keeps provider choice, user assignment, and fallback rules governed centrally instead of hidden in the chat UI. External providers and models are added through controlled administration with auditability, data-minimization checks, and human oversight for legal-risk outputs.",
@@ -836,10 +840,14 @@ export const translations = {
       "Otvorte pracovisko asistenta pre právne vyhľadávanie, prípravu dokumentov, plánovanie overovania a schvaľované volania nástrojov.",
     newsEyebrow: "Produktové aktuality",
     newsSubtitle: "Prečítajte si dátumované poznámky asistenta JurisDigta, compliance novinky a operačné mini-blogy.",
+    newsAudioModelsDate: "7. júl 2026",
     newsMcpDate: "22. jún 2026",
     newsLocalModelsDate: "7. júl 2026",
     newsApprovalDate: "21. jún 2026",
     newsMetadataDate: "20. jún 2026",
+    newsAudioModelsTitle: "STT/TTS zlepšenie komunikácie medzi klientom a AI Advokátom",
+    newsAudioModelsBody:
+      "Audio model môže zaznamenať rozhovor s klientom, previesť reč na text a pripraviť štruktúrovaný záznam konzultácie. Advokát tak rýchlejšie skontroluje skutkový stav, pretože systém zachytí celý dialóg a nie iba ručné poznámky. Text-to-speech vie klientovi prečítať zhrnutie, chýbajúce otázky alebo ďalšie kroky, aby klient hneď potvrdil význam. Presný prepis zvyšuje kvalitu následnej právnej analýzy a znižuje riziko, že pred rozhodnutím unikne dôležitý fakt. Pri právne rizikovej práci musí nahrávanie zostať založené na súhlase, auditovateľné a pod dohľadom ľudského advokáta. Na tejto funkcii sa už začalo pracovať.",
     newsLocalModelsTitle: "Lokálne modely pre bezplatné používateľské predplatné s routingom modelov",
     newsLocalModelsBody:
       "Bezplatných používateľov možno smerovať na lokálne modely Ollama pre nízkonákladové návrhy, pričom JurisDigta MCP zostáva povinný pre právne ukotvenie. Administrátor môže používateľa alebo predplatné povýšiť na schválené externé modely, keď to vyžaduje kvalita, kapacita alebo riziko prípadu. Routing modelov udržiava výber poskytovateľa, priradenie používateľov a fallback pravidlá pod centrálnou správou namiesto skrytia v chatovom UI. Externí poskytovatelia a modely sa pridávajú cez riadenú administráciu s auditovateľnosťou, kontrolou minimalizácie údajov a ľudským dohľadom pri právne rizikových výstupoch.",
@@ -1517,10 +1525,14 @@ export const translations = {
       "Öffnen Sie den Assistenten-Workspace für Rechtssuche, Dokumentvorbereitung, Verifizierungsplanung und genehmigungspflichtige Tool-Aufrufe.",
     newsEyebrow: "Produktneuigkeiten",
     newsSubtitle: "Lesen Sie datierte JurisDigta-Assistentennotizen, Compliance-Updates und operative Mini-Blogs.",
+    newsAudioModelsDate: "7. Juli 2026",
     newsMcpDate: "22. Juni 2026",
     newsLocalModelsDate: "7. Juli 2026",
     newsApprovalDate: "21. Juni 2026",
     newsMetadataDate: "20. Juni 2026",
+    newsAudioModelsTitle: "STT/TTS verbessert die Kommunikation zwischen Mandant und KI-Anwalt",
+    newsAudioModelsBody:
+      "Audiomodelle können eine Mandantenberatung aufnehmen, Sprache in Text umwandeln und ein strukturiertes Gesprächsprotokoll vorbereiten. Dadurch prüft der Anwalt den Sachverhalt schneller, weil der vollständige Dialog erhalten bleibt und nicht nur handschriftliche Notizen. Text-to-Speech kann Zusammenfassungen, offene Fragen oder nächste Schritte vorlesen, damit der Mandant die Bedeutung sofort bestätigt. Präzise Transkripte verbessern die Qualität der weiteren Rechtsanalyse und verringern das Risiko, dass vor einer Entscheidung ein wichtiger Fakt fehlt. Bei rechtlich riskanter Arbeit muss die Aufnahme einwilligungsbasiert, auditierbar und unter menschlicher anwaltlicher Aufsicht bleiben. Die Arbeit an dieser Funktion hat bereits begonnen.",
     newsLocalModelsTitle: "Lokale Modelle für kostenlose Benutzerabos mit Modellrouting",
     newsLocalModelsBody:
       "Kostenlose Benutzer können für kostengünstige Entwürfe auf lokale Ollama-Modelle geroutet werden, während JurisDigta MCP für die rechtliche Fundierung verpflichtend bleibt. Administratoren können Benutzer oder Abos auf freigegebene externe Modelle hochstufen, wenn Qualität, Kapazität oder Fallrisiko es erfordern. Das Modellrouting hält Provider-Auswahl, Benutzerzuordnung und Fallback-Regeln zentral gesteuert statt verborgen im Chat-UI. Externe Provider und Modelle werden über kontrollierte Administration mit Auditierbarkeit, Datenminimierungsprüfung und menschlicher Aufsicht für rechtlich riskante Ausgaben hinzugefügt.",

--- a/frontend/aijurisdictionfronend/src/pages/News.tsx
+++ b/frontend/aijurisdictionfronend/src/pages/News.tsx
@@ -2,6 +2,13 @@ import React from "react";
 import { BsLockFill } from "react-icons/bs";
 import { useLanguage } from "../components/LanguageProvider";
 
+type NewsPost = {
+  date: string;
+  title: string;
+  body: string;
+  kind: "mcp" | "plain";
+};
+
 const News: React.FC = () => {
   const { t } = useLanguage();
   const capabilities = [
@@ -13,7 +20,13 @@ const News: React.FC = () => {
     t("assistantCapabilityLocation")
   ];
 
-  const posts = [
+  const posts: NewsPost[] = [
+    {
+      date: t("newsLocalModelsDate"),
+      title: t("newsLocalModelsTitle"),
+      body: t("newsLocalModelsBody"),
+      kind: "plain"
+    },
     {
       date: t("newsMcpDate"),
       title: t("assistantMandatoryMcpTitle"),

--- a/frontend/aijurisdictionfronend/src/pages/News.tsx
+++ b/frontend/aijurisdictionfronend/src/pages/News.tsx
@@ -22,6 +22,12 @@ const News: React.FC = () => {
 
   const posts: NewsPost[] = [
     {
+      date: t("newsAudioModelsDate"),
+      title: t("newsAudioModelsTitle"),
+      body: t("newsAudioModelsBody"),
+      kind: "plain"
+    },
+    {
       date: t("newsLocalModelsDate"),
       title: t("newsLocalModelsTitle"),
       body: t("newsLocalModelsBody"),

--- a/frontend/aijurisdictionfronend/src/styles/app.css
+++ b/frontend/aijurisdictionfronend/src/styles/app.css
@@ -1529,6 +1529,15 @@
   margin: 0;
 }
 
+.assistant-capability-list {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.assistant-capability-list li {
+  padding-left: 0.15rem;
+}
+
 .workspace-page {
   padding-top: 0;
   height: calc(100vh - 6rem);


### PR DESCRIPTION
## Summary
- Adds the local Ollama/model-routing news item to `/aktuality` in SK/EN/DE translations.
- Aligns the MCP capability bullets with the news card content/title column.
- Adds a short frontend news-page documentation note and expands the News page regression test.

## Compliance
- GDPR: informational copy only; no user identifiers, prompts, provider credentials, or model secrets exposed.
- EU AI Act: copy calls out provider governance, routing controls, auditability, data minimization, and human oversight for legal-risk outputs.

## Verification
- `npm test -- --run src/__tests__/newsPage.test.tsx`
- `npm run build`
- `npm run lint` (passes with existing warnings in unrelated files)
- Screenshot prepared locally: `output/playwright/issue-499-aktuality.png`

Closes #499