### PR TITLE
Fix Slovak private loan confirmation document route

### DIFF
--- a/api/aijuristiction-api/app/chat/api.py
+++ b/api/aijuristiction-api/app/chat/api.py
@@ -3766,6 +3766,26 @@ def _generated_case_document_body_for_storage(content: str) -> str:
 
 def _synthesized_generated_case_document_body_for_storage(content: str) -> str:
     normalized = _canonicalize_document_text(content)
+    if (
+        "potvrdenie" in normalized
+        and any(token in normalized for token in ("pozic", "pozick", "pozical", "dlznik", "dlznika"))
+        and any(marker in normalized for marker in ("na stiahnutie", "pripravil som navrh", "pripravim finalne"))
+    ):
+        if "?" in normalized[-180:]:
+            return ""
+        visible_lines = [line.strip() for line in _user_visible_text(content).splitlines()]
+        start_index = next(
+            (
+                index
+                for index, line in enumerate(visible_lines)
+                if "potvrdenie o pozicke" in _canonicalize_document_text(line)
+            ),
+            -1,
+        )
+        if start_index >= 0:
+            body = "\n".join(line for line in visible_lines[start_index:] if line).strip()
+            if body:
+                return body
     if not (
         "potvrdenie" in normalized
         and any(token in normalized for token in ("zaplat", "uhrad", "platb"))
@@ -3802,6 +3822,8 @@ def _generated_case_document_legal_title(value: str) -> str:
         return "Power of Attorney"
     if "splnomocnenie" in normalized or "plnomocenstvo" in normalized:
         return "Splnomocnenie"
+    if "potvrdenie" in normalized and any(token in normalized for token in ("pozic", "pozick", "pozical")):
+        return "Potvrdenie o pozicke"
     if "potvrdenie" in normalized and any(token in normalized for token in ("zaplat", "uhrad", "platb")):
         return "Potvrdenie o zaplatení"
     return title

--- a/api/aijuristiction-api/app/chat/country_services/slovakia.py
+++ b/api/aijuristiction-api/app/chat/country_services/slovakia.py
@@ -81,6 +81,34 @@ def prepare_slovakia_direct_reply(
     )
     company_query = _extract_slovak_company_query(messages=messages, current_content=current_content)
     has_company_query = bool(company_query)
+    payment_or_loan_confirmation_requested = _looks_like_payment_confirmation_final_request(
+        current_content=current_content,
+        prior_messages=prior_messages,
+    )
+    if payment_or_loan_confirmation_requested and not has_company_query:
+        direct_processing_events: list[dict[str, object]] = []
+        emit_processing_event(
+            events=direct_processing_events,
+            event=build_processing_event(
+                stage="analysis",
+                message="Analyzujem poziadavku na slovenske potvrdenie o platbe alebo pozicke.",
+            ),
+            callback=processing_event_callback,
+        )
+        _append_payment_confirmation_validation_events(
+            events=direct_processing_events,
+            current_content=current_content,
+            company_record=None,
+            callback=processing_event_callback,
+        )
+        return DirectReplyPreparation(
+            supplemental_documents=[],
+            direct_reply=_build_slovak_payment_confirmation_ready_reply(
+                current_content=current_content,
+                company_record=None,
+            ),
+            processing_events=direct_processing_events,
+        )
     if (
         not asks_company_registry_info
         and not looks_like_company_document
@@ -176,10 +204,7 @@ def prepare_slovakia_direct_reply(
             callback=processing_event_callback,
         )
 
-    if _looks_like_payment_confirmation_final_request(
-        current_content=current_content,
-        prior_messages=prior_messages,
-    ):
+    if payment_or_loan_confirmation_requested:
         _append_payment_confirmation_validation_events(
             events=processing_events,
             current_content=current_content,
@@ -491,11 +516,12 @@ def _looks_like_payment_confirmation_final_request(
         message.content for message in prior_messages if message.role == MessageRole.USER
     )
     normalized = _canonicalize_slovak_text(f"{user_context} {current_content}")
-    if "potvrdenie" not in normalized or not any(
-        token in normalized for token in ("zaplat", "uhrad", "platb", "splatk")
-    ):
+    payment_tokens = ("zaplat", "uhrad", "platb", "splatk")
+    loan_tokens = ("pozic", "pozick", "pozical", "pozicala", "pozicali", "dlh", "dlzn")
+    if "potvrdenie" not in normalized or not any(token in normalized for token in payment_tokens + loan_tokens):
         return False
     final_markers = (
+        "chcem",
         "pdf",
         "vygeneruj",
         "generuj",
@@ -504,6 +530,7 @@ def _looks_like_payment_confirmation_final_request(
         "konecnu",
         "konecna",
         "priprav",
+        "vytvor",
     )
     return any(marker in normalized for marker in final_markers)
 
@@ -575,6 +602,10 @@ def _build_slovak_payment_confirmation_ready_reply(
         current_content=current_content,
         company_record=company_record,
     )
+    document_body = "\n".join(_build_slovak_confirmation_document_lines(facts))
+    document_title = "Potvrdenie o pozicke" if facts["document_kind"] == "loan_confirmation" else "Potvrdenie o zaplateni"
+    document_filename = "Potvrdenie_o_pozicke.pdf" if facts["document_kind"] == "loan_confirmation" else "Potvrdenie_o_zaplateni.pdf"
+    document_path = f"documents/{document_filename}"
     case_update: dict[str, object] = {
         "case": {
             "case_id": None,
@@ -585,19 +616,21 @@ def _build_slovak_payment_confirmation_ready_reply(
                 "opponent": {"name": facts["recipient"]},
             },
             "matter": {
-                "category": "commercial",
-                "topic": "potvrdenie_o_zaplateni",
+                "category": "civil" if facts["document_kind"] == "loan_confirmation" else "commercial",
+                "topic": facts["document_kind"],
                 "amount_eur": facts["amount_number"],
                 "key_dates": {"splatnost": facts["due_date"]},
                 "facts_summary": facts["purpose"],
-                "client_goal": "Pripravit potvrdenie o zaplateni vo formate PDF.",
+                "client_goal": f"Pripravit {document_title.lower()} vo formate PDF.",
             },
             "documents": [
                 {
                     "doc_id": "DOC-001",
-                    "type": "payment_proof",
-                    "filename": "Potvrdenie_o_zaplateni.pdf",
-                    "path": "documents/Potvrdenie_o_zaplateni.pdf",
+                    "type": facts["document_kind"],
+                    "title": document_title,
+                    "filename": document_filename,
+                    "path": document_path,
+                    "content": document_body,
                     "received_at": datetime.now(timezone.utc).isoformat(),
                     "notes": "Finalny dokument pripraveny na export.",
                 }
@@ -610,12 +643,23 @@ def _build_slovak_payment_confirmation_ready_reply(
     verification_lines = [
         "Tu je konecna verzia dokumentu - dokument je pripraveny na export a stiahnutie.",
         "",
+        "Pripravil som navrh dokumentu. Pred podpisom doplnte chybajuce udaje, skontrolujte totoznost stran a nechajte dokument pravne skontrolovat, ak sa na nom budete spoliehat.",
+        "",
         "Podklady pre export:",
-        f"Platitel: {facts['payer']}",
-        f"Prijemca: {facts['recipient']}",
+        f"Dokument: {document_title}",
+        f"Poskytovatel / platitel: {facts['payer']}",
+        f"Prijemca / dlznik: {facts['recipient']}",
         f"Suma: {facts['amount']}",
-        f"Datum splatnosti / platby: {facts['due_date']}",
-        f"Ucel platby: {facts['purpose']}",
+        f"Doba / datum splatnosti: {facts['due_date']}",
+        f"Ucel: {facts['purpose']}",
+        "",
+        "Odporucane kroky pred pouzitim:",
+        "1. Doplnte presnu sumu pozicky a identifikacne udaje poskytovatela pozicky.",
+        "2. Overte obciansky preukaz a adresu dlznika pred podpisom.",
+        "3. Podpiste dokument oboma stranami; pri vyssej sume zvazte overenie podpisov.",
+        "AI navrh pred pouzitim skontrolujte clovekom.",
+        "",
+        document_body,
     ]
     if facts["company_summary"]:
         verification_lines.extend(["", f"Overenie firmy: {facts['company_summary']}"])
@@ -630,8 +674,10 @@ def _extract_payment_confirmation_request_facts(
     current_content: str,
     company_record: dict[str, object] | None,
 ) -> dict[str, object]:
+    normalized = _canonicalize_slovak_text(current_content)
+    is_loan_confirmation = any(token in normalized for token in ("pozic", "pozick", "pozical", "dlh", "dlzn"))
     amount_match = re.search(r"\b([0-9\s]+(?:[.,][0-9]{1,2})?\s*(?:eur|eu|€))\b", current_content, re.IGNORECASE)
-    amount = " ".join(amount_match.group(1).split()) if amount_match else "5000 EUR"
+    amount = " ".join(amount_match.group(1).split()) if amount_match else "Suma bude doplnena pred podpisom."
     amount_number_match = re.search(r"[0-9]+(?:[.,][0-9]{1,2})?", amount.replace(" ", ""))
     amount_number = float(amount_number_match.group(0).replace(",", ".")) if amount_number_match else None
     due_match = re.search(
@@ -639,11 +685,21 @@ def _extract_payment_confirmation_request_facts(
         current_content,
         re.IGNORECASE,
     )
-    due_date = due_match.group(1) if due_match else "Dátum bude doplnený pred podpisom."
+    loan_term_match = re.search(
+        r"\bna\s+([0-9]+)\s*(rok|roky|rokov|mesiac|mesiace|mesiacov)\b",
+        current_content,
+        re.IGNORECASE,
+    )
+    if due_match:
+        due_date = due_match.group(1)
+    elif loan_term_match:
+        due_date = f"{loan_term_match.group(1)} {loan_term_match.group(2)} od odovzdania pozicky"
+    else:
+        due_date = "Datum bude doplneny pred podpisom."
     spz = _extract_slovak_spz(current_content)
-    purpose = "splátka auta"
+    purpose = "potvrdenie o prijati pozicky" if is_loan_confirmation else "splatka auta"
     if spz:
-        purpose = f"splátka auta so SPZ {spz}"
+        purpose = f"splatka auta so SPZ {spz}"
     company_name = str((company_record or {}).get("name") or "").strip()
     company_ico = str((company_record or {}).get("registration_number") or "").strip()
     company_seat = str((company_record or {}).get("seat") or "").strip()
@@ -658,9 +714,13 @@ def _extract_payment_confirmation_request_facts(
             )
             if part
         )
-    recipient = company_summary or company_name or "Príjemca bude doplnený pred podpisom."
-    payer = _extract_represented_person(current_content) or "Marek Matonok"
+    borrower_name = _extract_private_loan_borrower(current_content)
+    borrower_address = _extract_private_loan_address(current_content)
+    borrower_id = _extract_private_loan_identity_number(current_content)
+    recipient = company_summary or company_name or borrower_name or "Prijemca bude doplneny pred podpisom."
+    payer = _extract_represented_person(current_content) or "Poskytovatel pozicky bude doplneny pred podpisom."
     return {
+        "document_kind": "loan_confirmation" if is_loan_confirmation else "payment_confirmation",
         "amount": amount,
         "amount_number": amount_number,
         "due_date": due_date,
@@ -669,7 +729,90 @@ def _extract_payment_confirmation_request_facts(
         "recipient": recipient,
         "payer": payer,
         "company_summary": company_summary,
+        "borrower_address": borrower_address,
+        "borrower_id": borrower_id,
     }
+
+
+def _extract_private_loan_borrower(content: str) -> str:
+    patterns = (
+        r"pozicala\s+peniaze\s+([^,.;]+)",
+        r"pozical\s+peniaze\s+([^,.;]+)",
+        r"pozicat\s+peniaze\s+[^,.;]*?\s+([A-ZÁÄČĎÉÍĹĽŇÓÔŔŠŤÚÝŽ][^,.;]+)",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, content, flags=re.IGNORECASE)
+        if match is not None:
+            return " ".join(match.group(1).strip().split())
+    return ""
+
+
+def _extract_private_loan_address(content: str) -> str:
+    match = re.search(r"\badresa\s+([^.;]+?)(?:,\s*(?:cislo|číslo)\b|$)", content, flags=re.IGNORECASE)
+    if match is None:
+        return ""
+    return " ".join(match.group(1).strip(" ,").split())
+
+
+def _extract_private_loan_identity_number(content: str) -> str:
+    match = re.search(
+        r"(?:cislo|číslo)\s+obcianskeho\s*[:=]?\s*([A-Z0-9-]+)",
+        content,
+        flags=re.IGNORECASE,
+    )
+    if match is None:
+        return ""
+    return match.group(1).strip().upper()
+
+
+def _build_slovak_confirmation_document_lines(facts: dict[str, object]) -> list[str]:
+    if facts["document_kind"] != "loan_confirmation":
+        return [
+            "Potvrdenie o zaplateni",
+            "",
+            f"Platitel: {facts['payer']}",
+            f"Prijemca: {facts['recipient']}",
+            f"Suma: {facts['amount']}",
+            f"Datum platby / splatnosti: {facts['due_date']}",
+            f"Ucel platby: {facts['purpose']}",
+            "",
+            "Vyhlasenie:",
+            "Prijemca tymto potvrdzuje prijatie uvedenej platby od platitela.",
+            "",
+            "V [mesto], dna [datum vystavenia]",
+            "",
+            "Podpis prijemcu: _______________________________",
+        ]
+    borrower_address = str(facts.get("borrower_address") or "Adresa dlznika bude doplnena pred podpisom.")
+    borrower_id = str(facts.get("borrower_id") or "Cislo dokladu bude doplnene pred podpisom.")
+    return [
+        "Potvrdenie o pozicke",
+        "",
+        f"Poskytovatel pozicky: {facts['payer']}",
+        f"Dlznik: {facts['recipient']}",
+        f"Adresa dlznika: {borrower_address}",
+        f"Cislo obcianskeho preukazu dlznika: {borrower_id}",
+        f"Suma pozicky: {facts['amount']}",
+        f"Doba / splatnost pozicky: {facts['due_date']}",
+        "",
+        "Vyhlasenie:",
+        (
+            "Poskytovatel pozicky tymto potvrdzuje, ze dlznikovi odovzdal penaznu pozicku "
+            "v uvedenej sume. Dlznik podpisom potvrdzuje prevzatie pozicky a zavazuje sa ju "
+            "vratit v uvedenej dobe, ak sa strany pisomne nedohodnu inak."
+        ),
+        "",
+        "Poznamka:",
+        (
+            "Pred podpisom doplnte presnu sumu, datum odovzdania penazi a identifikacne udaje "
+            "poskytovatela pozicky. Pri vyssej sume zvazte overenie podpisov."
+        ),
+        "",
+        "V [mesto], dna [datum vystavenia]",
+        "",
+        "Podpis poskytovatela pozicky: _______________________________",
+        "Podpis dlznika: _______________________________",
+    ]
 
 
 def _extract_represented_person(content: str) -> str:

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260519"
+version = "1.0.260520"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -3845,6 +3845,51 @@ def test_slovak_payment_confirmation_final_request_uses_tool_first_direct_reply(
     assert any(event.get("tool_name") == "slovakia_car_validate" for event in events)
 
 
+def test_slovak_private_loan_confirmation_first_turn_generates_document() -> None:
+    import app.chat.api as chat_api
+    from app.chat.country_services.slovakia import prepare_slovakia_direct_reply
+    from app.chat.models import Message, MessageRole, Session
+
+    session = Session(country="SK", language="sk-SK")
+    current_content = (
+        "Chcem pozicat peniaze na 1 rok a chcem nejake potvrdenie o tom ze som pozicala peniaze "
+        "Jankovi hraskovi, adresa testova 10, Poprad, Slovensko, cislo obcianskeho: BA12345DR."
+    )
+    messages = [Message(session_id=session.id, role=MessageRole.USER, content=current_content)]
+
+    preparation = prepare_slovakia_direct_reply(
+        session=session,
+        messages=messages,
+        current_content=current_content,
+        prior_messages=[],
+        normalize_document_lines=lambda text: [text],
+        extract_document_facts=lambda lines: {},
+        current_turn_confirms_document_generation=lambda content, previous_messages: False,
+        build_share_transfer_lines=lambda facts: [],
+    )
+
+    assert preparation.direct_reply is not None
+    assert "Potvrdenie o pozicke" in preparation.direct_reply
+    assert "Jankovi hraskovi" in preparation.direct_reply
+    assert "BA12345DR" in preparation.direct_reply
+    assert "Podpis poskytovatela pozicky" in preparation.direct_reply
+    assert "Podpis dlznika" in preparation.direct_reply
+    assert "CASE_UPDATE_JSON" in preparation.direct_reply
+
+    case_update = chat_api._extract_case_update(preparation.direct_reply)
+    drafts = chat_api._generated_case_document_drafts_from_case_update(
+        case_update,
+        timestamp="20260711T080000Z",
+    )
+
+    assert len(drafts) == 1
+    assert drafts[0].filename == "potvrdenie_o_pozicke_20260711T080000Z.pdf"
+    assert "Potvrdenie o pozicke" in drafts[0].body
+    assert "Jankovi hraskovi" in drafts[0].body
+    assert "BA12345DR" in drafts[0].body
+    assert "CASE_UPDATE_JSON" not in drafts[0].body
+
+
 def test_first_turn_final_pdf_payment_request_counts_as_export_ready() -> None:
     from app.chat.api import _document_export_ready, _document_generation_confirmed
     from app.chat.models import Message, MessageRole, Session

--- a/docs/CASE_EXPORT_TEST_FIXTURES.md
+++ b/docs/CASE_EXPORT_TEST_FIXTURES.md
@@ -34,6 +34,8 @@ Use this folder for correct question/answer/document examples that should remain
 
 This fixture database supports the broader frontend/browser test solution in GitHub issue `#422` for account, billing, invoice, and admin E2E coverage. Keep `#422` as the main browser test initiative and use `tests/modelsTesting` as the reusable legal-answer/document fixture layer for scenarios that need model-output comparison.
 
+Regression issue `#518` keeps the Slovak private loan-confirmation prompt deterministic: a first-turn request such as "Chcem pozicat peniaze na 1 rok..." must route to a legal-document draft with a `CASE_UPDATE_JSON.case.documents[*].content` body, so generated-document storage and PDF export do not depend on local model wording.
+
 ## Compliance Notes
 
 - Export only the minimum fixture set required for validation.

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -327,3 +327,8 @@ print(
     "latest imported court decision short name and published date without exposing "
     "court decision text, parties, file numbers, ECLI values, or source identifiers."
 )
+print(
+    "loan_confirmation_regression => Slovak first-turn private loan confirmation "
+    "requests route deterministically to CASE_UPDATE_JSON case.documents content "
+    "and generated PDF export instead of local-model echo text."
+)


### PR DESCRIPTION
Fixes #518.\n\n## Summary\n- routes first-turn Slovak private loan-confirmation prompts before the non-company early return\n- recognizes loan wording such as pozicat/pozicala/pozicka and extracts borrower address/ID/term\n- embeds the legal document body in CASE_UPDATE_JSON case.documents content for deterministic generated-document/PDF export\n- adds regression coverage for the exact production prompt\n\n## Validation\n- .\\scripts\\validate_api.ps1\n- .\\conda\\python.exe -m pytest api\\aijuristiction-api\\tests\n- .\\conda\\python.exe -m pytest tests\\test_models_testing_fixtures.py\n- .\\conda\\python.exe examples\\minimal_demo.py