### PR TITLE
Fix Slovak loan confirmation document flow

### DIFF
--- a/api/aijuristiction-api/app/chat/api.py
+++ b/api/aijuristiction-api/app/chat/api.py
@@ -3802,6 +3802,8 @@ def _generated_case_document_legal_title(value: str) -> str:
         return "Power of Attorney"
     if "splnomocnenie" in normalized or "plnomocenstvo" in normalized:
         return "Splnomocnenie"
+    if "potvrdenie" in normalized and any(token in normalized for token in ("pozick", "dlh", "dlzob")):
+        return "Potvrdenie o pozicke"
     if "potvrdenie" in normalized and any(token in normalized for token in ("zaplat", "uhrad", "platb")):
         return "Potvrdenie o zaplatení"
     return title
@@ -8174,6 +8176,8 @@ def _detect_document_kind(
         "potvrdenie o uhrad",
         "potvrdenie o prijati plat",
         "potvrdenie prijatia plat",
+        "potvrdenie o pozick",
+        "potvrdenie o dlzob",
         "doklad o zaplat",
         "doklad o uhrad",
         "payment confirmation",

--- a/api/aijuristiction-api/app/chat/country_services/slovakia.py
+++ b/api/aijuristiction-api/app/chat/country_services/slovakia.py
@@ -70,6 +70,29 @@ def prepare_slovakia_direct_reply(
         prior_messages=prior_messages,
     )
 
+    if _looks_like_payment_confirmation_final_request(
+        current_content=current_content,
+        prior_messages=prior_messages,
+    ):
+        direct_processing_events: list[dict[str, object]] = []
+        emit_processing_event(
+            events=direct_processing_events,
+            event=build_processing_event(
+                stage="document_ready",
+                message="Pripravil som podklady pre slovenske potvrdenie.",
+                details={"document_names": ["Potvrdenie"]},
+            ),
+            callback=processing_event_callback,
+        )
+        return DirectReplyPreparation(
+            supplemental_documents=[],
+            direct_reply=_build_slovak_payment_confirmation_ready_reply(
+                current_content=current_content,
+                company_record=None,
+            ),
+            processing_events=direct_processing_events,
+        )
+
     asks_company_registry_info = _looks_like_company_registry_information_question(current_content)
     looks_like_company_document = _looks_like_company_document_matter(
         current_content=current_content,
@@ -492,7 +515,19 @@ def _looks_like_payment_confirmation_final_request(
     )
     normalized = _canonicalize_slovak_text(f"{user_context} {current_content}")
     if "potvrdenie" not in normalized or not any(
-        token in normalized for token in ("zaplat", "uhrad", "platb", "splatk")
+        token in normalized
+        for token in (
+            "zaplat",
+            "uhrad",
+            "platb",
+            "splatk",
+            "pozicat",
+            "pozical",
+            "pozicala",
+            "pozick",
+            "dlh",
+            "dlzob",
+        )
     ):
         return False
     final_markers = (
@@ -504,6 +539,8 @@ def _looks_like_payment_confirmation_final_request(
         "konecnu",
         "konecna",
         "priprav",
+        "chcem",
+        "ziadam",
     )
     return any(marker in normalized for marker in final_markers)
 
@@ -575,6 +612,13 @@ def _build_slovak_payment_confirmation_ready_reply(
         current_content=current_content,
         company_record=company_record,
     )
+    if _looks_like_loan_confirmation_request(current_content):
+        facts = _extract_loan_confirmation_request_facts(current_content)
+    document_title = (
+        "Potvrdenie o pozicke"
+        if facts["document_kind"] == "loan_confirmation"
+        else "Potvrdenie o zaplateni"
+    )
     case_update: dict[str, object] = {
         "case": {
             "case_id": None,
@@ -585,19 +629,20 @@ def _build_slovak_payment_confirmation_ready_reply(
                 "opponent": {"name": facts["recipient"]},
             },
             "matter": {
-                "category": "commercial",
-                "topic": "potvrdenie_o_zaplateni",
+                "category": "civil" if facts["document_kind"] == "loan_confirmation" else "commercial",
+                "topic": facts["topic"],
                 "amount_eur": facts["amount_number"],
                 "key_dates": {"splatnost": facts["due_date"]},
                 "facts_summary": facts["purpose"],
-                "client_goal": "Pripravit potvrdenie o zaplateni vo formate PDF.",
+                "client_goal": f"Pripravit {document_title.lower()} vo formate PDF.",
             },
             "documents": [
                 {
                     "doc_id": "DOC-001",
-                    "type": "payment_proof",
-                    "filename": "Potvrdenie_o_zaplateni.pdf",
-                    "path": "documents/Potvrdenie_o_zaplateni.pdf",
+                    "type": facts["document_kind"],
+                    "filename": f"{document_title.replace(' ', '_')}.pdf",
+                    "path": f"documents/{document_title.replace(' ', '_')}.pdf",
+                    "content": "\n".join(_build_slovak_payment_confirmation_document_lines(facts)),
                     "received_at": datetime.now(timezone.utc).isoformat(),
                     "notes": "Finalny dokument pripraveny na export.",
                 }
@@ -608,7 +653,13 @@ def _build_slovak_payment_confirmation_ready_reply(
         }
     }
     verification_lines = [
-        "Tu je konecna verzia dokumentu - dokument je pripraveny na export a stiahnutie.",
+        f"Tu je konecna verzia dokumentu {document_title} - dokument je pripraveny na export a stiahnutie.",
+        "",
+        "Odporucane kroky pred pouzitim:",
+        "1. Doplnte presnu sumu, ak nebola uvedena v zadani.",
+        "2. Skontrolujte identifikacne udaje oboch stran a datum odovzdania penazi.",
+        "3. Podpiste dokument oboma stranami; pri vyssej sume zvazte notarske osvedcenie podpisov.",
+        "4. AI navrh pred pouzitim skontrolujte clovekom s pravnou zodpovednostou.",
         "",
         "Podklady pre export:",
         f"Platitel: {facts['payer']}",
@@ -670,6 +721,121 @@ def _extract_payment_confirmation_request_facts(
         "payer": payer,
         "company_summary": company_summary,
     }
+
+
+def _looks_like_loan_confirmation_request(content: str) -> bool:
+    normalized = _canonicalize_slovak_text(content)
+    return "potvrdenie" in normalized and any(
+        token in normalized for token in ("pozicat", "pozical", "pozicala", "pozick", "dlh", "dlzob")
+    )
+
+
+def _extract_loan_confirmation_request_facts(content: str) -> dict[str, object]:
+    amount_match = re.search(
+        r"\b([0-9\s]+(?:[.,][0-9]{1,2})?\s*(?:eur|eu|€))\b",
+        content,
+        re.IGNORECASE,
+    )
+    amount = (
+        " ".join(amount_match.group(1).split())
+        if amount_match is not None
+        else "Suma pozicky bude doplnena pred podpisom."
+    )
+    amount_number_match = re.search(r"[0-9]+(?:[.,][0-9]{1,2})?", amount.replace(" ", ""))
+    amount_number = float(amount_number_match.group(0).replace(",", ".")) if amount_number_match else None
+    return {
+        "amount": amount,
+        "amount_number": amount_number,
+        "due_date": _extract_loan_duration(content),
+        "spz": "",
+        "purpose": "potvrdenie o poskytnuti penaznej pozicky",
+        "recipient": _extract_loan_recipient(content) or "Dlznik bude doplneny pred podpisom.",
+        "payer": _extract_loan_lender(content) or "Poskytovatel pozicky bude doplneny pred podpisom.",
+        "company_summary": "",
+        "document_kind": "loan_confirmation",
+        "topic": "potvrdenie_o_pozicke",
+    }
+
+
+def _extract_loan_duration(content: str) -> str:
+    normalized = _canonicalize_slovak_text(content)
+    match = re.search(r"\b(?:na|pre)\s+([0-9]+)\s+(rok|roky|mesiac|mesiace|dni|den)\b", normalized)
+    if match is None:
+        return "Lehota vratenia bude doplnena pred podpisom."
+    return f"Lehota vratenia: {match.group(1)} {match.group(2)}."
+
+
+def _extract_loan_recipient(content: str) -> str:
+    name_match = re.search(
+        r"\b(?:peniaze|pozicku)\s+([A-Za-zÁÄČĎÉÍĽĹŇÓÔŔŠŤÚÝŽáäčďéíľĺňóôŕšťúýž]+ovi\s+[A-Za-zÁÄČĎÉÍĽĹŇÓÔŔŠŤÚÝŽáäčďéíľĺňóôŕšťúýž]+)",
+        content,
+        re.IGNORECASE,
+    )
+    if name_match is None:
+        return ""
+    parts = [" ".join(name_match.group(1).strip(" ,.;").split())]
+    tail = content[name_match.end() : name_match.end() + 220]
+    address_match = re.search(r"adresa\s+([^.;]+?)(?:,\s*c[ií]slo|\s+c[ií]slo|$)", tail, re.IGNORECASE)
+    id_match = re.search(r"(?:c[ií]slo\s+obcianskeho)\s*:?\s*([A-Z0-9-]+)", tail, re.IGNORECASE)
+    if address_match is not None:
+        parts.append(f"adresa {address_match.group(1).strip(' ,.')}")
+    if id_match is not None:
+        parts.append(f"cislo OP {id_match.group(1).strip(' ,.')}")
+    return ", ".join(parts)
+
+
+def _extract_loan_lender(content: str) -> str:
+    normalized = _canonicalize_slovak_text(content)
+    if "som pozicala" in normalized:
+        return "Poskytovatelka pozicky bude doplnena pred podpisom."
+    if "som pozical" in normalized:
+        return "Poskytovatel pozicky bude doplneny pred podpisom."
+    return ""
+
+
+def _build_slovak_payment_confirmation_document_lines(facts: dict[str, object]) -> list[str]:
+    if facts["document_kind"] == "loan_confirmation":
+        return [
+            "Potvrdenie o pozicke",
+            "",
+            f"Poskytovatel pozicky: {facts['payer']}",
+            f"Dlznik: {facts['recipient']}",
+            f"Suma pozicky: {facts['amount']}",
+            f"Doba vratenia / splatnost: {facts['due_date']}",
+            f"Ucel dokumentu: {facts['purpose']}",
+            "",
+            "Vyhlasenie:",
+            (
+                "Dlznik potvrdzuje, ze od poskytovatela pozicky prevzal penazne prostriedky "
+                "v uvedenej sume a zavazuje sa ich vratit v dohodnutej lehote."
+            ),
+            (
+                "Strany potvrdzuju, ze tento dokument je pisomnym dokladom o poskytnuti pozicky. "
+                "Pred podpisom je potrebne doplnit presnu sumu, datum odovzdania, sposob odovzdania "
+                "a uplne identifikacne udaje oboch stran."
+            ),
+            "",
+            "V [mesto], dna [datum vystavenia]",
+            "",
+            "Podpis poskytovatela pozicky: _______________________________",
+            "Podpis dlznika: _____________________________________________",
+        ]
+    return [
+        "Potvrdenie o zaplateni",
+        "",
+        f"Platitel: {facts['payer']}",
+        f"Prijemca: {facts['recipient']}",
+        f"Suma: {facts['amount']}",
+        f"Datum platby: {facts['due_date']}",
+        f"Ucel platby: {facts['purpose']}",
+        "",
+        "Vyhlasenie:",
+        "Prijemca tymto potvrdzuje, ze od platitela prijal vyssie uvedenu platbu.",
+        "",
+        "V [mesto], dna [datum vystavenia]",
+        "",
+        "Podpis prijemcu: _______________________________",
+    ]
 
 
 def _extract_represented_person(content: str) -> str:

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260518"
+version = "1.0.260519"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -6347,6 +6347,93 @@ def test_pending_payment_confirmation_reply_is_synthesized_for_storage() -> None
     assert "Chvilu prosim" not in body
 
 
+def test_exact_loan_confirmation_prompt_uses_direct_document_flow(monkeypatch) -> None:
+    import app.chat.api as chat_api
+    from app.chat.models import MessageRole, Session
+    from app.chat.repository import InMemoryChatRepository
+
+    stored_documents: list[dict[str, object]] = []
+
+    class _FakeStore:
+        def list_case_documents(self, *, case_id: str):
+            return []
+
+        def add_case_document(
+            self,
+            *,
+            case_id: str,
+            kind: str,
+            version: int,
+            original_filename: str,
+            payload: bytes,
+            uploaded_by_user_id: str | None = None,
+        ) -> str:
+            doc_id = f"doc-generated-{len(stored_documents) + 1}"
+            stored_documents.append(
+                {
+                    "case_id": case_id,
+                    "kind": kind,
+                    "version": version,
+                    "original_filename": original_filename,
+                    "payload": payload.decode("utf-8"),
+                    "uploaded_by_user_id": uploaded_by_user_id,
+                }
+            )
+            return doc_id
+
+    def _unexpected_lawyer_agent(*_args, **_kwargs):
+        raise AssertionError("Loan confirmation prompt should not fall through to model echo")
+
+    repository = InMemoryChatRepository()
+    monkeypatch.setattr(chat_api, "_repository", repository)
+    monkeypatch.setattr(chat_api, "_get_store", lambda: _FakeStore())
+    monkeypatch.setattr(chat_api, "_persist_case_message_if_needed", lambda **_kwargs: None)
+    monkeypatch.setattr(chat_api, "_record_case_ai_model_audit", lambda **_kwargs: None)
+    monkeypatch.setattr("aijurisdictionagents.agents.create_lawyer_agent", _unexpected_lawyer_agent)
+
+    session_id = uuid4()
+    session = repository.create_session(
+        Session(
+            id=session_id,
+            user_id=uuid4(),
+            case_id="case-loan-513",
+            country="SK",
+            language="SK",
+            discussion_type="advice",
+        )
+    )
+    prompt = (
+        "Chcem pozicat peniaze na 1 rok a chcem nejake potvrdenie o tom ze som "
+        "pozicala peniaze Jankovi hraskovi, adresa testova 10, Poprad, Slovensko, "
+        "cislo obcianskeho: BA12345DR."
+    )
+
+    _user, lawyer, visible, events, route = chat_api._run_direct_lawyer_turn(
+        session_id=session_id,
+        session=session,
+        content=prompt,
+    )
+
+    assert route is None
+    assert events and events[0]["stage"] == "document_ready"
+    assert lawyer.role == MessageRole.ASSISTANT
+    assert visible != prompt
+    assert "Potvrdenie o pozicke" in visible
+    assert "Odporucane kroky pred pouzitim" in visible
+    assert "CASE_UPDATE_JSON" not in visible
+    assert "Ktor" not in visible
+    generated_documents = [
+        item for item in stored_documents if item["kind"] == "generated_document"
+    ]
+    assert len(generated_documents) == 1
+    assert str(generated_documents[0]["original_filename"]).startswith("potvrdenie_o_pozicke_")
+    payload = str(generated_documents[0]["payload"])
+    assert "Potvrdenie o pozicke" in payload
+    assert "Jankovi hraskovi" in payload
+    assert "BA12345DR" in payload
+    assert "CASE_UPDATE_JSON" not in payload
+
+
 def test_technical_document_notice_does_not_block_pdf_export_readiness() -> None:
     from app.chat.api import _build_direct_reply_result
     from app.chat.models import Message, MessageRole, Session

--- a/docs/assistant_architecture.md
+++ b/docs/assistant_architecture.md
@@ -23,6 +23,8 @@ The frontend renders per-answer citations below assistant answers and a deduplic
 
 For generated legal-document drafts, the live assistant stream and the hydrated case-history path must converge on the same user-visible output. If the stream finishes with a progress sentence but the refreshed case history contains a formatted document preview or generated-document action, the frontend shows the hydrated preview/action immediately and keeps the same preview/action after reload. This prevents users from seeing terminal PDF-progress text when the generated document is already persisted.
 
+Narrow Slovak requests for a payment confirmation or a simple loan confirmation can use a deterministic direct-reply path when the user already asks for the document and the required facts can be represented with placeholders for missing values. This path must still return practical next steps, mark the output as an AI-assisted legal-risk draft needing human review, persist a generated `case.documents` entry with the legal-document body, and avoid sending personal identifiers to an external model merely to classify the request.
+
 Legal-source citations carry retrieval provenance. JurisDigta MCP/vector results use source score `1.0` and retrieval tools such as `JurisDigta MCP searchLaws` or `JurisDigta MCP searchCourtDecisions`. If the system vector DB has no reliable legal source, the backend may use `AIWebSearchAgent` only for official legal sources such as Slov-Lex or official court-decision pages; these fallback citations use source score `0.9`, `source_type=web`, and must render a visible warning that the source came from official web search rather than the JurisDigta system vector DB.
 
 ## Quality Target

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -106,6 +106,11 @@ print(
     "case-history previews and generated-document actions over terminal PDF progress text."
 )
 print(
+    "loan_confirmation_document_flow => Slovak one-year loan confirmation requests are routed to "
+    "the direct generated-document flow with next steps, human-review disclosure, and a persisted "
+    "potvrdenie_o_pozicke PDF export body instead of echoing the user prompt."
+)
+print(
     "multilingual_document_exports => CASE_UPDATE_JSON case.documents entries are saved/exported "
     "as separate clean documents by default; use bundle=single_pdf only when one combined PDF is requested."
 )


### PR DESCRIPTION
﻿## Summary
- Fixes Slovak loan-confirmation prompts so they use the direct generated-document flow instead of falling through to model echo.
- Persists a `Potvrdenie o pozicke` generated document body with a safe export filename and user-visible next steps/human-review disclosure.
- Adds regression coverage for the exact production prompt and updates architecture docs plus the minimal demo.

## Validation
- `./scripts/validate_api.ps1`
- `./conda/python.exe -m pytest api/aijuristiction-api/tests/test_chat.py -k "loan_confirmation_prompt or generated_payment_confirmation_document_uses_legal_filename or pending_payment_confirmation_reply_is_synthesized_for_storage"`
- `./conda/python.exe examples/minimal_demo.py`

## Notes
- Full `./conda/python.exe -m pytest api/aijuristiction-api/tests` was attempted twice and timed out at 5 minutes and 10 minutes before returning a result.

Fixes #513
