### PR TITLE
Fix live assistant document preview

### DIFF
--- a/docs/assistant_architecture.md
+++ b/docs/assistant_architecture.md
@@ -21,6 +21,8 @@ Chat result metadata now normalizes JurisDigta law lookup results into durable c
 
 The frontend renders per-answer citations below assistant answers and a deduplicated case citation list in the right configuration panel. Empty states stay explicit when no reliable citation exists or lookup was inconclusive.
 
+For generated legal-document drafts, the live assistant stream and the hydrated case-history path must converge on the same user-visible output. If the stream finishes with a progress sentence but the refreshed case history contains a formatted document preview or generated-document action, the frontend shows the hydrated preview/action immediately and keeps the same preview/action after reload. This prevents users from seeing terminal PDF-progress text when the generated document is already persisted.
+
 Legal-source citations carry retrieval provenance. JurisDigta MCP/vector results use source score `1.0` and retrieval tools such as `JurisDigta MCP searchLaws` or `JurisDigta MCP searchCourtDecisions`. If the system vector DB has no reliable legal source, the backend may use `AIWebSearchAgent` only for official legal sources such as Slov-Lex or official court-decision pages; these fallback citations use source score `0.9`, `source_type=web`, and must render a visible warning that the source came from official web search rather than the JurisDigta system vector DB.
 
 ## Quality Target

