### PR TITLE
Harden prod Docker pip installs

### DIFF
--- a/Deployment/self-managed-server-deployment.md
+++ b/Deployment/self-managed-server-deployment.md
@@ -346,6 +346,13 @@ cd /srv/jurisdigta/app
 docker build -t jurisdigta-laws-collector:local -f src/services/laws_collector/Dockerfile .
 ```
 
+The API, document processor, and laws collector Dockerfiles set
+`PIP_DEFAULT_TIMEOUT=120` and `PIP_RETRIES=10` for the heavy numpy/Torch install
+layers. Keep these settings in sync when changing those images. The self-managed
+runner can have slow external package downloads during production releases, and
+the deploy should retry transient `files.pythonhosted.org` or PyTorch wheel
+timeouts instead of failing the release immediately.
+
 Run migrations for the laws PostgreSQL database before a long-running import:
 
 ```bash

--- a/api/aijuristiction-api/Dockerfile
+++ b/api/aijuristiction-api/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.11-slim AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    PIP_DEFAULT_TIMEOUT=120 \
+    PIP_RETRIES=10
 
 WORKDIR /workspace
 
@@ -18,8 +20,8 @@ COPY mobile_app/pubspec.yaml ./mobile_app/pubspec.yaml
 COPY api/aijuristiction-api ./api/aijuristiction-api
 
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir --index-url https://pypi.org/simple "numpy>=2.1,<2.4" && \
-    pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu "torch>=2.3,<2.8" && \
+    pip install --no-cache-dir --retries "$PIP_RETRIES" --timeout "$PIP_DEFAULT_TIMEOUT" --index-url https://pypi.org/simple "numpy>=2.1,<2.4" && \
+    pip install --no-cache-dir --retries "$PIP_RETRIES" --timeout "$PIP_DEFAULT_TIMEOUT" --index-url https://download.pytorch.org/whl/cpu "torch>=2.3,<2.8" && \
     python -c "import numpy, torch; print(f'numpy=={numpy.__version__}'); print(f'torch=={torch.__version__}')" > /tmp/runtime-constraints.txt && \
     printf '%s\n' \
       'opentelemetry-exporter-otlp==1.40.0' \
@@ -29,8 +31,8 @@ RUN pip install --no-cache-dir --upgrade pip && \
       'opentelemetry-proto==1.40.0' \
       'onnxruntime==1.27.0' \
       'opencv-python==4.13.0.92' >> /tmp/runtime-constraints.txt && \
-    pip install --no-cache-dir --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu --constraint /tmp/runtime-constraints.txt -e . && \
-    pip install --no-cache-dir --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu --constraint /tmp/runtime-constraints.txt -e ./api/aijuristiction-api
+    pip install --no-cache-dir --retries "$PIP_RETRIES" --timeout "$PIP_DEFAULT_TIMEOUT" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu --constraint /tmp/runtime-constraints.txt -e . && \
+    pip install --no-cache-dir --retries "$PIP_RETRIES" --timeout "$PIP_DEFAULT_TIMEOUT" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu --constraint /tmp/runtime-constraints.txt -e ./api/aijuristiction-api
 
 USER app
 

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260514"
+version = "1.0.260515"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/services/document_processor/Dockerfile
+++ b/src/services/document_processor/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.11-slim
 
+ENV PIP_DEFAULT_TIMEOUT=120 \
+    PIP_RETRIES=10
+
 WORKDIR /app
 
 RUN apt-get update && \
@@ -15,11 +18,11 @@ COPY src /app/src
 # from turning routine deploys into multi-GB downloads. Keep the exact installed
 # build constrained while installing the app, otherwise transitive dependencies
 # can upgrade torch back to a CUDA-enabled PyPI build.
