### PR TITLE
Fix contaminated splnomocnenie PDF exports

### DIFF
--- a/api/aijuristiction-api/app/cases_api.py
+++ b/api/aijuristiction-api/app/cases_api.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, Field
 from app.chat.api import (
     _build_professional_document_pdf,
     _load_case_documents_for_llm,
+    _sanitize_generated_legal_document_body,
     _user_visible_text,
 )
 from app.security import require_api_key
@@ -857,6 +858,7 @@ def _render_generated_case_document_pdf_bytes(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Rendered PDF content is unavailable for document {document.doc_id}",
         )
+    visible_content = _clean_generated_case_document_pdf_content(visible_content)
     return _build_professional_document_pdf(
         title=_generated_case_document_title(visible_content),
         lines=visible_content.splitlines(),
@@ -1235,6 +1237,19 @@ def _generated_case_document_storage_content(*, document: CaseDocument, store: A
             exc_info=True,
         )
     return ""
+
+
+def _clean_generated_case_document_pdf_content(content: str) -> str:
+    stripped = content.strip()
+    if not stripped:
+        return ""
+    extracted = _extract_generated_case_document_body(stripped)
+    if extracted:
+        return extracted
+    sanitized = _sanitize_generated_legal_document_body(stripped)
+    if sanitized and _looks_like_generated_case_document_body(sanitized):
+        return sanitized
+    return stripped
 
 
 def _latest_generated_case_document_visible_content(

--- a/api/aijuristiction-api/app/chat/api.py
+++ b/api/aijuristiction-api/app/chat/api.py
@@ -3487,6 +3487,8 @@ def _sanitize_generated_legal_document_body(content: str) -> str:
         "výborne pripravím",
         "pripravim splnomocnenie",
         "pripravim dokument",
+        "tu je finalny navrh",
+        "tu je finalny dokument",
         "technicke udaje som ulozil",
         "technical data was saved",
     )
@@ -6006,7 +6008,7 @@ def _build_document_export_assets(
     facts = _apply_user_profile_document_defaults(facts=facts, user_profile=user_profile)
     facts = _sanitize_missing_document_facts(facts)
     document_entries = _case_update_document_entries(case_update)
-    if len(document_entries) <= 1:
+    if not document_entries:
         document_entries = _fallback_document_entries_for_export(
             messages=messages,
             result=result,
@@ -6019,6 +6021,34 @@ def _build_document_export_assets(
             language=language,
             document_kind=document_kind,
         )
+        if entry is not None and _document_entry_content(entry):
+            entry_title, entry_lines = _build_document_asset_content(
+                entry=entry,
+                document_kind=document_kind,
+                facts=facts,
+                country=country,
+                language=language,
+                law_citation_lines=law_citation_lines,
+                fallback_index=1,
+            )
+            export_title = entry_title or title
+            return [
+                _DocumentExportAsset(
+                    filename=_document_asset_filename(
+                        entry=entry,
+                        fallback_filename=_build_pdf_filename(session_id=session_id, kind="document"),
+                    ),
+                    title=export_title,
+                    lines=_strip_duplicate_body_title(title=export_title, lines=entry_lines),
+                    disclaimer=disclaimer,
+                    use_corporate_template=_is_third_party_document(
+                        document_kind=document_kind,
+                        entry=entry,
+                        title=export_title,
+                        lines=entry_lines,
+                    ),
+                )
+            ]
         return [
             _DocumentExportAsset(
                 filename=_document_asset_filename(

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260517"
+version = "1.0.260518"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_cases.py
+++ b/api/aijuristiction-api/tests/test_cases.py
@@ -466,6 +466,83 @@ def test_generated_case_document_pdf_reads_generated_document_storage(
     assert "firemneho auta" in generated_pdf_text
 
 
+def test_generated_case_document_pdf_filters_contaminated_splnomocnenie_storage(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("DB_OPTION", "local")
+    monkeypatch.setenv("STORAGE_OPTION", "local")
+    monkeypatch.setenv("DB_LOCAL", str(tmp_path / "api.sqlite3"))
+    monkeypatch.setenv("STORE_LOCAL", str(tmp_path / "storage"))
+
+    client = TestClient(app)
+    user_id = _create_user(client, idx=24)
+    created = client.post(
+        "/v1/cases",
+        headers=_headers(),
+        json={"user_id": user_id, "title": "Splnomocnenie auto"},
+    )
+    assert created.status_code == 201
+    case_id = created.json()["case_id"]
+
+    store = ApiDatabaseStore.from_env()
+    store.initialize()
+    generated_doc_id = store.add_case_document(
+        case_id=case_id,
+        kind="generated_document",
+        version=1,
+        original_filename="splnomocnenie-contaminated.txt",
+        payload=(
+            "Vyborne, pripravim finalny navrh splnomocnenia vo formate PDF.\n"
+            "---\n"
+            "**Splnomocnenie**\n\n"
+            "Ja, Marek Matonok, konatel spolocnosti ESolutions SK s.r.o., so sidlom "
+            "Partizanska 665, Spisske Bystre, 05918, tymto splnomocnujem Emiliu "
+            "Matonokovu na pouzivanie firemneho vozidla s evidencnym cislom PP472DT "
+            "v obdobi od 1. jula 2026 do 31. decembra 2026.\n\n"
+            "Podpis: ________________________\n"
+            "---\n"
+            "Tu je finalny navrh splnomocnenia.\n"
+            "CASE_UPDATE_JSON:\n{}"
+        ).encode("utf-8"),
+        uploaded_by_user_id=user_id,
+    )
+
+    generated_pdf = client.get(
+        f"/v1/cases/{case_id}/documents/{generated_doc_id}/pdf?user_id={user_id}",
+        headers=_headers(),
+    )
+
+    assert generated_pdf.status_code == 200
+    generated_pdf_text = "\n".join(
+        page.extract_text() or "" for page in PdfReader(BytesIO(generated_pdf.content)).pages
+    )
+    normalized_text = " ".join(generated_pdf_text.lower().split())
+    for expected in (
+        "splnomocnenie",
+        "esolutions sk s.r.o.",
+        "marek matonok",
+        "emiliu matonokovu",
+        "partizanska 665",
+        "spisske bystre",
+        "05918",
+        "pp472dt",
+        "1. jula 2026",
+        "31. decembra 2026",
+    ):
+        assert expected in normalized_text
+    for polluted in (
+        "vyborne",
+        "pripravim",
+        "tu je finalny navrh",
+        "case_update_json",
+        "system",
+        "assistant",
+        "---",
+        "**",
+    ):
+        assert polluted not in normalized_text
+
+
 def test_paid_user_can_export_case_zip_with_documents_model_audit_and_checksums(
     monkeypatch, tmp_path
 ) -> None:

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -602,6 +602,95 @@ def test_multilingual_case_update_documents_export_as_clean_separate_assets(monk
     assert any("Power of Attorney" in page_text for page_text in page_texts[1:])
 
 
+def test_single_splnomocnenie_case_update_export_uses_clean_document_body(monkeypatch) -> None:
+    from app.chat.models import Message, MessageRole, Session, SessionResult
+    from app.chat.repository import InMemoryChatRepository
+    import app.chat.api as chat_api
+
+    repository = InMemoryChatRepository()
+    monkeypatch.setattr(chat_api, "_repository", repository)
+
+    session = repository.create_session(Session(country="SK", discussion_type="advice", language="sk-SK"))
+    document_body = (
+        "**Splnomocnenie**\n\n"
+        "Ja, Marek Matonok, konatel spolocnosti ESolutions SK s.r.o., so sidlom "
+        "Partizanska 665, Spisske Bystre, 05918, tymto splnomocnujem Emiliu "
+        "Matonokovu na pouzivanie firemneho vozidla s evidencnym cislom PP472DT "
+        "v obdobi od 1. jula 2026 do 31. decembra 2026.\n\n"
+        "Podpis: ________________________"
+    )
+    case_update = {
+        "case": {
+            "documents": [
+                {
+                    "title": "Splnomocnenie",
+                    "filename": "splnomocnenie.pdf",
+                    "language": "sk-SK",
+                    "content": document_body,
+                }
+            ]
+        }
+    }
+    assistant_content = (
+        "Vyborne, pripravim finalny navrh splnomocnenia vo formate PDF.\n\n"
+        "---\n\n"
+        f"{document_body}\n\n"
+        "---\n\n"
+        "Tu je finalny navrh splnomocnenia.\n\n"
+        "CASE_UPDATE_JSON:\n"
+        f"{json.dumps(case_update, ensure_ascii=False)}"
+    )
+    repository.add_message(
+        Message(
+            session_id=session.id,
+            role=MessageRole.ASSISTANT,
+            agent_name="LawyerSlovakia",
+            content=assistant_content,
+        )
+    )
+    repository.set_result(
+        session.id,
+        SessionResult(
+            final_recommendation=assistant_content,
+            judge_rationale="Direct lawyer reply prepared for session export.",
+            metadata={},
+        ),
+    )
+
+    selected_document_pdf = client.get(
+        f"/v1/chat/sessions/{session.id}/export/documents/0",
+        headers=AUTH_HEADERS,
+    )
+
+    assert selected_document_pdf.status_code == 200
+    pdf_text = _pdf_text(selected_document_pdf.content)
+    canonical_pdf_text = _canonical_text(pdf_text)
+    for expected in (
+        "splnomocnenie",
+        "esolutions sk s.r.o.",
+        "marek matonok",
+        "emiliu matonokovu",
+        "partizanska 665",
+        "spisske bystre",
+        "05918",
+        "pp472dt",
+        "1. jula 2026",
+        "31. decembra 2026",
+    ):
+        assert expected in canonical_pdf_text
+    for polluted in (
+        "vyborne",
+        "pripravim",
+        "tu je finalny navrh",
+        "case_update_json",
+        "system",
+        "assistant",
+        "---",
+        "**",
+    ):
+        assert polluted not in canonical_pdf_text
+
+
 def test_fallback_document_entries_ignore_single_contract_section_headings() -> None:
     from app.chat.api import _fallback_document_entries_for_export
     from app.chat.models import Message, MessageRole

--- a/docs/DOCUMENT_TEMPLATES_API.md
+++ b/docs/DOCUMENT_TEMPLATES_API.md
@@ -108,8 +108,10 @@ For generated court-facing or client/third-party output documents, including req
   summary bullets, follow-up prompts, raw markdown separators/bold markers, and unselected alternate-language
   document blocks are not included in the final PDF
 - structured `CASE_UPDATE_JSON.case.documents` entries are treated as the source of truth for generated legal
-  documents; each entry with its own `content`/`body`/`text` field is persisted and exported as a separate
-  generated document by default, so case history, download, and email attachment flows expose all language variants
+  documents; each entry with its own `content`/`body`/`text` field is persisted and exported as the legal-document
+  body even when there is only one generated document, so assistant confirmations, download status text, and
+  technical payloads cannot contaminate the PDF body. Multiple entries are exported as separate generated
+  documents by default, so case history, download, and email attachment flows expose all language variants
 - missing party details in generated documents can be filled from the signed-in user's profile by default
   (name, address, tax number, identity card number, date of birth, and social security number); these values
   are used in the document body only and are not added to the QR payload


### PR DESCRIPTION
## Summary
- use single `CASE_UPDATE_JSON.case.documents` entries as the source document body for chat-session PDF exports
- sanitize generated case-document PDF content so assistant confirmations, status text, markdown separators, and CASE_UPDATE_JSON do not enter legal-document bodies
- add deterministic splnomocnenie PDF regressions for chat export and case-document PDF export
- document the tightened generated-document export contract and bump API revision to 1.0.260518

## Validation
- `./scripts/validate_api.ps1`
- `./conda/python.exe -m pytest api/aijuristiction-api/tests`
- `./conda/python.exe examples/minimal_demo.py`
- Focused regressions: `./conda/python.exe -m pytest api/aijuristiction-api/tests/test_chat.py::test_single_splnomocnenie_case_update_export_uses_clean_document_body api/aijuristiction-api/tests/test_cases.py::test_generated_case_document_pdf_filters_contaminated_splnomocnenie_storage`

## E2E note
- `npm run test:free-plan-document` could not complete in this local environment. First, port 8080 was occupied by an existing JurisDigta MCP-shaped service whose `/v1/users/sign-up` returned 404. Running this worktree API on port 8091 reached the test body, but `/reply` failed while loading the local embedding model because Hugging Face certificate verification failed for `sentence-transformers/all-MiniLM-L6-v2`.

Closes #504