### PR TITLE
Fix scheduled E2E status report

### DIFF
--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -943,6 +943,7 @@ Scheduled E2E status:
 - The generated artifacts are `scheduled-e2e-status.md`, `scheduled-e2e-results.json`, and Playwright `test-results`.
 - Scheduled runs use local SQLite paths under the GitHub runner temp directory, `LLM_PROVIDER=mock`, and log-only email transport. This keeps the run deterministic and avoids processing production user data or sending messages.
 - Browser frontend specs that require `FRONTEND_BASE_URL` are listed in the catalog, but they are marked `not scheduled` by the default API-focused scheduled run until a frontend environment is explicitly provided.
+- To reproduce the status-report generation locally after a Playwright JSON run, execute `node scripts/summarize-e2e-status.mjs e2e-test-catalog.json scheduled-e2e-results.json scheduled-e2e-status.md` from `api/aijuristiction-api/e2e-playwright`. The summarizer accepts both bare Playwright spec file names and `tests/...` paths from the JSON reporter.
 
 Run only the chat simulation test:
 

--- a/api/aijuristiction-api/app/chat/result_metadata.py
+++ b/api/aijuristiction-api/app/chat/result_metadata.py
@@ -482,6 +482,10 @@ def _read_or_create_model_knowledge_cutoff_snapshot(
             )
             return cached_snapshot
 
