### PR TITLE
Add AI model token Grafana dashboard

### DIFF
--- a/Deployment/monitoring/README.md
+++ b/Deployment/monitoring/README.md
@@ -26,6 +26,7 @@ GET /v1/system/status?minutes=60
 - Docker stdout/stderr logs and server job log files through Grafana Alloy and Loki.
 - Provisioned AI model usage panels in `JurisDigta Application Performance` for aggregate status, cost, requests by route, input/output/total tokens by model, and top cost by plan/task/provider/model route.
 - Provisioned masked top-10 case token panels in `JurisDigta Ollama And AI Models` for Grafana-only operational triage.
+- Provisioned `JurisDigta AI Model Token Usage` for aggregate total-token counts over time and per model/window.
 
 ## Security Baseline
 
@@ -117,6 +118,7 @@ Provisioned Grafana panels:
 - local/Ollama and paid-model total tokens by provider/model/route
 - masked top 10 cases by token volume and estimated cost
 - input, cached input, output, and total tokens by model
+- total tokens over time by model and status window
 - top AI model cost by plan, task, provider, model, and route type
 
 Case-level drill-down remains limited to masked top-case Grafana rows. Raw
@@ -516,7 +518,8 @@ Grafana loads JurisDigta dashboards from `grafana/dashboards` into the
 
 - `JurisDigta Server Performance`: CPU, RAM, disk, load, network, disk I/O, and container memory.
 - `JurisDigta Application Performance`: API/MCP/web/Grafana HTTP probes, component status, email queue/sent/time, document queue/processed/time, laws processing cursor and runtime, and application error counts.
-- `JurisDigta Ollama And AI Models`: Ollama API health, configured model presence, installed/running model counts, model size, loaded model VRAM, probe latency, local/Ollama tokens, paid-model tokens, requests, estimated cost, and masked top cases by token volume.
+- `JurisDigta Ollama And AI Models`: Ollama API health, configured model presence, installed/running model counts, model size, loaded model VRAM, probe latency, local/Ollama tokens, paid-model tokens, requests, estimated cost, and masked top cases by token volume. Its usage-window selector is populated from available Prometheus token windows so it does not default to an empty status window.
+- `JurisDigta AI Model Token Usage`: total tokens over time by provider/model/window, current total-token rows per model, 30-day total-token bar gauges per model, and input/output/cached token breakdowns.
 - `JurisDigta Laws Collector`: total imported laws over time, latest imported law identifier such as `179/2026`, execution time, imported laws per latest run, processed entries/documents, and recent sanitized collector errors.
 - `JurisDigta Court Decision Service`: current collector status, imported decisions, latest imported decision safe short name and published date, latest imported decision timestamp, stored versions, versions with embeddings, processing/processed/idle activity, storage totals, and recent sanitized collector errors.
 - `JurisDigta Errors`: total errors, error telemetry status, error counts by source, HTTP probe status codes, and scrape target health.

--- a/Deployment/monitoring/grafana/dashboards/jurisdigta-ai-model-token-usage.json
+++ b/Deployment/monitoring/grafana/dashboards/jurisdigta-ai-model-token-usage.json
@@ -1,0 +1,289 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "jurisdigta-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (provider, model, window_minutes) (jurisdigta_ai_model_total_tokens_window)",
+          "legendFormat": "{{window_minutes}}m {{provider}} {{model}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Tokens By Model And Window",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "jurisdigta-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "id": 2,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "expr": "sum by (provider, model, window_minutes, route_class, route_type) (jurisdigta_ai_model_total_tokens_window)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Current Total Tokens Per Model",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "__name__": true,
+              "instance": true,
+              "job": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "total_tokens",
+              "model": "model",
+              "provider": "provider",
+              "route_class": "route_class",
+              "route_type": "route_type",
+              "window_minutes": "window_minutes"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "jurisdigta-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "id": 3,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "expr": "sum by (provider, model) (jurisdigta_ai_model_total_tokens_window{window_minutes=\"43200\"})",
+          "legendFormat": "{{provider}} {{model}}",
+          "refId": "A"
+        }
+      ],
+      "title": "30d Total Tokens By Model",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "jurisdigta-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (provider, model, window_minutes) (jurisdigta_ai_model_input_tokens_window)",
+          "legendFormat": "input {{window_minutes}}m {{provider}} {{model}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (provider, model, window_minutes) (jurisdigta_ai_model_output_tokens_window)",
+          "legendFormat": "output {{window_minutes}}m {{provider}} {{model}}",
+          "refId": "B"
+        },
+        {
+          "expr": "sum by (provider, model, window_minutes) (jurisdigta_ai_model_cached_input_tokens_window)",
+          "legendFormat": "cached input {{window_minutes}}m {{provider}} {{model}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Input, Output, And Cached Tokens By Model",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "jurisdigta",
+    "ai-models",
+    "tokens"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "JurisDigta AI Model Token Usage",
+  "uid": "jurisdigta-ai-model-token-usage",
+  "version": 1,
+  "weekStart": ""
+}

