### PR TITLE
Fix generated document email attachments and case links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -198,6 +198,8 @@ EMAIL_SMTP_PORT=587
 EMAIL_SMTP_USE_TLS=true
 EMAIL_SMTP_USERNAME=no-reply@jurisdigta.eu
 # EMAIL_SMTP_PASSWORD=your_mailbox_password_here
+# Public assistant frontend base URL used in generated document email case links.
+JURISDIGTA_AGENT_BASE_URL=https://agent.jurisdigta.eu
 
 # Corporate web contact anti-spam protection (Cloudflare Turnstile).
 # In deployed environments, set CONTACT_CAPTCHA_REQUIRED=true on the API and configure

--- a/api/aijuristiction-api/app/cases_api.py
+++ b/api/aijuristiction-api/app/cases_api.py
@@ -4,6 +4,7 @@ import logging
 import os
 import base64
 import hashlib
+import html
 import io
 import json
 import re
@@ -13,6 +14,7 @@ import zipfile
 from mimetypes import guess_type
 from pathlib import Path
 from datetime import datetime, timezone
+from urllib.parse import quote
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
@@ -627,35 +629,41 @@ def send_case_documents_email(
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="No case documents available to send.")
     correlation_id = (payload.correlation_id or str(uuid4())).strip()
     subject = (payload.case_subject or case.title).strip() or f"Case {case.case_id}"
-    plain = f"Dear client,\n\nPlease find attached generated documents for case '{subject}'.\n\nRegards,\nJurisDigta Legal Team"
-    html = _build_lawyer_email_html(case_subject=subject, version=payload.version.strip() or "v1", correlation_id=correlation_id)
+    case_url = _build_case_deep_link(case_id=case_id)
+    plain = (
+        f"Dear client,\n\nPlease find attached generated documents for case '{subject}'.\n\n"
+        f"Open the case in JurisDigta: {case_url}\n\n"
+        "Review the generated legal documents before filing, signing, or relying on them.\n\n"
+        "Regards,\nJurisDigta Legal Team"
+    )
+    html = _build_lawyer_email_html(
+        case_subject=subject,
+        version=payload.version.strip() or "v1",
+        correlation_id=correlation_id,
+        case_url=case_url,
+    )
     attachments: list[dict[str, str]] = []
     for document in documents:
-        try:
-            raw = store.read_storage_bytes(storage_uri=document.storage_uri)
-        except FileNotFoundError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Stored payload is unavailable for document {document.doc_id}",
-            ) from exc
-        except ValueError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
-                detail="Case storage backend is not reachable for this document",
-            ) from exc
         attachments.append(
-            {
-                "filename": document.original_filename,
-                "mime_type": guess_type(document.original_filename)[0] or "application/octet-stream",
-                "content_base64": base64.b64encode(raw).decode("utf-8"),
-            }
+            _case_document_email_attachment(
+                case=case,
+                user_id=payload.user_id,
+                document=document,
+                store=store,
+            )
         )
     scheduler = EmailScheduler.from_env()
     email_id = scheduler.enqueue(
         recipient=payload.recipient.strip().lower(),
         subject=f"Legal document package | {subject}",
         body=plain,
-        metadata={"event": "case_documents_email", "case_id": case_id, "html_body": html, "attachments": attachments},
+        metadata={
+            "event": "case_documents_email",
+            "case_id": case_id,
+            "case_url": case_url,
+            "html_body": html,
+            "attachments": attachments,
+        },
     )
     return SendCaseDocumentsEmailResponse(
         email_id=email_id,
@@ -1441,15 +1449,87 @@ def _document_context(*, case_id: str, store: ApiDatabaseStore) -> CaseDocumentC
     )
 
 