+    if _is_non_production_model_name(model_name):
+        _ensure_model_knowledge_permanent_memory_entry(store=store, model_name=model_name)
+        return (None, _UNAVAILABLE_MODEL_KNOWLEDGE_SOURCE)
+
     resolved_snapshot = _resolve_model_knowledge_cutoff_via_web_search(model_name=model_name)
     if resolved_snapshot is not None:
         _persist_model_knowledge_cutoff_snapshot(
@@ -581,6 +585,11 @@ def _resolve_llm_model_name() -> str:
     if provider == "mock":
         return "mock"
     return "unknown"
+
+
+def _is_non_production_model_name(model_name: str) -> bool:
+    normalized = model_name.strip().lower()
+    return normalized in {"mock", "test", "fixture", "local_mock"}
 
 
 def _resolve_model_knowledge_cutoff_cache_path() -> Path | None:

--- a/api/aijuristiction-api/e2e-playwright/scripts/summarize-e2e-status.mjs
+++ b/api/aijuristiction-api/e2e-playwright/scripts/summarize-e2e-status.mjs
@@ -11,8 +11,8 @@ if (!catalogPath || !reportPath || !outputPath) {
   process.exit(2);
 }
 
-const catalog = JSON.parse(stripBom(await readFile(catalogPath, 'utf8')));
-const report = JSON.parse(stripBom(await readFile(reportPath, 'utf8')));
+const catalog = JSON.parse(await readJsonText(catalogPath));
+const report = JSON.parse(await readJsonText(reportPath));
 
 const resultsByFileAndTitle = new Map();
 collectSpecs(report.suites ?? [], []);
@@ -103,7 +103,12 @@ function resolveStatus(tests, results) {
 }
 
 function normalizePath(value) {
-  return value.replaceAll('\\', '/').replace(/^.*?tests\//, 'tests/');
+  const normalized = value.replaceAll('\\', '/');
+  const testPath = normalized.match(/(?:^|\/)(tests\/.+)$/)?.[1];
+  if (testPath) return testPath;
+
+  const fileName = normalized.split('/').pop() ?? normalized;
+  return fileName ? `tests/${fileName}` : normalized;
 }
 
 function formatDuration(milliseconds) {
@@ -120,6 +125,21 @@ function escapeCell(value) {
   return String(value ?? '').replaceAll('|', '\\|').replace(/\r?\n/g, '<br>');
 }
 
-function stripBom(value) {
-  return value.charCodeAt(0) === 0xfeff ? value.slice(1) : value;
+async function readJsonText(filePath) {
+  const buffer = await readFile(filePath);
+  const text = decodeJsonBuffer(buffer);
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
+function decodeJsonBuffer(buffer) {
+  if (buffer.length >= 2 && buffer[0] === 0xff && buffer[1] === 0xfe) {
+    return buffer.subarray(2).toString('utf16le');
+  }
+  if (buffer.length >= 2 && buffer[0] === 0xfe && buffer[1] === 0xff) {
+    return buffer.subarray(2).swap16().toString('utf16le');
+  }
+  if (buffer.length > 3 && buffer[1] === 0 && buffer[3] === 0) {
+    return buffer.toString('utf16le');
+  }
+  return buffer.toString('utf8');
 }

--- a/api/aijuristiction-api/e2e-playwright/tests/health.spec.ts
+++ b/api/aijuristiction-api/e2e-playwright/tests/health.spec.ts
@@ -8,5 +8,10 @@ test.beforeEach(async ({ request, baseURL }) => {
 test('health endpoint is healthy', async ({ request, baseURL }) => {
   const response = await request.get(`${baseURL}/health`);
   expect(response.ok()).toBeTruthy();
-  await expect(response.json()).resolves.toEqual({ status: 'ok' });
+  await expect(response.json()).resolves.toMatchObject({
+    status: 'ok',
+    service: 'aijuristiction-api',
+    llm: { status: 'ok' },
+    database: { status: 'ok' },
+  });
 });

--- a/api/aijuristiction-api/e2e-playwright/tests/mobile-auth-subscription.spec.ts
+++ b/api/aijuristiction-api/e2e-playwright/tests/mobile-auth-subscription.spec.ts
@@ -64,7 +64,7 @@ test('mobile auth + subscription flow: sign-up, sign-in and request subscription
   const plans = (await plansResponse.json()) as Array<{ plan_code: string }>;
   expect(plans.length).toBeGreaterThan(0);
 
-  const targetPlanCode = plans[plans.length - 1]?.plan_code;
+  const targetPlanCode = plans.find((plan) => plan.plan_code === 'case')?.plan_code;
   expect(targetPlanCode).toBeTruthy();
 
   const createSubscriptionResponse = await request.post(`${baseURL}/v1/users/${userId}/subscriptions`, {

--- a/api/aijuristiction-api/e2e-playwright/tests/payment-process.spec.ts
+++ b/api/aijuristiction-api/e2e-playwright/tests/payment-process.spec.ts
@@ -94,17 +94,17 @@ test('payment process: user checks out Case plan and confirms sandbox payment', 
   expect(checkoutUrl.searchParams.get('paymentId')).toBe(checkout.payment_id);
   expect(checkoutUrl.searchParams.get('token')).toBeTruthy();
 
-  const payingSubscriptionsResponse = await request.get(`${baseURL}/v1/users/${user.user_id}/subscriptions`, {
+  const pendingSubscriptionsResponse = await request.get(`${baseURL}/v1/users/${user.user_id}/subscriptions`, {
     headers: { 'x-api-key': apiKey },
   });
-  expect(payingSubscriptionsResponse.status()).toBe(200);
-  const payingSubscriptions = (await payingSubscriptionsResponse.json()) as SubscriptionResponse[];
+  expect(pendingSubscriptionsResponse.status()).toBe(200);
+  const pendingSubscriptions = (await pendingSubscriptionsResponse.json()) as SubscriptionResponse[];
   expect(
-    payingSubscriptions.some(
+    pendingSubscriptions.some(
       (subscription) =>
         subscription.subscription_id === checkout.subscription_id &&
         subscription.plan_code === 'case' &&
-        subscription.status === 'paying'
+        subscription.status === 'pending'
     )
   ).toBeTruthy();
 
@@ -182,5 +182,5 @@ test('payment process guards: disabled plans and unknown payments do not activat
   expect(subscriptionsResponse.status()).toBe(200);
   const subscriptions = (await subscriptionsResponse.json()) as SubscriptionResponse[];
   const subscription = subscriptions.find((item) => item.subscription_id === checkout.subscription_id);
-  expect(subscription?.status).toBe('paying');
+  expect(subscription?.status).toBe('pending');
 });

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260518"
+version = "1.0.260519"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -7182,6 +7182,39 @@ def test_law_snapshot_reuses_cached_model_cutoff_without_expiration(monkeypatch,
     )
 
 
+def test_law_snapshot_does_not_web_search_for_mock_model(monkeypatch, tmp_path) -> None:
+    import app.chat.result_metadata as result_metadata
+
+    monkeypatch.setenv("LAWS_DB_BACKEND", "sqlite")
+    monkeypatch.setenv("LAWS_DB_LOCAL", str(tmp_path / "missing-laws.sqlite3"))
+    monkeypatch.delenv("MODEL_KNOWLEDGE_CUTOFF_CACHE_FILE", raising=False)
+    monkeypatch.setattr(
+        result_metadata.ApiDatabaseStore,
+        "from_env",
+        lambda: SimpleNamespace(
+            get_permanent_memory=lambda _key: None,
+            upsert_permanent_memory=lambda **_kwargs: None,
+        ),
+    )
+    monkeypatch.setattr(
+        result_metadata,
+        "AIWebSearchAgent",
+        lambda: SimpleNamespace(search=lambda **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected web search"))),
+    )
+    monkeypatch.setattr(
+        result_metadata,
+        "_fetch_text_from_url",
+        lambda _url: (_ for _ in ()).throw(AssertionError("unexpected page fetch")),
+    )
+
+    snapshot = result_metadata.get_law_knowledge_snapshot("SK", model_name="mock")
+
+    assert snapshot.last_law_update_date is None
+    assert snapshot.last_law_update_source == "unavailable"
+    assert snapshot.model_knowledge_cutoff_date is None
+    assert snapshot.model_knowledge_cutoff_source == "unavailable"
+
+
 def test_law_snapshot_uses_direct_openai_model_page_when_search_returns_no_results(
     monkeypatch, tmp_path
 ) -> None:


### PR DESCRIPTION
## Summary
- Fix scheduled E2E status report mapping for Playwright JSON files emitted as bare spec names.
- Keep mock-mode version metadata deterministic by skipping external model-cutoff lookup for non-production model names.
- Update scheduled E2E assertions for the expanded health contract, enabled Case plan subscription flow, and pending-until-confirmed payments.

## Validation
- `node scripts/summarize-e2e-status.mjs e2e-test-catalog.json %TEMP%\issue489-run29083392596\scheduled-e2e-results.json %TEMP%\issue489-fixed-status.md`
- Scheduled E2E subset locally on `API_BASE_URL=http://127.0.0.1:18080`: all scheduled checks passed and `scheduled-e2e-status.md` was generated.
- `..\..\conda\python.exe -m ruff check app tests`
- `..\..\conda\python.exe -m mypy app`
- `.\conda\python.exe -m pytest api\aijuristiction-api\tests` (`379 passed`)
- `.\scripts\validate_api.ps1`

Refs #489