--- a/Deployment/monitoring/grafana/dashboards/jurisdigta-ollama-models.json
+++ b/Deployment/monitoring/grafana/dashboards/jurisdigta-ollama-models.json
@@ -693,9 +693,14 @@
       {
         "current": {
           "selected": true,
-          "text": "1h",
-          "value": "60"
+          "text": "30d",
+          "value": "43200"
         },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "jurisdigta-prometheus"
+        },
+        "definition": "label_values(jurisdigta_ai_model_total_tokens_window, window_minutes)",
         "hide": 0,
         "includeAll": false,
         "label": "Usage window",
@@ -703,7 +708,7 @@
         "name": "usage_window",
         "options": [
           {
-            "selected": true,
+            "selected": false,
             "text": "1h",
             "value": "60"
           },
@@ -718,15 +723,20 @@
             "value": "10080"
           },
           {
-            "selected": false,
+            "selected": true,
             "text": "30d",
             "value": "43200"
           }
         ],
-        "query": "60,1440,10080,43200",
+        "query": {
+          "query": "label_values(jurisdigta_ai_model_total_tokens_window, window_minutes)",
+          "refId": "StandardVariableQuery"
+        },
         "queryValue": "",
+        "refresh": 2,
         "skipUrlSync": false,
-        "type": "custom"
+        "sort": 3,
+        "type": "query"
       }
     ]
   },

--- a/tests/test_server_monitoring.py
+++ b/tests/test_server_monitoring.py
@@ -59,6 +59,7 @@ def test_monitoring_dashboards_include_ollama_ai_models_dashboard() -> None:
     dashboard_path = MONITORING_DIR / "grafana" / "dashboards" / "jurisdigta-ollama-models.json"
     dashboard = json.loads(dashboard_path.read_text(encoding="utf-8"))
     panel_titles = {str(panel.get("title")) for panel in dashboard["panels"]}
+    usage_window = next(item for item in dashboard["templating"]["list"] if item["name"] == "usage_window")
 
     assert dashboard["uid"] == "jurisdigta-ollama-models"
     assert "Ollama API" in panel_titles
@@ -67,7 +68,31 @@ def test_monitoring_dashboards_include_ollama_ai_models_dashboard() -> None:
     assert "Local/Ollama Total Tokens" in panel_titles
     assert "Paid Model Total Tokens" in panel_titles
     assert "Top 10 Cases By Tokens (Masked)" in panel_titles
-    assert any(item["name"] == "usage_window" for item in dashboard["templating"]["list"])
+    assert usage_window["current"]["value"] == "43200"
+    assert usage_window["type"] == "query"
+    assert usage_window["definition"] == "label_values(jurisdigta_ai_model_total_tokens_window, window_minutes)"
+
+
+def test_monitoring_dashboards_include_ai_model_token_usage_dashboard() -> None:
+    dashboard_path = MONITORING_DIR / "grafana" / "dashboards" / "jurisdigta-ai-model-token-usage.json"
+    dashboard = json.loads(dashboard_path.read_text(encoding="utf-8"))
+    panel_titles = {str(panel.get("title")) for panel in dashboard["panels"]}
+    target_queries = {
+        str(target.get("expr"))
+        for panel in dashboard["panels"]
+        for target in panel.get("targets", [])
+        if isinstance(target, dict)
+    }
+
+    assert dashboard["uid"] == "jurisdigta-ai-model-token-usage"
+    assert "Total Tokens By Model And Window" in panel_titles
+    assert "Current Total Tokens Per Model" in panel_titles
+    assert "30d Total Tokens By Model" in panel_titles
+    assert "Input, Output, And Cached Tokens By Model" in panel_titles
+    assert (
+        "sum by (provider, model, window_minutes) (jurisdigta_ai_model_total_tokens_window)"
+        in target_queries
+    )
 
 
 def test_monitoring_dashboards_include_court_decision_service_dashboard() -> None:


### PR DESCRIPTION
## Summary
- Add a separate Grafana dashboard for AI model total-token usage by model and status window.
- Update the existing Ollama/AI models dashboard usage-window selector so it defaults to populated token windows instead of an empty 1h view.
- Document the new dashboard and add monitoring-dashboard coverage.

## Validation
- JSON validation for updated/new Grafana dashboards
- C:\Users\maton\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m pytest tests\test_server_monitoring.py -q
- Live Prometheus query check on jurisdigta-server for new token expressions