### PR TITLE
Add temporary encrypted dev secrets export

### DIFF
--- a/.github/workflows/temporary_dev_secrets_age_export.yml
+++ b/.github/workflows/temporary_dev_secrets_age_export.yml
@@ -1,0 +1,108 @@
+name: Temporary encrypted dev secrets export
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirmation:
+        description: "Type EXPORT_DEV_SECRETS to create the encrypted artifact"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  export-dev-secrets:
+    if: ${{ inputs.confirmation == 'EXPORT_DEV_SECRETS' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: dev
+    env:
+      AGE_RECIPIENT: age1097msxwal0acva4dxte4ldpuccujcmv7spd869s74xuljlts0ypsg6j7v2
+      AIJ_AZURE_SPEECH_KEY: ${{ secrets.AIJ_AZURE_SPEECH_KEY }}
+      APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}
+      AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+      AZURE_POSTGRES_ADMIN_PASSWORD: ${{ secrets.AZURE_POSTGRES_ADMIN_PASSWORD }}
+      CAR_VALIDATION_API_KEY: ${{ secrets.CAR_VALIDATION_API_KEY }}
+      CORPORATE_WEB_FTP_PASSWORD: ${{ secrets.CORPORATE_WEB_FTP_PASSWORD }}
+      EMAIL_SMTP_PASSWORD: ${{ secrets.EMAIL_SMTP_PASSWORD }}
+      GH_PROJECT_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
+      MOBILE_ANDROID_KEYSTORE_BASE64: ${{ secrets.MOBILE_ANDROID_KEYSTORE_BASE64 }}
+      MOBILE_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.MOBILE_ANDROID_KEYSTORE_PASSWORD }}
+      MOBILE_ANDROID_KEY_ALIAS: ${{ secrets.MOBILE_ANDROID_KEY_ALIAS }}
+      MOBILE_ANDROID_KEY_PASSWORD: ${{ secrets.MOBILE_ANDROID_KEY_PASSWORD }}
+
+    steps:
+      - name: Install age
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends age
+
+      - name: Create encrypted dotenv file
+        id: encrypt
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+
+          plaintext="${RUNNER_TEMP}/dev-secrets.env"
+          encrypted="${RUNNER_TEMP}/dev-secrets.env.age"
+          cleanup() {
+            if [ -f "$plaintext" ]; then
+              shred -u "$plaintext" 2>/dev/null || rm -f "$plaintext"
+            fi
+          }
+          trap cleanup EXIT
+
+          secret_names=(
+            AIJ_AZURE_SPEECH_KEY
+            APPLICATIONINSIGHTS_CONNECTION_STRING
+            AZURE_OPENAI_API_KEY
+            AZURE_POSTGRES_ADMIN_PASSWORD
+            CAR_VALIDATION_API_KEY
+            CORPORATE_WEB_FTP_PASSWORD
+            EMAIL_SMTP_PASSWORD
+            GH_PROJECT_TOKEN
+            MOBILE_ANDROID_KEYSTORE_BASE64
+            MOBILE_ANDROID_KEYSTORE_PASSWORD
+            MOBILE_ANDROID_KEY_ALIAS
+            MOBILE_ANDROID_KEY_PASSWORD
+          )
+
+          missing=()
+          for name in "${secret_names[@]}"; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            printf 'Missing required dev environment secret: %s\n' "${missing[@]}" >&2
+            exit 1
+          fi
+
+          for name in "${secret_names[@]}"; do
+            value="${!name}"
+            if [[ "$value" == *$'\n'* || "$value" == *$'\r'* ]]; then
+              echo "Secret $name contains a newline and cannot be represented safely in dotenv format." >&2
+              exit 1
+            fi
+            printf '%s=%s\n' "$name" "$value" >> "$plaintext"
+          done
+
+          age --encrypt --recipient "$AGE_RECIPIENT" --output "$encrypted" "$plaintext"
+          sha256sum "$encrypted" > "${encrypted}.sha256"
+          echo "encrypted_path=$encrypted" >> "$GITHUB_OUTPUT"
+          echo "checksum_path=${encrypted}.sha256" >> "$GITHUB_OUTPUT"
+          echo "Encrypted 12 dev environment secrets. No plaintext secret values were logged."
+
+      - name: Upload encrypted artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-secrets-age-${{ github.run_id }}
+          path: |
+            ${{ steps.encrypt.outputs.encrypted_path }}
+            ${{ steps.encrypt.outputs.checksum_path }}
+          if-no-files-found: error
+          retention-days: 1

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -6,6 +6,44 @@ Maintenance rule:
 
 - Whenever a GitHub workflow gains new parameters, or infrastructure/deployment setup changes, update this document in the same change so `test` and `prod` setup instructions stay current.
 
+## Temporary encrypted `dev` secret export
+
+The manual `Temporary encrypted dev secrets export` workflow is a short-lived,
+operator-only migration aid. It reads the explicitly allowlisted secrets from the
+protected `dev` GitHub Environment, creates a dotenv file on the hosted runner,
+encrypts it to the repository operator's age recipient, and uploads only the
+encrypted file plus its SHA-256 checksum. The artifact retention period is one day.
+
+Safety requirements:
+
+- Require environment approval for `dev` before running the job.
+- Enter `EXPORT_DEV_SECRETS` in the workflow confirmation input.
+- Never print, inspect, or upload the plaintext file.
+- Delete the workflow after the one-time transfer is complete.
+- Keep `C:\__jurisdigta\age-identity.txt` private and outside Git.
+
+Download the workflow artifact, extract it under `C:\__jurisdigta`, and decrypt it:
+
+```powershell
+age --decrypt `
+  --identity C:\__jurisdigta\age-identity.txt `
+  --output C:\__jurisdigta\.env `
+  C:\__jurisdigta\dev-secrets.env.age
+```
+
+Confirm the encrypted download before decryption when the checksum file is present:
+
+```powershell
+$expected = (Get-Content C:\__jurisdigta\dev-secrets.env.age.sha256).Split()[0]
+$actual = (Get-FileHash C:\__jurisdigta\dev-secrets.env.age -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($actual -ne $expected) { throw "Encrypted artifact checksum mismatch" }
+```
+
+The resulting `.env` contains only the 12 allowlisted GitHub Environment secrets;
+it does not include ordinary `dev` Environment variables. Apply restrictive local
+ACLs and merge it with the required non-secret configuration rather than treating
+it as a complete runtime configuration.
+
 ## Goal
 
 Create two new GitHub Environments:


### PR DESCRIPTION
## Summary
- add a manual workflow bound to the protected \dev\ GitHub Environment
- export the 12 explicitly allowlisted environment secrets only
- encrypt the dotenv payload to the operator age recipient before upload
- retain the encrypted artifact for one day and document verification/decryption/cleanup

## Safety
- requires the exact \EXPORT_DEV_SECRETS\ confirmation
- grants only \contents: read\`n- never logs or uploads plaintext secret values
- removes the plaintext runner file through an exit trap

## Validation
- \ctionlint v1.7.12\`n- \git diff --check\`n- local age encrypt/decrypt round-trip using the configured recipient