-RUN pip install --no-cache-dir --index-url https://pypi.org/simple "numpy>=2.1,<2.4" && \
-    pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu "torch>=2.3,<2.8"
+RUN pip install --no-cache-dir --retries "$PIP_RETRIES" --timeout "$PIP_DEFAULT_TIMEOUT" --index-url https://pypi.org/simple "numpy>=2.1,<2.4" && \
+    pip install --no-cache-dir --retries "$PIP_RETRIES" --timeout "$PIP_DEFAULT_TIMEOUT" --index-url https://download.pytorch.org/whl/cpu "torch>=2.3,<2.8"
 RUN python -c "import numpy, torch; print(f'numpy=={numpy.__version__}'); print(f'torch=={torch.__version__}')" > /tmp/runtime-constraints.txt && \
     printf '%s\n' 'onnxruntime==1.27.0' 'opencv-python==4.13.0.92' >> /tmp/runtime-constraints.txt && \
-    pip install --no-cache-dir --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu --constraint /tmp/runtime-constraints.txt .
+    pip install --no-cache-dir --retries "$PIP_RETRIES" --timeout "$PIP_DEFAULT_TIMEOUT" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu --constraint /tmp/runtime-constraints.txt .
 
 ENV PYTHONUNBUFFERED=1
 

--- a/src/services/laws_collector/Dockerfile
+++ b/src/services/laws_collector/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.11-slim
 
+ENV PIP_DEFAULT_TIMEOUT=120 \
+    PIP_RETRIES=10
+
 WORKDIR /app
 
 RUN apt-get update \
@@ -12,11 +15,11 @@ COPY src /app/src
 
 # The root package depends on sentence-transformers. Preinstalling and
 # constraining CPU torch prevents PyPI from resolving CUDA-enabled wheels.
-RUN pip install --no-cache-dir --index-url https://pypi.org/simple "numpy>=2.1,<2.4" && \
-    pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu "torch>=2.3,<2.8"
+RUN pip install --no-cache-dir --retries "$PIP_RETRIES" --timeout "$PIP_DEFAULT_TIMEOUT" --index-url https://pypi.org/simple "numpy>=2.1,<2.4" && \
+    pip install --no-cache-dir --retries "$PIP_RETRIES" --timeout "$PIP_DEFAULT_TIMEOUT" --index-url https://download.pytorch.org/whl/cpu "torch>=2.3,<2.8"
 RUN python -c "import numpy, torch; print(f'numpy=={numpy.__version__}'); print(f'torch=={torch.__version__}')" > /tmp/runtime-constraints.txt && \
     printf '%s\n' 'onnxruntime==1.27.0' 'opencv-python==4.13.0.92' >> /tmp/runtime-constraints.txt && \
-    pip install --no-cache-dir --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu --constraint /tmp/runtime-constraints.txt .
+    pip install --no-cache-dir --retries "$PIP_RETRIES" --timeout "$PIP_DEFAULT_TIMEOUT" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu --constraint /tmp/runtime-constraints.txt .
 
 ENV PYTHONUNBUFFERED=1
 ENV LAWS_WORKER_FIXTURE=baseline


### PR DESCRIPTION
## Summary
- harden API, document processor, and laws collector Docker builds with pip retry and read-timeout settings for heavy numpy/Torch install layers
- document the self-managed prod package-download resilience rule
- bump API package revision after changing the API Dockerfile

## Root cause
The failed prod deploy run https://github.com/mmaideveloper/aijurisdictionagents/actions/runs/28893455644 failed in job 85712107714 while building `src/services/laws_collector/Dockerfile`. Pip timed out downloading `numpy-2.3.5` from `files.pythonhosted.org` during the heavy CPU numpy/Torch layer and exited with code 2.

## Validation
- `ruff check app tests` from `api/aijuristiction-api`
- `mypy app` from `api/aijuristiction-api`
- `pytest api/aijuristiction-api/tests` -> 371 passed

## Notes
Docker Desktop is not running on the local Windows host, so local Docker image builds could not be executed here. The prod self-hosted workflow should be rerun after merge.