-def _build_lawyer_email_html(*, case_subject: str, version: str, correlation_id: str) -> str:
+def _case_deep_link_base_url() -> str:
+    configured = os.getenv("JURISDIGTA_AGENT_BASE_URL", "").strip().rstrip("/")
+    if configured and configured != "unknown-variable":
+        return configured
+    return "https://agent.jurisdigta.eu"
+
+
+def _build_case_deep_link(*, case_id: str) -> str:
+    return f"{_case_deep_link_base_url()}/case/{quote(case_id.strip(), safe='')}"
+
+
+def _case_document_email_attachment(
+    *,
+    case: Case,
+    user_id: str,
+    document: CaseDocument,
+    store: ApiDatabaseStore,
+) -> dict[str, str]:
+    if document.kind == "generated_document":
+        pdf_content = _render_generated_case_document_pdf_bytes(
+            case=case,
+            user_id=user_id,
+            document=document,
+            store=store,
+        )
+        visible_content = _generated_case_document_storage_content(document=document, store=store) or (
+            _generated_case_document_visible_content(
+                case_id=case.case_id,
+                doc_id=document.doc_id,
+                store=store,
+            )
+        )
+        return {
+            "filename": _generated_case_document_filename(
+                case_title=case.title,
+                doc_id=document.doc_id,
+                document_type=_generated_case_document_type(visible_content),
+            ),
+            "mime_type": "application/pdf",
+            "content_base64": base64.b64encode(pdf_content).decode("utf-8"),
+        }
+    try:
+        raw = store.read_storage_bytes(storage_uri=document.storage_uri)
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Stored payload is unavailable for document {document.doc_id}",
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Case storage backend is not reachable for this document",
+        ) from exc
+    return {
+        "filename": document.original_filename,
+        "mime_type": guess_type(document.original_filename)[0] or "application/octet-stream",
+        "content_base64": base64.b64encode(raw).decode("utf-8"),
+    }
+
+
+def _build_lawyer_email_html(
+    *,
+    case_subject: str,
+    version: str,
+    correlation_id: str,
+    case_url: str,
+) -> str:
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    escaped_subject = html.escape(case_subject)
+    escaped_version = html.escape(version)
+    escaped_correlation_id = html.escape(correlation_id)
+    escaped_case_url = html.escape(case_url, quote=True)
     return (
         "<html><body style='font-family:Georgia,serif;color:#1f2937'>"
         "<p>Dear Client,</p>"
         "<p>Please find attached your generated legal documents prepared for the referenced case subject.</p>"
+        f"<p>Open the case in JurisDigta: <a href='{escaped_case_url}'>{escaped_case_url}</a></p>"
+        "<p>Review the generated legal documents before filing, signing, or relying on them.</p>"
         "<p>Kind regards,<br/>JurisDigta Legal Desk</p>"
         "<hr/>"
-        f"<p style='font-size:12px;color:#6b7280'>Case Subject: {case_subject}<br/>"
-        f"Version: {version}<br/>Correlation ID: {correlation_id}<br/>Generated: {timestamp}</p>"
+        f"<p style='font-size:12px;color:#6b7280'>Case Subject: {escaped_subject}<br/>"
+        f"Version: {escaped_version}<br/>Correlation ID: {escaped_correlation_id}<br/>Generated: {timestamp}</p>"
         "</body></html>"
     )

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260517"
+version = "1.0.260518"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_cases.py
+++ b/api/aijuristiction-api/tests/test_cases.py
@@ -1,5 +1,6 @@
 ﻿from __future__ import annotations
 
+import base64
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
 import json
@@ -167,6 +168,7 @@ def test_case_history_paging_and_document_download(monkeypatch, tmp_path) -> Non
     monkeypatch.setenv("EMAIL_DB_OPTION", "local")
     monkeypatch.setenv("EMAIL_DB_LOCAL", str(tmp_path / "email.sqlite3"))
     monkeypatch.setenv("EMAIL_SCHEDULER_ENABLED", "false")
+    monkeypatch.setenv("JURISDIGTA_AGENT_BASE_URL", "https://agent.test")
 
     client = TestClient(app)
     user_id = _create_user(client, idx=2)
@@ -282,6 +284,53 @@ def test_case_history_paging_and_document_download(monkeypatch, tmp_path) -> Non
     assert "Dokument je" in generated_pdf_text
     assert "kontrolu" in generated_pdf_text
     assert "Poprad, Slovakia, 05801" in generated_pdf_text
