### PR TITLE
Prepare mobile release 0.1.5+101 for production API

### DIFF
--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -331,6 +331,9 @@ Required variable:
 | --- | --- |
 | `API_BASE_URL` | API base URL passed into Flutter builds |
 
+For the `prod` GitHub Environment, set `API_BASE_URL` to
+`https://api.jurisdigta.eu` so published mobile APKs use the production API.
+
 Recommended signing secrets for stable Android release upgrades:
 
 | Secret | Purpose |

--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -375,6 +375,10 @@ and pass it to Flutter as `--dart-define=AIJ_API_BASE_URL=...` for APK/Web build
 Set `API_BASE_URL` per GitHub Environment (for example dev/stage/prod) to target
 that environment's API during build.
 
+For production mobile releases, set `API_BASE_URL=https://api.jurisdigta.eu`
+in the selected GitHub Environment before running the workflow with
+`release=true`.
+
 For a full repository checklist to create additional GitHub Environments such as
 `test` and `prod`, see `docs/GITHUB_ENVIRONMENTS.md`.
 
@@ -418,7 +422,7 @@ Local helper scripts:
 - Export the release keystore as base64 for `MOBILE_ANDROID_KEYSTORE_BASE64`:
   `pwsh ./mobile_app/tool/export_release_keystore_base64.ps1`
 - Build a signed release APK locally with the generated keystore:
-  `pwsh ./mobile_app/tool/build_release_signed.ps1 -KeystorePassword "<password>" -KeyAlias "release" -ApiBaseUrl "http://10.0.2.2:8080"`
+  `pwsh ./mobile_app/tool/build_release_signed.ps1 -KeystorePassword "<password>" -KeyAlias "release" -ApiBaseUrl "https://api.jurisdigta.eu"`
 
 Mobile app versioning rule:
 

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ai_jurisdiction_mobile
-version: 0.1.5+100
+version: 0.1.5+101
 publish_to: none
 
 environment:


### PR DESCRIPTION
## Summary
- bump mobile app build revision to 0.1.5+101
- document production mobile release builds with API_BASE_URL=https://api.jurisdigta.eu
- align GitHub Environment setup docs for prod mobile releases

## Validation
- flutter pub get
- flutter analyze --no-fatal-infos
- flutter test
- flutter build apk --release --build-name=0.1.5 --build-number=101 --dart-define=AIJ_API_BASE_URL=https://api.jurisdigta.eu (APK built; local command hit Codex timeout after Gradle completed)
- Invoke-WebRequest https://api.jurisdigta.eu/health

## Compliance
- No new personal data collection or processing paths. Production endpoint configuration keeps existing mobile privacy/oversight behavior unchanged.