--- a/examples/frontend_live_document_preview_issue_503_minimal_demo.py
+++ b/examples/frontend_live_document_preview_issue_503_minimal_demo.py
@@ -1,0 +1,51 @@
+"""Minimal guardrail for issue #503 live document preview behavior.
+
+This fast check verifies that the frontend keeps the live assistant response
+aligned with the hydrated case-history path and that the browser E2E fixture is
+present. It does not replace the Playwright regression test.
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ASSISTANT_WORKSPACE = REPO_ROOT / "frontend" / "aijurisdictionfronend" / "src" / "pages" / "AssistantWorkspace.tsx"
+E2E_SPEC = (
+    REPO_ROOT
+    / "frontend"
+    / "aijurisdictionfronend"
+    / "e2e"
+    / "assistant-live-document-preview.spec.ts"
+)
+
+
+def main() -> None:
+    workspace_source = ASSISTANT_WORKSPACE.read_text(encoding="utf-8")
+    e2e_source = E2E_SPEC.read_text(encoding="utf-8")
+    required_workspace_markers = [
+        "shouldPreferHydratedAssistantMessage",
+        "progressOnlyAssistantPattern",
+        "findLatestAssistantInteraction",
+        "appendGeneratedDocumentsResponseBlock",
+    ]
+    required_e2e_markers = [
+        "Teraz vytvorim PDF dokument. Chvilu prosim.",
+        "assistant live response keeps formatted document preview",
+        "splnomocnenie_issue_503.pdf",
+        "JurisDigta MCP searchLaws",
+    ]
+
+    missing = [
+        marker for marker in required_workspace_markers if marker not in workspace_source
+    ] + [marker for marker in required_e2e_markers if marker not in e2e_source]
+
+    if missing:
+        raise SystemExit(f"Issue #503 live document preview guardrails are incomplete: {missing}")
+
+    print("Issue #503 live document preview guardrails are present.")
+    print(f"Frontend: {ASSISTANT_WORKSPACE.relative_to(REPO_ROOT)}")
+    print(f"E2E: {E2E_SPEC.relative_to(REPO_ROOT)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -98,6 +98,10 @@ print(
     "assistant chatter, alternate-language blocks, and raw markdown stay out of the PDF."
 )
 print(
+    "frontend_live_document_preview_issue_503 => live assistant document responses prefer hydrated "
+    "case-history previews and generated-document actions over terminal PDF progress text."
+)
+print(
     "multilingual_document_exports => CASE_UPDATE_JSON case.documents entries are saved/exported "
     "as separate clean documents by default; use bundle=single_pdf only when one combined PDF is requested."
 )

--- a/frontend/aijurisdictionfronend/.env.example
+++ b/frontend/aijurisdictionfronend/.env.example
@@ -8,3 +8,4 @@ VITE_CHAT_MODEL_LABEL=Azure Foundry model
 # VITE_AIJ_SPEECHTYPE options: message | conversation
 # message is the default. conversation keeps the existing Voice-agent transcript flow.
 VITE_AIJ_SPEECHTYPE=message
+FRONTEND_E2E_PORT=5189

--- a/frontend/aijurisdictionfronend/README.md
+++ b/frontend/aijurisdictionfronend/README.md
@@ -28,7 +28,7 @@ Run the browser regression suite with:
 npm run test:e2e
 ```
 
-The suite starts Vite locally and uses mocked JurisDigta API responses. Deployment workflows run this Playwright gate before deployment so a failed document-download or document-listing regression blocks release.
+The suite starts Vite locally and uses mocked JurisDigta API responses. Deployment workflows run this Playwright gate before deployment so a failed document-preview, document-download, or document-listing regression blocks release. If the default Playwright port is already in use, set `FRONTEND_E2E_PORT`, for example `FRONTEND_E2E_PORT=5190 npm run test:e2e`. Issue #503 is covered by `e2e/assistant-live-document-preview.spec.ts`, which verifies the live assistant response path and the post-refresh case-history path both show the formatted JurisDigta document preview, generated PDF action, and citation source.
 
 ## API Chat Integration (Task #238)
 
@@ -348,6 +348,19 @@ Issue #401 browser regression check:
 ```bash
 cd api/aijuristiction-api/e2e-playwright
 FRONTEND_BASE_URL=http://127.0.0.1:5173 npx playwright test tests/frontend-document-preview-formatting.spec.ts
+```
+
+Issue #503 live document preview minimal demo:
+
+```bash
+python examples/frontend_live_document_preview_issue_503_minimal_demo.py
+```
+
+Issue #503 browser regression check:
+
+```bash
+cd frontend/aijurisdictionfronend
+npm run test:e2e -- e2e/assistant-live-document-preview.spec.ts
 ```
 
 Issue #369 case-create layout minimal demo:

--- a/frontend/aijurisdictionfronend/e2e/assistant-live-document-preview.spec.ts
+++ b/frontend/aijurisdictionfronend/e2e/assistant-live-document-preview.spec.ts
@@ -1,0 +1,246 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+const authUser = {
+  userId: "issue-503-user",
+  email: "issue-503@example.test",
+  name: "Issue 503 Test User"
+};
+
+const apiCase = {
+  case_id: "issue-503-case",
+  user_id: authUser.userId,
+  company_id: null,
+  title: "issue 503 live preview",
+  status: "in_progress",
+  created_at: "2026-07-09T08:00:00Z",
+  updated_at: "2026-07-09T08:05:00Z"
+};
+
+const generatedDocument = {
+  doc_id: "issue-503-splnomocnenie",
+  kind: "generated_document",
+  version: 1,
+  original_filename: "splnomocnenie_issue_503.pdf",
+  processing_status: "processed",
+  processing_error: null,
+  processed_at: "2026-07-09T08:05:00Z",
+  created_at: "2026-07-09T08:05:00Z"
+};
+
+const draftDocument = `Splnomocnenie je pripravene na kontrolu.
+
+**Splnomocnenie**
+
+Ja, dolu podpisany Marek Matonok, tymto splnomocnujem Emiliu Testovu na pouzivanie firemneho motoroveho vozidla ESolutions SK s.r.o.
+
+SPZ vozidla: PP472DT
+
+Datum: 9. jula 2026
+Podpis: ______________________`;
+
+const hydratedAssistantContent = `${draftDocument}
+
+Generated document:
+- [splnomocnenie_issue_503.pdf](/app/documents/view?caseId=issue-503-case&docId=issue-503-splnomocnenie&kind=generated_document&filename=splnomocnenie_issue_503.pdf&caseTitle=issue+503+live+preview&userId=issue-503-user)`;
+
+const citation = {
+  id: "issue-503-citation",
+  case_id: apiCase.case_id,
+  question_message_id: "issue-503-user-message",
+  answer_message_id: "issue-503-assistant-message",
+  source_type: "law",
+  source_id: "slov-lex-obciansky-zakonnik",
+  source_url: "https://www.slov-lex.sk/",
+  title: "Obciansky zakonnik",
+  citation_label: "Obciansky zakonnik",
+  law_number: "40/1964 Zb.",
+  section: null,
+  effective_from: "2026-07-09",
+  court: null,
+  ecli: null,
+  file_number: null,
+  decision_date: null,
+  snippet: "Plnomocenstvo vyzaduje identifikaciu splnomocnitela, splnomocnenca a rozsah opravnenia.",
+  retrieval_tool: "JurisDigta MCP searchLaws",
+  relevance_score: 1,
+  created_at: "2026-07-09T08:05:00Z"
+};
+
+const historyBeforeGeneration = {
+  has_more: false,
+  documents: [],
+  citations: [],
+  messages: [
+    {
+      communication_id: "issue-503-existing-user",
+      role: "user",
+      content: "Priprav splnomocnenie.",
+      agent_name: null,
+      created_at: "2026-07-09T08:01:00Z"
+    }
+  ]
+};
+
+const historyAfterGeneration = {
+  has_more: false,
+  documents: [generatedDocument],
+  citations: [citation],
+  messages: [
+    {
+      communication_id: "issue-503-user-message",
+      role: "user",
+      content: "Priprav splnomocnenie pre Emiliu Testovu na firemne auto PP472DT.",
+      agent_name: null,
+      created_at: "2026-07-09T08:04:00Z"
+    },
+    {
+      communication_id: "issue-503-assistant-message",
+      role: "assistant",
+      content: hydratedAssistantContent,
+      agent_name: "LawyerSlovakia",
+      created_at: "2026-07-09T08:05:00Z",
+      citations: [citation]
+    }
+  ]
+};
+
+const fulfillJson = async (route: Route, body: unknown) => {
+  await route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify(body)
+  });
+};
+
+const fulfillStream = async (route: Route) => {
+  await route.fulfill({
+    status: 200,
+    contentType: "text/event-stream",
+    body: [
+      "event: processing",
+      'data: {"stage":"drafting","message":"Teraz vytvorim PDF dokument. Chvilu prosim."}',
+      "",
+      "event: message",
+      `data: ${JSON.stringify({
+        id: "issue-503-stream-message",
+        session_id: "issue-503-session",
+        role: "assistant",
+        content: "Teraz vytvorim PDF dokument. Chvilu prosim.",
+        agent_name: "LawyerSlovakia",
+        created_at: "2026-07-09T08:04:30Z"
+      })}`,
+      "",
+      "event: done",
+      'data: {"session_id":"issue-503-session","status":"completed"}',
+      "",
+      ""
+    ].join("\n")
+  });
+};
+
+async function seedAuth(page: Page) {
+  await page.addInitScript((user) => {
+    window.sessionStorage.setItem("jurisdigta.web.auth.user.v1", JSON.stringify(user));
+    window.localStorage.setItem("aj_frontend_lang", "en");
+  }, authUser);
+}
+
+test("assistant live response keeps formatted document preview, generated PDF action, and citations after reload", async ({
+  page,
+  context
+}, testInfo) => {
+  let generationFinished = false;
+  let pdfRouteHit = false;
+
+  await page.route("**/v1/model-routing/effective?**", (route) =>
+    fulfillJson(route, {
+      plan_code: "free",
+      route_type: "free_local",
+      provider: "local_ollama",
+      provider_display_name: "Local Ollama",
+      model: "qwen3:1.7b",
+      model_profile_id: "local_ollama_default",
+      is_local: true,
+      is_external: false,
+      label: "Local Ollama - qwen3:1.7b"
+    })
+  );
+  await page.route("**/v1/cases?user_id=**", (route) => fulfillJson(route, [apiCase]));
+  await page.route("**/v1/cases/issue-503-case/history?**", (route) =>
+    fulfillJson(route, generationFinished ? historyAfterGeneration : historyBeforeGeneration)
+  );
+  await page.route("**/v1/chat/sessions", (route) =>
+    fulfillJson(route, {
+      id: "issue-503-session",
+      user_id: authUser.userId,
+      case_id: apiCase.case_id,
+      country: "SK",
+      language: "en",
+      discussion_type: "advice",
+      state: "active",
+      created_at: "2026-07-09T08:04:00Z"
+    })
+  );
+  await page.route("**/v1/chat/sessions/issue-503-session/stream", async (route) => {
+    generationFinished = true;
+    await fulfillStream(route);
+  });
+  await context.route("**/v1/cases/issue-503-case/documents/issue-503-splnomocnenie/pdf?**", async (route) => {
+    pdfRouteHit = true;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/pdf",
+      headers: {
+        "Content-Disposition": 'inline; filename="splnomocnenie_issue_503.pdf"'
+      },
+      body: "%PDF-1.4\n% issue 503 generated document\n%%EOF"
+    });
+  });
+
+  await seedAuth(page);
+  await page.goto("/app/assistant", { waitUntil: "domcontentloaded" });
+
+  const caseButton = page.locator(".case-item").filter({ hasText: apiCase.title }).first();
+  await expect(caseButton).toBeVisible();
+  await caseButton.click();
+
+  await page.getByLabel("Assistant message").fill("Priprav splnomocnenie pre Emiliu Testovu na firemne auto PP472DT.");
+  await page.getByRole("button", { name: "Send message" }).click();
+
+  const preview = page.locator(".assistant-document-preview").first();
+  await expect(preview).toBeVisible({ timeout: 15_000 });
+  await expect(preview.getByRole("heading", { name: "Splnomocnenie" })).toBeVisible();
+  await expect(preview).toContainText("Emiliu Testovu");
+  await expect(preview).toContainText("PP472DT");
+  await expect(page.locator(".assistant-thread__viewport")).not.toContainText("Teraz vytvorim PDF dokument");
+  await expect(page.locator(".assistant-thread__viewport")).not.toContainText("**");
+
+  const generatedAction = page.getByLabel("Generated documents").getByRole("link", {
+    name: /splnomocnenie_issue_503\.pdf/
+  });
+  await expect(generatedAction).toBeVisible();
+  await expect(page.locator(".case-item").filter({ hasText: /1 legal document/ }).first()).toBeVisible();
+  await expect(page.getByText("Obciansky zakonnik").first()).toBeVisible();
+  await expect(page.getByText("JurisDigta MCP searchLaws").first()).toBeVisible();
+
+  await testInfo.attach("issue-503-live-preview.png", {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: "image/png"
+  });
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(page.locator(".case-item").filter({ hasText: apiCase.title }).first()).toBeVisible();
+  await page.locator(".case-item").filter({ hasText: apiCase.title }).first().click();
+  await expect(page.locator(".assistant-document-preview").first()).toBeVisible();
+  await expect(
+    page.getByLabel("Generated documents").getByRole("link", { name: /splnomocnenie_issue_503\.pdf/ })
+  ).toBeVisible();
+
+  const viewerPromise = context.waitForEvent("page");
+  await page.getByLabel("Generated documents").getByRole("link", { name: /splnomocnenie_issue_503\.pdf/ }).click();
+  const viewer = await viewerPromise;
+  await viewer.waitForLoadState("domcontentloaded");
+  await expect(viewer).toHaveURL(/\/app\/documents\/view/);
+  await expect(viewer.getByText("splnomocnenie_issue_503.pdf")).toBeVisible();
+  await expect.poll(() => pdfRouteHit).toBe(true);
+  await viewer.close();
+});

--- a/frontend/aijurisdictionfronend/playwright.config.ts
+++ b/frontend/aijurisdictionfronend/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const e2ePort = process.env.FRONTEND_E2E_PORT?.trim() || "5189";
+const e2eBaseUrl = `http://127.0.0.1:${e2ePort}`;
+
 export default defineConfig({
   testDir: "./e2e",
   timeout: 30_000,
@@ -8,12 +11,12 @@ export default defineConfig({
   },
   reporter: [["list"]],
   use: {
-    baseURL: "http://127.0.0.1:5189",
+    baseURL: e2eBaseUrl,
     trace: "retain-on-failure"
   },
   webServer: {
-    command: "npm run dev -- --host 127.0.0.1 --port 5189 --strictPort",
-    url: "http://127.0.0.1:5189",
+    command: `npm run dev -- --host 127.0.0.1 --port ${e2ePort} --strictPort`,
+    url: e2eBaseUrl,
     reuseExistingServer: false,
     timeout: 60_000
   },

--- a/frontend/aijurisdictionfronend/src/__tests__/assistantWorkspace.test.tsx
+++ b/frontend/aijurisdictionfronend/src/__tests__/assistantWorkspace.test.tsx
@@ -535,6 +535,98 @@ describe("AssistantWorkspace", () => {
     );
   });
 
+  it("uses hydrated generated document history instead of a terminal PDF progress sentence", async () => {
+    const prompt = "Priprav splnomocnenie.";
+    vi.mocked(createChatSession).mockResolvedValue({
+      id: "session-1",
+      user_id: "user-1",
+      case_id: "case-1",
+      country: "SK",
+      language: "sk",
+      discussion_type: "advice",
+      state: "active",
+      created_at: "2026-07-09T00:00:00Z"
+    });
+    vi.mocked(streamSession).mockImplementation(async function* () {
+      yield {
+        event: "message",
+        data: {
+          id: "message-1",
+          session_id: "session-1",
+          role: "assistant",
+          content: "Teraz vytvorÃ­m PDF dokument. ChvÃ­Ä¾u prosÃ­m.",
+          agent_name: "AI Lawyer",
+          created_at: "2026-07-09T00:00:01Z"
+        }
+      };
+      yield {
+        event: "done",
+        data: { session_id: "session-1", status: "completed" }
+      };
+    });
+    caseActions.loadCaseData.mockResolvedValue({
+      id: "case-1",
+      title: "Splnomocnenie",
+      documents: [
+        {
+          id: "doc-generated",
+          caseId: "case-1",
+          kind: "generated_document",
+          originalFilename: "splnomocnenie.pdf",
+          mimeType: "application/pdf",
+          size: 0,
+          sizeLabel: "processed",
+          uploadedAt: "2026-07-09T00:00:02Z"
+        }
+      ],
+      interactionHistory: [
+        {
+          id: "message-1",
+          actor: "AI Lawyer",
+          createdAt: "2026-07-09T00:00:02Z",
+          message: `Splnomocnenie je pripravene.
+
+**Splnomocnenie**
+
+Ja, dolu podpisany, tymto splnomocnujem Emiliu Testovu.
+
+Datum: 9. jula 2026
+Podpis: ______________________
+
+Generated document:
+- [splnomocnenie.pdf](/app/documents/view?caseId=case-1&docId=doc-generated&kind=generated_document)`,
+          citations: []
+        }
+      ]
+    });
+
+    render(<AssistantWorkspace />);
+
+    const result = capturedAdapter?.run({
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: prompt }]
+        }
+      ],
+      abortSignal: new AbortController().signal
+    });
+
+    let lastResult: CapturedRunResult | undefined;
+    if (result && Symbol.asyncIterator in result) {
+      for await (const update of result) {
+        lastResult = update;
+      }
+    } else {
+      lastResult = await result;
+    }
+
+    expect(lastResult?.content?.[0]?.text).toContain("**Splnomocnenie**");
+    expect(lastResult?.content?.[0]?.text).toContain("[splnomocnenie.pdf](/app/documents/view?caseId=case-1&docId=doc-generated");
+    expect(lastResult?.content?.[0]?.text).not.toContain("Teraz vytvorÃ­m PDF dokument");
+    expect(lastResult?.content?.[0]?.text?.match(/Generated document:/g)).toHaveLength(1);
+  });
+
   it("separates document drafts from conversational assistant text for preview rendering", () => {
     const presentation = parseAssistantMessagePresentation(`Pripravim teraz obidve verzie splnomocnenia.
 

--- a/frontend/aijurisdictionfronend/src/pages/AssistantWorkspace.tsx
+++ b/frontend/aijurisdictionfronend/src/pages/AssistantWorkspace.tsx
@@ -224,8 +224,12 @@ const buildGeneratedDocumentsResponseBlock = ({
   return [heading, ...links].join("\n");
 };
 
-const appendGeneratedDocumentsResponseBlock = (content: string, block: string): string =>
-  block ? `${content.trim()}\n\n${block}`.trim() : content;
+const appendGeneratedDocumentsResponseBlock = (content: string, block: string): string => {
+  if (!block || content.includes("/app/documents/view?")) {
+    return content;
+  }
+  return `${content.trim()}\n\n${block}`.trim();
+};
 
 const localizeApiErrorDetail = (
   error: unknown,
@@ -504,6 +508,38 @@ const AssistantTextPart: React.FC = () => {
   );
 };
 
+const userInteractionActors = new Set(["You", "You (Voice)", "You (Video)"]);
+
+const isAssistantInteraction = (interaction: CaseInteraction): boolean =>
+  !userInteractionActors.has(interaction.actor) && interaction.actor !== "System";
+
+const findLatestAssistantInteraction = (caseItem: CaseRecord | null): CaseInteraction | null => {
+  if (!caseItem) {
+    return null;
+  }
+  for (let index = caseItem.interactionHistory.length - 1; index >= 0; index -= 1) {
+    const interaction = caseItem.interactionHistory[index];
+    if (interaction && isAssistantInteraction(interaction)) {
+      return interaction;
+    }
+  }
+  return null;
+};
+
+const progressOnlyAssistantPattern = /teraz\s+vytvor[ií]m\s+pdf\s+dokument|chv[ií][ľl]u\s+pros[ií]m|creating\s+(?:the\s+)?pdf/i;
+
+const shouldPreferHydratedAssistantMessage = (currentText: string, hydratedText: string): boolean => {
+  if (!hydratedText.trim() || hydratedText.trim() === currentText.trim()) {
+    return false;
+  }
+  const presentation = parseAssistantMessagePresentation(hydratedText);
+  return (
+    progressOnlyAssistantPattern.test(currentText) ||
+    presentation.documentPreviews.length > 0 ||
+    presentation.documentLinks.length > 0
+  );
+};
+
 const AssistantThread: React.FC = () => {
   const { language, t } = useLanguage();
   const { isAuthenticated, isAuthLoading, user } = useAuth();
@@ -619,8 +655,16 @@ const AssistantThread: React.FC = () => {
             previousDocumentIds: visibleDocumentIdsBeforeRun,
             userId
           });
+          const hydratedAssistantMessage = findLatestAssistantInteraction(refreshedCase)?.message ?? "";
+          const streamedAssistantText = latestAssistantText || processingMessages.join("\n\n");
+          const responseSourceText = shouldPreferHydratedAssistantMessage(
+            streamedAssistantText,
+            hydratedAssistantMessage
+          )
+            ? hydratedAssistantMessage
+            : streamedAssistantText;
           const finalAssistantText = appendGeneratedDocumentsResponseBlock(
-            latestAssistantText || processingMessages.join("\n\n"),
+            responseSourceText,
             generatedDocumentsBlock
           );
 


### PR DESCRIPTION
## Summary
- Fix live assistant completion so a refreshed case-history document preview/action replaces terminal PDF progress text when generation has already persisted the document.
- Add frontend Playwright E2E coverage for issue #503: live response, reload/hydration parity, generated PDF route, and citations.
- Document the E2E gate and add a minimal runnable guardrail demo.

## Validation
- `python examples/frontend_live_document_preview_issue_503_minimal_demo.py`
- `npm run test -- --run src/__tests__/assistantWorkspace.test.tsx`
- `npm run build`
- `FRONTEND_E2E_PORT=5190 npm run test:e2e -- e2e/assistant-live-document-preview.spec.ts`

## Compliance
- Keeps generated legal documents behind authenticated case document routes.
- Does not invent citations; the E2E uses mocked JurisDigta MCP citation metadata and verifies visible citation provenance.
- Avoids logging or duplicating raw document content outside the case UI/test fixture.

Fixes #503