### PR TITLE
Start mobile voice only on user action

### DIFF
--- a/mobile_app/lib/chat/voice_conversation_settings.dart
+++ b/mobile_app/lib/chat/voice_conversation_settings.dart
@@ -3,6 +3,27 @@ import 'dart:convert';
 const String defaultVoiceConversationSettingsStorageKey =
     'mobile_voice_conversation_settings_v1';
 
+class VoiceSessionStartupState {
+  const VoiceSessionStartupState._({
+    required this.speakerOutputEnabled,
+    required this.speechInputEnabled,
+  });
+
+  factory VoiceSessionStartupState.forNewChat(
+    VoiceConversationSettings settings,
+  ) {
+    // Persisted settings configure voice after explicit user activation. They
+    // must never activate the microphone or speaker when a chat is opened.
+    return const VoiceSessionStartupState._(
+      speakerOutputEnabled: false,
+      speechInputEnabled: false,
+    );
+  }
+
+  final bool speakerOutputEnabled;
+  final bool speechInputEnabled;
+}
+
 class VoiceConversationSettings {
   const VoiceConversationSettings({
     required this.recordChatEnabled,
@@ -54,8 +75,7 @@ class VoiceConversationSettings {
       allowBargeIn: allowBargeIn ?? this.allowBargeIn,
       pauseFor: pauseFor ?? this.pauseFor,
       listenFor: listenFor ?? this.listenFor,
-      resumeListeningDelay:
-          resumeListeningDelay ?? this.resumeListeningDelay,
+      resumeListeningDelay: resumeListeningDelay ?? this.resumeListeningDelay,
     );
   }
 

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -4866,13 +4866,12 @@ class _ChatHomePageState extends State<ChatHomePage>
     if (!mounted) {
       return;
     }
+    final startupState = VoiceSessionStartupState.forNewChat(settings);
     setState(() {
       _voiceConversationSettings = settings;
-      if (settings.recordChatEnabled) {
-        _speakerOutputEnabled = true;
-        _speechInputEnabled = true;
-        _speechInputExplicitlyDisabled = false;
-      }
+      _speakerOutputEnabled = startupState.speakerOutputEnabled;
+      _speechInputEnabled = startupState.speechInputEnabled;
+      _speechInputExplicitlyDisabled = false;
     });
     await widget.logger.info(
       'Voice conversation settings loaded',
@@ -4880,9 +4879,6 @@ class _ChatHomePageState extends State<ChatHomePage>
         ..._voiceLogContext('voice_conversation_settings_load'),
       },
     );
-    if (settings.recordChatEnabled && _speechEnabled && !_isListening) {
-      await _startSpeechListening(resetHandledText: true);
-    }
   }
 
   Future<void> _persistVoiceConversationSettings() async {

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ai_jurisdiction_mobile
-version: 0.1.5+100
+version: 0.1.5+102
 publish_to: none
 
 environment:

--- a/mobile_app/test/voice_conversation_settings_test.dart
+++ b/mobile_app/test/voice_conversation_settings_test.dart
@@ -41,5 +41,18 @@ void main() {
       expect(decoded.allowBargeIn, isTrue);
       expect(decoded.pauseFor, const Duration(seconds: 45));
     });
+
+    test('new chat waits for explicit voice activation', () {
+      final persistedSettings = VoiceConversationSettings.recommended(
+        recordChatEnabled: true,
+      );
+
+      final startupState =
+          VoiceSessionStartupState.forNewChat(persistedSettings);
+
+      expect(persistedSettings.recordChatEnabled, isTrue);
+      expect(startupState.speakerOutputEnabled, isFalse);
+      expect(startupState.speechInputEnabled, isFalse);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- default every newly opened mobile chat to text mode
- preserve saved voice configuration without automatically enabling microphone or speaker output
- activate the configured voice flow only after the user taps the microphone
- add regression coverage for persisted record-chat settings
- bump the mobile build revision to `0.1.5+102`

## Root cause
Loading persisted `recordChatEnabled=true` settings directly enabled speaker output and speech input, then started speech recognition during chat initialization.

## Validation
- `flutter analyze --no-fatal-infos`
- `flutter test` (128 tests passed)
- `git diff --check`

Closes #523