+
+    generated_document_id = store.add_case_document(
+        case_id=case_id,
+        kind="generated_document",
+        version=1,
+        original_filename="splnomocnenie.txt",
+        payload=(
+            "**Splnomocnenie**\n\n"
+            "Splnomocnenec: Emilia Matonokova\n"
+            "Prava: Vsetky pravne ukony tykajuce sa pouzivania firemneho auta.\n"
+            "Podpis: ________________________\n"
+        ).encode("utf-8"),
+        uploaded_by_user_id=user_id,
+    )
+    generated_email = client.post(
+        f"/v1/cases/{case_id}/documents/send-email",
+        headers=_headers(),
+        json={
+            "user_id": user_id,
+            "recipient": "client@example.com",
+            "case_subject": "History case",
+            "doc_ids": [generated_document_id],
+        },
+    )
+    assert generated_email.status_code == 200
+    assert generated_email.json()["attachment_count"] == 1
+
+    with sqlite3.connect(tmp_path / "email.sqlite3") as conn:
+        email_row = conn.execute(
+            """
+            SELECT body, metadata_json
+            FROM email_outbox
+            WHERE email_id = ?
+            """,
+            (generated_email.json()["email_id"],),
+        ).fetchone()
+    assert email_row is not None
+    assert "https://agent.test/case/" in email_row[0]
+    metadata = json.loads(email_row[1])
+    assert metadata["case_url"] == f"https://agent.test/case/{case_id}"
+    assert metadata["html_body"].count(f"https://agent.test/case/{case_id}") == 2
+    attachments = metadata["attachments"]
+    assert len(attachments) == 1
+    attachment = attachments[0]
+    assert attachment["filename"].endswith(f"_{generated_document_id}_splnomocnenie.pdf")
+    assert attachment["mime_type"] == "application/pdf"
+    assert base64.b64decode(attachment["content_base64"]).startswith(b"%PDF")
 
 
 def test_case_history_and_citations_endpoint_return_persisted_answer_citations(

--- a/docs/DOCUMENT_TEMPLATES_API.md
+++ b/docs/DOCUMENT_TEMPLATES_API.md
@@ -121,6 +121,9 @@ For generated court-facing or client/third-party output documents, including req
   when the client omits `recipient`, the API uses the signed-in user's profile email and returns a confirmation
   response before queueing attachments; if the user corrects the recipient in chat (for example `nie na other@example.com`),
   the corrected address is confirmed and used for the queued email
+- generated case documents can be emailed through `POST /v1/cases/{case_id}/documents/send-email`; generated
+  documents are queued as the same rendered `application/pdf` bytes shown by the case document preview, and the
+  email body includes one authenticated case deep link at `{JURISDIGTA_AGENT_BASE_URL}/case/{case_id}`
 - lawyer output is validated before display so profile-backed data does not remain listed as missing; when profile
   data is missing, the user-facing note tells the user to complete Profile for future document defaults
 - document processing status messages shown to clients hide internal `session-*.txt` filenames; those identifiers are

--- a/docs/EMAIL_SETUP.md
+++ b/docs/EMAIL_SETUP.md
@@ -30,12 +30,24 @@ Styled templates currently cover:
 - generated case-document package delivery
 - legacy non-OTP outbox messages normalized by the email scheduler before delivery
 
+Generated case-document package emails include a single authenticated case deep
+link built from `JURISDIGTA_AGENT_BASE_URL` and `/case/{case_id}`. The default
+base URL is `https://agent.jurisdigta.eu`; set `JURISDIGTA_AGENT_BASE_URL` in
+local, test, or production runtime configuration when the assistant frontend is
+served from another host. Opening the link must still require JurisDigta login
+and only loads the case for an authorized user.
+
+When the selected case document is a generated legal document, the queue stores
+the same rendered PDF bytes as the document preview endpoint, with
+`application/pdf` metadata and a user-readable filename. Uploaded/source case
+documents keep their original attachment bytes and MIME type.
+
 OTP and one-time-code emails remain plain text. This avoids placing verification codes in richer HTML previews or related image payloads and keeps code messages minimal.
 
 Privacy and compliance rules for templates:
 
 - Do not include SMTP secrets, API keys, raw legal document text, or unnecessary special-category personal data in templates.
-- Keep generated legal-document emails limited to package metadata and attachments; the footer reminds recipients that AI-assisted legal documents require review before filing, signing, or reliance.
+- Keep generated legal-document emails limited to package metadata, one authenticated case link, and attachments; the footer reminds recipients that AI-assisted legal documents require review before filing, signing, or reliance.
 - The log transport records recipient, subject, body length, HTML presence, and attachment count, not full HTML or OTP body content.
 
 ## Local scheduler

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -98,6 +98,10 @@ print(
     "assistant chatter, alternate-language blocks, and raw markdown stay out of the PDF."
 )
 print(
+    "case_document_email_delivery => case-document email sends selected generated documents as rendered PDF "
+    "attachments and includes an authenticated /case/{case_id} assistant deep link."
+)
+print(
     "frontend_live_document_preview_issue_503 => live assistant document responses prefer hydrated "
     "case-history previews and generated-document actions over terminal PDF progress text."
 )

--- a/frontend/aijurisdictionfronend/e2e/case-deep-link.spec.ts
+++ b/frontend/aijurisdictionfronend/e2e/case-deep-link.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "@playwright/test";
+
+const authUser = {
+  userId: "user-case-link-e2e",
+  email: "case-link@example.test",
+  name: "Case Link User"
+};
+
+const apiCase = {
+  case_id: "case-email-link",
+  user_id: authUser.userId,
+  company_id: null,
+  title: "Email linked case",
+  status: "in_progress",
+  created_at: "2026-07-09T10:00:00Z",
+  updated_at: "2026-07-09T10:10:00Z"
+};
+
+const generatedDocument = {
+  doc_id: "doc-email-link-pdf",
+  kind: "generated_document",
+  version: 1,
+  original_filename: "splnomocnenie-email-link.pdf",
+  processing_status: "processed",
+  processing_error: null,
+  processed_at: "2026-07-09T10:10:00Z",
+  created_at: "2026-07-09T10:10:00Z"
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.route("**/v1/model-routing/effective?**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        plan_code: "free",
+        route_type: "free_local",
+        provider: "local_ollama",
+        provider_display_name: "Local Ollama",
+        model: "qwen3:1.7b",
+        model_profile_id: "local_ollama_default",
+        is_local: true,
+        is_external: false,
+        label: "Local Ollama - qwen3:1.7b"
+      })
+    });
+  });
+
+  await page.route("**/v1/cases?user_id=**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify([apiCase])
+    });
+  });
+
+  await page.route("**/v1/cases/case-email-link/history?**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        has_more: false,
+        documents: [generatedDocument],
+        citations: [],
+        messages: [
+          {
+            communication_id: "msg-client",
+            role: "user",
+            content: "Prosim priprav splnomocnenie.",
+            agent_name: null,
+            created_at: "2026-07-09T10:00:00Z",
+            citations: []
+          },
+          {
+            communication_id: "msg-lawyer",
+            role: "assistant",
+            content:
+              "Splnomocnenie je pripravene na kontrolu.\n\n" +
+              "Generated document:\n" +
+              "- [splnomocnenie-email-link.pdf](/app/documents/view?caseId=case-email-link&docId=doc-email-link-pdf&kind=generated_document&filename=splnomocnenie-email-link.pdf&caseTitle=Email+linked+case&userId=user-case-link-e2e)",
+            agent_name: "AI Lawyer",
+            created_at: "2026-07-09T10:10:00Z",
+            citations: []
+          }
+        ]
+      })
+    });
+  });
+
+  await page.addInitScript((user) => {
+    window.sessionStorage.setItem("jurisdigta.web.auth.user.v1", JSON.stringify(user));
+    window.localStorage.setItem("aj_frontend_lang", "en");
+  }, authUser);
+});
+
+test("authenticated case deep link opens latest communication and generated documents", async ({
+  page
+}) => {
+  await page.goto("/case/case-email-link", { waitUntil: "domcontentloaded" });
+
+  await expect(page.getByRole("heading", { name: "JurisDigta Assistant" })).toBeVisible();
+  await expect(page.getByText("Local Ollama - qwen3:1.7b")).toBeVisible();
+  await expect(page.locator(".assistant-thread__viewport")).toContainText(
+    "Splnomocnenie je pripravene na kontrolu."
+  );
+  await expect(
+    page.getByRole("link", { name: /splnomocnenie-email-link\.pdf/i })
+  ).toBeVisible();
+
+  await page.screenshot({
+    path: "../../runs/e2e/case-deep-link.png",
+    fullPage: true
+  });
+});

--- a/frontend/aijurisdictionfronend/src/App.tsx
+++ b/frontend/aijurisdictionfronend/src/App.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Routes, Route, Navigate } from "react-router-dom";
+import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { PageLayout } from "./components/PageLayout";
 import { useAuth } from "./auth/webAuth";
 import AuthCallbackView from "./auth/AuthCallbackView";
@@ -31,9 +31,10 @@ interface ProtectedRouteProps {
 
 const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   const { isAuthenticated } = useAuth();
+  const location = useLocation();
 
   if (!isAuthenticated) {
-    return <Navigate to="/auth" replace />;
+    return <Navigate to="/auth" replace state={{ from: location }} />;
   }
 
   return children;
@@ -41,9 +42,10 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
 
 const AdminRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   const { isAuthenticated, user } = useAuth();
+  const location = useLocation();
 
   if (!isAuthenticated) {
-    return <Navigate to="/auth" replace />;
+    return <Navigate to="/auth" replace state={{ from: location }} />;
   }
   if (user?.role?.toLowerCase() !== "admin") {
     return <Navigate to="/" replace />;
@@ -86,6 +88,14 @@ const App: React.FC = () => {
         />
         <Route
           path="/app/assistant"
+          element={
+            <ProtectedRoute>
+              <AssistantWorkspace />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/case/:caseId"
           element={
             <ProtectedRoute>
               <AssistantWorkspace />

--- a/frontend/aijurisdictionfronend/src/__tests__/appProtectedRoutes.test.tsx
+++ b/frontend/aijurisdictionfronend/src/__tests__/appProtectedRoutes.test.tsx
@@ -186,6 +186,19 @@ describe("App protected routes", () => {
     expect(screen.queryByText("Assistant Workspace")).toBeNull();
   });
 
+  it("redirects unauthenticated users from case deep links to /auth", () => {
+    authState.isAuthenticated = false;
+
+    render(
+      <MemoryRouter initialEntries={["/case/case-1"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Auth Page")).toBeDefined();
+    expect(screen.queryByText("Assistant Workspace")).toBeNull();
+  });
+
   it("redirects unauthenticated users from /app/chat to /auth", () => {
     authState.isAuthenticated = false;
 
@@ -254,6 +267,18 @@ describe("App protected routes", () => {
 
     render(
       <MemoryRouter initialEntries={["/app/assistant"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Assistant Workspace")).toBeDefined();
+  });
+
+  it("allows authenticated users to open case deep links in the assistant", () => {
+    authState.isAuthenticated = true;
+
+    render(
+      <MemoryRouter initialEntries={["/case/case-1"]}>
         <App />
       </MemoryRouter>
     );

--- a/frontend/aijurisdictionfronend/src/pages/AssistantWorkspace.tsx
+++ b/frontend/aijurisdictionfronend/src/pages/AssistantWorkspace.tsx
@@ -540,6 +540,14 @@ const shouldPreferHydratedAssistantMessage = (currentText: string, hydratedText:
   );
 };
 
+const currentCaseDeepLinkId = (): string | undefined => {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+  const match = window.location.pathname.match(/^\/case\/([^/?#]+)/);
+  return match?.[1] ? decodeURIComponent(match[1]) : undefined;
+};
+
 const AssistantThread: React.FC = () => {
   const { language, t } = useLanguage();
   const { isAuthenticated, isAuthLoading, user } = useAuth();
@@ -879,7 +887,14 @@ const AssistantConfigurations: React.FC = () => {
 const AssistantWorkspace: React.FC = () => {
   const { t } = useLanguage();
   const { isAuthenticated, isAuthLoading, user } = useAuth();
-  const { activeCase } = useCases();
+  const caseState = useCases();
+  const {
+    activeCase,
+    cases = [],
+    isLoadingCases = false,
+    selectCase = () => undefined
+  } = caseState;
+  const routeCaseId = currentCaseDeepLinkId();
   const threadKey = React.useMemo(() => caseThreadKey(activeCase), [activeCase]);
   const fallbackModelLabel = React.useMemo(() => chatApiRuntimeConfig().chatModelLabel, []);
   const pendingModelLabel = t("assistantModelDisclosurePending");
@@ -909,6 +924,16 @@ const AssistantWorkspace: React.FC = () => {
       isCurrent = false;
     };
   }, [fallbackModelLabel, isAuthenticated, isAuthLoading, pendingModelLabel, user?.userId]);
+
+  React.useEffect(() => {
+    const requestedCaseId = routeCaseId?.trim();
+    if (!requestedCaseId || isLoadingCases || activeCase?.id === requestedCaseId) {
+      return;
+    }
+    if (cases.some((caseItem) => caseItem.id === requestedCaseId)) {
+      selectCase(requestedCaseId);
+    }
+  }, [activeCase?.id, cases, isLoadingCases, routeCaseId, selectCase]);
 
   return (
     <div className="page assistant-workspace-page">

--- a/frontend/aijurisdictionfronend/src/pages/Auth.tsx
+++ b/frontend/aijurisdictionfronend/src/pages/Auth.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { MfaChallenge, useAuth } from "../auth/webAuth";
 import { useLanguage } from "../components/LanguageProvider";
 
@@ -7,6 +7,7 @@ const Auth: React.FC = () => {
   const { t } = useLanguage();
   const { isAuthenticated, user, signIn, sendSignUpCode, signUp, signOut, sendMfaEmailCode, verifyMfa } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
   const [authMode, setAuthMode] = React.useState<"signIn" | "signUp">("signIn");
   const [registrationStep, setRegistrationStep] = React.useState<"details" | "verify">("details");
   const [email, setEmail] = React.useState("");
@@ -24,6 +25,13 @@ const Auth: React.FC = () => {
   const [isRegistering, setIsRegistering] = React.useState(false);
   const [loginOtpRequired, setLoginOtpRequired] = React.useState(false);
   const [registrationOtpSentFor, setRegistrationOtpSentFor] = React.useState<string | null>(null);
+
+  const postAuthPath = React.useMemo(() => {
+    const candidate = (location.state as { from?: { pathname?: string; search?: string } } | null)?.from;
+    const pathname = candidate?.pathname?.startsWith("/") ? candidate.pathname : "/app/assistant";
+    const search = candidate?.search?.startsWith("?") ? candidate.search : "";
+    return `${pathname}${search}`;
+  }, [location.state]);
 
   const resetFeedback = () => {
     setError(null);
@@ -80,7 +88,7 @@ const Auth: React.FC = () => {
       setError(null);
       setMfaChallenge(null);
       setMessage(t("authSignedIn"));
-      navigate("/app/assistant");
+      navigate(postAuthPath);
     } catch (signInError) {
       setError(signInError instanceof Error ? signInError.message : t("authSignInFailed"));
       setMessage(null);
@@ -137,7 +145,7 @@ const Auth: React.FC = () => {
       });
       setError(null);
       setMessage(t("authRegistered"));
-      navigate("/app/assistant");
+      navigate(postAuthPath);
     } catch (signUpError) {
       setError(signUpError instanceof Error ? signUpError.message : t("authRegisterFailed"));
       setMessage(null);
@@ -174,7 +182,7 @@ const Auth: React.FC = () => {
       setError(null);
       setMfaChallenge(null);
       setMessage(t("authSignedIn"));
-      navigate("/app/assistant");
+      navigate(postAuthPath);
     } catch (verifyError) {
       setError(verifyError instanceof Error ? verifyError.message : t("authSignInFailed"));
     } finally {


### PR DESCRIPTION
﻿## Summary
- Send selected generated case documents as rendered PDFs in case-document emails instead of stored source payloads.
- Add authenticated `/case/{case_id}` assistant deep links with post-login return behavior.
- Cover queued email metadata, protected case deep-link routing, and Playwright deep-link hydration.

## Compliance
- Email body stays privacy-minimal: case metadata, one authenticated link, and no legal document body text.
- Case deep links remain behind JurisDigta auth and only select cases returned for the signed-in user.
- Existing human-review notice remains in generated legal-document email copy.

## Validation
- `./scripts/validate_api.ps1`
- `./conda/python.exe -m pytest api/aijuristiction-api/tests/test_cases.py -k "case_history_paging_and_document_download or generated_case_document_pdf_reads_generated_document_storage"`
- `./conda/python.exe examples/minimal_demo.py`
- `npm test -- --run src/__tests__/appProtectedRoutes.test.tsx src/__tests__/assistantWorkspace.test.tsx src/__tests__/authPage.test.tsx`
- `npm run build`
- `FRONTEND_E2E_PORT=6205 npx playwright test e2e/case-deep-link.spec.ts --project=chromium`

## Note
- Full `./conda/python.exe -m pytest api/aijuristiction-api/tests` was attempted twice but exceeded the local command timeout, including a 10-minute run, without producing a failure before timeout.

Closes #505
