### PR TITLE
Implement profile-aware environment consolidation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# Canonical key schema only; never add real secrets here.
+# Profiles and required/optional classification: config/env_profiles.json and docs/ENV_VARIABLES.md.
+# Local application profiles materialize to ignored .env; temporary Azure infrastructure uses ignored .env.dev.
+# Audit before implementation: .\scripts\sync_env_profile.ps1 -Mode Audit -Profile codex-agent -Strict
 # API chat model selection is resolved from database model-routing tables.
 # LLM_PROVIDER is only for deterministic offline tests when explicitly set to mock.
 # LLM_PROVIDER=mock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,10 @@ Environment variable rule:
 
 - Whenever you add a new environment variable to the project, add a documented example entry to `.env.example` in the same change.
 - Whenever `.env.example` changes, update local `.env` from it before sharing runtime configuration. Missing keys must be added to `.env` with the value `unknown-variable` so startup and sync tooling can warn clearly without guessing secrets.
-- Use `.\scripts\sync_jurisdigta_env.ps1` to sync local environment configuration. The script copies SSH key material from `E:\jurisdigta\ssh` into the dedicated local SSH folder, updates local `.env`, and transfers the full `.env` to `jurisdigta-server:/srv/jurisdigta/secrets/jurisdigta.env` with restrictive permissions.
+- Before the first project command or code edit for every implementation task, run `.\scripts\sync_env_profile.ps1 -Mode Pull -Profile codex-agent`. Codex must invoke the script and may inspect only its redacted key-name/status output, never `.env` or secret values. If the server is unavailable, run `-Mode Audit -Profile codex-agent -Strict`; continue only with a previously verified local profile. This gate does not apply to read-only review or task preparation.
+- Use `.\scripts\sync_env_profile.ps1` for profile-aware audit/bootstrap/pull. The encrypted USB on `jurisdigta-server` is authoritative; developer push is prohibited. `.\scripts\sync_jurisdigta_env.ps1` is legacy and must not be used to publish laptop secrets.
 - Keep `.env` and private keys out of Git. The server copy is a runtime secret file, not a shared source-controlled artifact.
+- Keep temporary Azure infrastructure values in ignored `.env.dev`; pass it explicitly with `-EnvFilePath .env.dev`. Application startup must not assume `.env.dev` is loaded.
 
 LLM provider default rule:
 

--- a/Deployment/server/install_env_usb_profile.sh
+++ b/Deployment/server/install_env_usb_profile.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+profile="${1:-}"
+source_file="${2:-}"
+usb_root="${JURISDIGTA_ENV_USB_ROOT:-/mnt/jurisdigta-backup/jurisdigta-env/profiles}"
+runtime_file="${JURISDIGTA_RUNTIME_ENV:-/srv/jurisdigta/secrets/jurisdigta.env}"
+
+if [[ ! "$profile" =~ ^(local-core|codex-agent|laws-collector|azure-dev|mcp-local)$ ]]; then
+  echo "Unsupported profile name." >&2
+  exit 2
+fi
+if [[ ! -f "$source_file" ]]; then
+  echo "Operator source file does not exist." >&2
+  exit 2
+fi
+mountpoint -q "$(dirname "$(dirname "$usb_root")")" || { echo "Expected encrypted USB mount is unavailable." >&2; exit 3; }
+install -d -m 0700 "$usb_root"
+temporary="$(mktemp "$usb_root/.${profile}.XXXXXX")"
+trap 'rm -f "$temporary"' EXIT
+install -m 0600 "$source_file" "$temporary"
+mv -f "$temporary" "$usb_root/$profile.env"
+
+if [[ "$profile" == "local-core" ]]; then
+  install -d -m 0700 "$(dirname "$runtime_file")"
+  runtime_temporary="$(mktemp "$(dirname "$runtime_file")/.jurisdigta.env.XXXXXX")"
+  install -m 0600 "$usb_root/$profile.env" "$runtime_temporary"
+  mv -f "$runtime_temporary" "$runtime_file"
+fi
+echo "Installed profile $profile; values were not displayed."

--- a/README.md
+++ b/README.md
@@ -311,8 +311,16 @@ Case storage (Slovak advice mode):
 - Uploaded files are copied to `cases/<case-id>/documents/` with a date prefix.
 - Use `--case-id <guid>` to append a new discussion entry to an existing case.
 
-Environment variables are loaded from `.env` if present. Copy `.env.example` to `.env`
-and edit as needed.
+Environment variables are loaded from `.env` if present. `.env.example` is the
+key schema; profile rules are documented in `docs/ENV_VARIABLES.md`. Audit a
+local profile without printing values:
+
+```powershell
+.\scripts\sync_env_profile.ps1 -Mode Audit -Profile local-core -Strict
+```
+
+Temporary Azure infrastructure settings use ignored `.env.dev` and must be
+passed explicitly to infrastructure scripts.
 
 To use OpenAI, set:
 

--- a/config/env_profiles.json
+++ b/config/env_profiles.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "local-core": {"required": ["DB_OPTION", "DB_LOCAL", "STORAGE_OPTION", "STORE_LOCAL"], "optional": ["LLM_PROVIDER", "SYSTEM_STATUS_FILE"]},
+    "codex-agent": {"extends": ["local-core"], "required": ["SYSTEM_EMBEDDING_MODEL_OPTION", "SYSTEM_EMBEDDING_MODEL"], "optional": ["AI_MODEL_CREDENTIAL_ENCRYPTION_KEY"]},
+    "laws-collector": {"extends": ["local-core"], "required": ["LAWS_COUNTRY", "LAWS_STORAGE_LOCAL", "LAWS_WORKER_FIXTURE", "LAWS_WORKER_MAX_CYCLES", "LAWS_WORKER_MAX_PROBES"]},
+    "azure-dev": {"required": ["AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_TENANT_ID", "AZURE_SUBSCRIPTION_ID", "AZURE_RESOURCE_GROUP", "AZURE_LOCATION"]},
+    "mcp-local": {"extends": ["local-core"], "required": ["MCP_PORT", "MCP_API_JWT_SECRET", "MCP_CORS_ALLOW_ORIGINS"]}
+  }
+}

--- a/docs/ENV_SYNC.md
+++ b/docs/ENV_SYNC.md
@@ -1,5 +1,24 @@
 # JurisDigta Environment Sync
 
+> **Current canonical workflow:** use `scripts/sync_env_profile.ps1` and
+> `docs/ENV_VARIABLES.md`. The encrypted USB attached to `jurisdigta-server` is
+> authoritative and developer laptops pull profiles. The older
+> `sync_jurisdigta_env.ps1` push flow is retained only for historical reference
+> and must not be used to publish a laptop `.env`.
+
+Run the mandatory redacted implementation gate with:
+
+```powershell
+.\scripts\sync_env_profile.ps1 -Mode Pull -Profile codex-agent
+```
+
+If the trusted server is temporarily unavailable, audit the last verified local
+copy without retrieving secrets:
+
+```powershell
+.\scripts\sync_env_profile.ps1 -Mode Audit -Profile codex-agent -Strict
+```
+
 This runbook defines how workstation `.env` files are aligned with `.env.example`
 and copied to the self-managed `jurisdigta-server`.
 

--- a/docs/ENV_VARIABLES.md
+++ b/docs/ENV_VARIABLES.md
@@ -1,0 +1,57 @@
+# Environment Profiles
+
+`.env.example` is the key schema; it never contains real secrets. Developer files
+`.env` and `.env.dev` are ignored. The encrypted USB attached to
+`jurisdigta-server` is the authoritative shared value store.
+
+## Classification
+
+| Profile | File | Purpose | Required-key source |
+|---|---|---|---|
+| `local-core` | `.env` | Local API and agent development | `config/env_profiles.json` |
+| `codex-agent` | `.env` | AI-agent implementation/testing | Extends `local-core` |
+| `laws-collector` | `.env` | Production-style local laws collection | Extends `local-core` |
+| `mcp-local` | `.env` | Local MCP transport/authentication | Extends `local-core` |
+| `azure-dev` | `.env.dev` | Temporary Azure development infrastructure | Separate explicit profile |
+
+Every key in `.env.example` is part of the schema. Keys listed as `required` in
+the selected profile are blocking; all other schema keys are optional for that
+profile. Optional inactive keys should be absent or commented, not active with
+`unknown-variable`. Secret-like keys never receive guessed defaults.
+
+## Commands
+
+```powershell
+.\scripts\sync_env_profile.ps1 -Mode Audit -Profile codex-agent -Strict
+.\scripts\sync_env_profile.ps1 -Mode Bootstrap -Profile local-core
+.\scripts\sync_env_profile.ps1 -Mode Pull -Profile codex-agent
+.\scripts\sync_env_profile.ps1 -Mode Audit -Profile azure-dev -EnvFilePath .env.dev -Strict
+```
+
+Output contains key names and states only. `Pull` uses pinned SSH host
+verification, downloads to a temporary protected location, merges atomically,
+validates, restores the previous local file on failure, and removes temporary
+files. There is no developer push mode.
+
+## USB layout
+
+The encrypted USB mount provides:
+
+```text
+/mnt/jurisdigta-backup/jurisdigta-env/profiles/
+  local-core.env
+  codex-agent.env
+  laws-collector.env
+  azure-dev.env
+  mcp-local.env
+```
+
+Use `Deployment/server/install_env_usb_profile.sh` as a privileged operator.
+The USB must already satisfy issue #395 encryption, mount, retention, integrity,
+and recovery-key requirements. The runtime server file is an atomic materialized
+copy, not another authority.
+
+Audit events may record actor, profile, key name, result, and checksum/version.
+They must never record values, prompts, documents, personal data, or legal-case
+content. Revoke developer SSH access during offboarding and securely delete
+local materialized files and backups.

--- a/docs/manual_infrastucture_setup.md
+++ b/docs/manual_infrastucture_setup.md
@@ -656,3 +656,14 @@ The self-managed production deployment script performs the Ollama install, priva
 - Local model routing keeps case content inside JurisDigta-controlled infrastructure, but normal server access controls, retention, deletion, and privacy-safe logging still apply.
 - Keep legal-risk outputs subject to human oversight before production traffic is enabled.
 - For Cloudflare Tunnel and Access, avoid logging personal data, legal documents, API keys, database credentials, or full user prompts in edge, dashboard, or application logs.
+
+### Encrypted USB environment profile store
+
+- Owner: JurisDigta server operator. The USB encryption/recovery key must be held outside the USB and outside Git/Codex context.
+- Prerequisite: complete issue #395 encryption, stable UUID mount, integrity, retention, and recovery controls for `/mnt/jurisdigta-backup`.
+- Store profiles under `/mnt/jurisdigta-backup/jurisdigta-env/profiles` with directory mode `0700` and files mode `0600`.
+- Install or rotate a profile with `sudo Deployment/server/install_env_usb_profile.sh <profile> <operator-source-file>`; the command never prints values.
+- Validate from a developer laptop with `.\scripts\sync_env_profile.ps1 -Mode Pull -Profile codex-agent`. Pinned SSH host verification and per-developer keys are mandatory.
+- Revoke a departing developer's SSH key, delete their local `.env`/`.env.dev` and protected backups, and retain only the approved server audit event containing actor, profile, key names, version/checksum, and result.
+- Rollback uses the encrypted/versioned USB backup repository from issue #395. Restore into an isolated location, audit names/checksums without values, then materialize atomically.
+- If the USB is missing, has the wrong UUID, is read-only/full, or fails integrity validation, fail closed and alert through privacy-safe monitoring. Never fall back to a plaintext laptop push.

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -6,6 +6,11 @@ from aijurisdictionagents.agents.audio_action_tools import AIAudioToolRecognizer
 from aijurisdictionagents.api_db import ApiDatabaseStore, CASE_WRITE_WINDOW_EXPIRED_CODE
 from aijurisdictionagents.api_db.e2e_test_users import provision_e2e_test_users
 
+print(
+    "env_profiles => run scripts/sync_env_profile.ps1 -Mode Audit -Profile codex-agent -Strict; "
+    "only key names/statuses are reported and secret values remain redacted."
+)
+
 agent = AIAudioToolRecognizerAgent()
 print("speechtype default => message (review STT transcript before send)")
 for text in [

--- a/examples/sync_jurisdigta_env_demo.ps1
+++ b/examples/sync_jurisdigta_env_demo.ps1
@@ -1,13 +1,8 @@
-param(
-    [string]$EnvExamplePath = ".env.example",
-    [string]$EnvPath = ".env"
-)
+param([string]$Profile = "local-core", [string]$EnvPath = ".env")
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
 
-& (Join-Path $repoRoot "scripts\sync_jurisdigta_env.ps1") `
-    -EnvExamplePath $EnvExamplePath `
-    -EnvPath $EnvPath `
-    -SkipSshKeySync `
-    -SkipTransfer `
-    -DryRun
+& (Join-Path $repoRoot "scripts\sync_env_profile.ps1") `
+    -Mode Audit `
+    -Profile $Profile `
+    -EnvFilePath $EnvPath

--- a/scripts/env_config.py
+++ b/scripts/env_config.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Profile-aware environment audit/bootstrap/merge; output is always value-redacted."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+import tempfile
+
+UNKNOWN = "unknown-variable"
+ACTIVE_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$")
+EXAMPLE_RE = re.compile(r"^\s*#?\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$")
+UNSAFE = (
+    "unknown-variable",
+    "your_",
+    "your-",
+    "changeit",
+    "replace-with",
+    "optional_",
+    "<",
+    ">",
+    "$(",
+    "instrumentationkey=",
+)
+
+
+def root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def parse(path: Path, example: bool = False) -> tuple[dict[str, str], list[str], list[int]]:
+    values: dict[str, str] = {}
+    duplicates: list[str] = []
+    malformed: list[int] = []
+    if not path.exists():
+        return values, duplicates, malformed
+    matcher = EXAMPLE_RE if example else ACTIVE_RE
+    for number, line in enumerate(path.read_text(encoding="utf-8-sig").splitlines(), 1):
+        if not line.strip() or (not example and line.lstrip().startswith("#")):
+            continue
+        match = matcher.match(line)
+        if not match:
+            if not example:
+                malformed.append(number)
+            continue
+        key, value = match.group(1), match.group(2).strip()
+        if key in values:
+            duplicates.append(key)
+        else:
+            values[key] = value
+    return values, sorted(set(duplicates)), malformed
+
+
+def profiles(path: Path) -> dict[str, dict[str, set[str]]]:
+    definitions = json.loads(path.read_text(encoding="utf-8"))["profiles"]
+    result: dict[str, dict[str, set[str]]] = {}
+
+    def resolve(name: str, stack: tuple[str, ...] = ()) -> dict[str, set[str]]:
+        if name in result:
+            return result[name]
+        if name in stack:
+            raise ValueError("Circular environment profile inheritance")
+        definition = definitions[name]
+        required = set(definition.get("required", []))
+        optional = set(definition.get("optional", []))
+        for parent in definition.get("extends", []):
+            inherited = resolve(parent, stack + (name,))
+            required.update(inherited["required"])
+            optional.update(inherited["optional"])
+        optional.difference_update(required)
+        result[name] = {"required": required, "optional": optional}
+        return result[name]
+
+    for name in definitions:
+        resolve(name)
+    return result
+
+
+def safe(value: str) -> bool:
+    lower = value.strip().lower()
+    return bool(lower) and not any(marker in lower for marker in UNSAFE)
+
+
+def atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent, text=True)
+    temporary_path = Path(temporary)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(text)
+        if os.name != "nt":
+            os.chmod(temporary_path, stat.S_IRUSR | stat.S_IWUSR)
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def audit(env_path: Path, example_path: Path, profile: dict[str, set[str]]) -> dict[str, object]:
+    values, duplicates, malformed = parse(env_path)
+    schema, _, _ = parse(example_path, example=True)
+    required = set(profile["required"])
+    alternatives: list[list[str]] = []
+    if values.get("LLM_PROVIDER", "").lower() == "azurefoundry":
+        required.update(
+            {
+                "AZURE_OPENAI_ENDPOINT",
+                "AZURE_OPENAI_DEPLOYMENT",
+                "AZURE_OPENAI_API_VERSION",
+                "AZURE_OPENAI_EMBEDDINGS_MODEL",
+            }
+        )
+        if not any(
+            values.get(key, "").strip() not in {"", UNKNOWN}
+            for key in ("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_AD_TOKEN")
+        ):
+            alternatives.append(["AZURE_OPENAI_AD_TOKEN", "AZURE_OPENAI_API_KEY"])
+    missing = sorted(required - values.keys())
+    unresolved = sorted(key for key in required & values.keys() if values[key] in {"", UNKNOWN})
+    optional_unknown = sorted(
+        key for key, value in values.items() if key not in required and value in {"", UNKNOWN}
+    )
+    blocking = bool(missing or unresolved or alternatives or duplicates or malformed)
+    return {
+        "profile_ready": not blocking,
+        "missing_required": missing,
+        "unresolved_required": unresolved,
+        "missing_one_of": alternatives,
+        "unknown_optional": optional_unknown,
+        "duplicate_keys": duplicates,
+        "malformed_line_numbers": malformed,
+        "extra_keys": sorted(values.keys() - schema.keys()),
+        "configured_key_count": len(values),
+        "schema_key_count": len(schema),
+    }
+
+
+def bootstrap(
+    env_path: Path, example_path: Path, selected_keys: set[str] | None = None
+) -> dict[str, list[str]]:
+    schema, _, _ = parse(example_path, example=True)
+    existing, _, _ = parse(env_path)
+    lines = env_path.read_text(encoding="utf-8-sig").splitlines() if env_path.exists() else []
+    repaired: list[str] = []
+    for index, line in enumerate(lines):
+        match = ACTIVE_RE.match(line)
+        if match and match.group(2).strip() == UNKNOWN and safe(schema.get(match.group(1), "")):
+            lines[index] = f"{match.group(1)}={schema[match.group(1)]}"
+            repaired.append(match.group(1))
+    added: list[str] = []
+    for key, default in schema.items():
+        if selected_keys is not None and key not in selected_keys:
+            continue
+        if key not in existing:
+            lines.append(f"{key}={default if safe(default) else UNKNOWN}")
+            added.append(key)
+    atomic_write(env_path, "\n".join(lines).rstrip() + "\n")
+    return {"added": sorted(added), "repaired": sorted(repaired)}
+
+
+def merge(env_path: Path, source_path: Path) -> dict[str, list[str]]:
+    source, duplicates, malformed = parse(source_path)
+    if not source or duplicates or malformed:
+        raise ValueError("Authoritative profile is empty, duplicated, or malformed")
+    lines = env_path.read_text(encoding="utf-8-sig").splitlines() if env_path.exists() else []
+    seen: set[str] = set()
+    updated: list[str] = []
+    for index, line in enumerate(lines):
+        match = ACTIVE_RE.match(line)
+        if match:
+            key = match.group(1)
+            seen.add(key)
+            if key in source:
+                lines[index] = f"{key}={source[key]}"
+                updated.append(key)
+    added = sorted(source.keys() - seen)
+    lines.extend(f"{key}={source[key]}" for key in added)
+    atomic_write(env_path, "\n".join(lines).rstrip() + "\n")
+    return {"added": added, "updated": sorted(updated)}
+
+
+def names(label: str, values: list[object]) -> str:
+    return f"{label}: {', '.join(map(str, values)) if values else 'none'}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profiles", type=Path, default=root() / "config/env_profiles.json")
+    parser.add_argument("--example", type=Path, default=root() / ".env.example")
+    parser.add_argument("--env-file", type=Path, default=root() / ".env")
+    parser.add_argument("--profile", default="local-core")
+    commands = parser.add_subparsers(dest="command", required=True)
+    check = commands.add_parser("audit")
+    check.add_argument("--json", action="store_true")
+    check.add_argument("--strict", action="store_true")
+    commands.add_parser("bootstrap")
+    combine = commands.add_parser("merge")
+    combine.add_argument("--source", type=Path, required=True)
+    args = parser.parse_args()
+    selected = profiles(args.profiles)
+    if args.profile not in selected:
+        print(f"Unknown environment profile: {args.profile}", file=sys.stderr)
+        return 2
+    if args.command == "bootstrap":
+        selected_keys = selected[args.profile]["required"] | selected[args.profile]["optional"]
+        result = bootstrap(args.env_file, args.example, selected_keys)
+        print(names("Added keys", result["added"]))
+        print(names("Repaired keys", result["repaired"]))
+        print("Values are redacted.")
+        return 0
+    if args.command == "merge":
+        result = merge(args.env_file, args.source)
+        print(names("Added keys", result["added"]))
+        print(names("Updated keys", result["updated"]))
+        print("Values are redacted.")
+        return 0
+    result = audit(args.env_file, args.example, selected[args.profile])
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Profile {args.profile}: {'READY' if result['profile_ready'] else 'BLOCKED'}")
+        for label, key in (
+            ("Missing", "missing_required"),
+            ("Unresolved", "unresolved_required"),
+            ("Optional unresolved", "unknown_optional"),
+            ("Duplicates", "duplicate_keys"),
+            ("Extra", "extra_keys"),
+        ):
+            print(names(label, result[key]))
+        for alternatives in result["missing_one_of"]:
+            print(names("One of required", alternatives))
+        print(names("Malformed lines", result["malformed_line_numbers"]))
+        print("Values are redacted.")
+    return 1 if args.strict and not result["profile_ready"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_env_profile.ps1
+++ b/scripts/sync_env_profile.ps1
@@ -1,0 +1,73 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("Audit", "Bootstrap", "Pull")]
+    [string]$Mode = "Audit",
+    [ValidateSet("local-core", "codex-agent", "laws-collector", "azure-dev", "mcp-local")]
+    [string]$Profile = "local-core",
+    [string]$EnvFilePath,
+    [string]$ServerAlias = "jurisdigta-server",
+    [string]$UsbProfileRoot = "/mnt/jurisdigta-backup/jurisdigta-env/profiles",
+    [string]$PythonPath,
+    [switch]$Strict
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+if (-not $EnvFilePath) {
+    $EnvFilePath = if ($Profile -eq "azure-dev") { ".env.dev" } else { ".env" }
+}
+if (-not [System.IO.Path]::IsPathRooted($EnvFilePath)) {
+    $EnvFilePath = Join-Path $repoRoot $EnvFilePath
+}
+if (-not $PythonPath) {
+    $candidate = Join-Path $repoRoot "conda\python.exe"
+    $PythonPath = if (Test-Path $candidate) { $candidate } else { "python" }
+}
+$tool = Join-Path $repoRoot "scripts\env_config.py"
+
+function Invoke-EnvTool {
+    param([string[]]$Arguments)
+    & $PythonPath $tool --env-file $EnvFilePath --profile $Profile @Arguments |
+        ForEach-Object { Write-Host $_ }
+    return $LASTEXITCODE
+}
+
+if ($Mode -eq "Audit") {
+    $arguments = @("audit")
+    if ($Strict) { $arguments += "--strict" }
+    exit (Invoke-EnvTool -Arguments $arguments)
+}
+if ($Mode -eq "Bootstrap") {
+    $code = Invoke-EnvTool -Arguments @("bootstrap")
+    if ($code -ne 0) { exit $code }
+    $arguments = @("audit")
+    if ($Strict) { $arguments += "--strict" }
+    exit (Invoke-EnvTool -Arguments $arguments)
+}
+
+if (-not (Get-Command scp -ErrorAction SilentlyContinue)) {
+    throw "scp is required for server profile synchronization."
+}
+$temporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("jurisdigta-env-" + [guid]::NewGuid().ToString("N"))
+$download = Join-Path $temporaryRoot "$Profile.env"
+$backup = Join-Path $temporaryRoot "local-backup.env"
+New-Item -ItemType Directory -Path $temporaryRoot -Force | Out-Null
+try {
+    if (Test-Path $EnvFilePath) { Copy-Item -LiteralPath $EnvFilePath -Destination $backup -Force }
+    $remote = "${ServerAlias}:$UsbProfileRoot/$Profile.env"
+    & scp -q -o BatchMode=yes -o StrictHostKeyChecking=yes $remote $download
+    if ($LASTEXITCODE -ne 0) { throw "Secure profile download failed for $Profile." }
+    $code = Invoke-EnvTool -Arguments @("merge", "--source", $download)
+    if ($code -ne 0) { throw "Downloaded profile merge failed." }
+    $code = Invoke-EnvTool -Arguments @("audit", "--strict")
+    if ($code -ne 0) { throw "Downloaded profile did not satisfy the selected profile." }
+    Write-Host "Environment profile pull completed. Values remain redacted."
+}
+catch {
+    if (Test-Path $backup) { Copy-Item -LiteralPath $backup -Destination $EnvFilePath -Force }
+    throw
+}
+finally {
+    Remove-Item -LiteralPath $temporaryRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/sync_jurisdigta_env.ps1
+++ b/scripts/sync_jurisdigta_env.ps1
@@ -12,6 +12,7 @@ param(
     [switch]$SkipTransfer,
     [switch]$UseSudo,
     [switch]$AcceptNewHostKey,
+    [switch]$AllowLegacyPush,
     [switch]$DryRun
 )
 
@@ -360,6 +361,9 @@ if (-not $SkipSshKeySync) {
 }
 
 if (-not $SkipTransfer) {
+    if (-not $AllowLegacyPush) {
+        throw "Legacy laptop-to-server .env push is disabled. Use scripts/sync_env_profile.ps1 -Mode Pull. Pass -AllowLegacyPush only for an explicitly approved emergency migration."
+    }
     Publish-EnvToServer `
         -LocalEnvPath $resolvedEnvPath `
         -HostAlias $ServerAlias `

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+import json
+import pytest
+from scripts.env_config import audit, bootstrap, merge, profiles
+
+
+def profile_file(tmp_path: Path) -> Path:
+    path = tmp_path / "profiles.json"
+    path.write_text(
+        json.dumps({"profiles": {"local-core": {"required": ["DB_OPTION"]}}}), encoding="utf-8"
+    )
+    return path
+
+
+def test_audit_blocks_unknown_without_exposing_values(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text("DB_OPTION=unknown-variable\nSECRET=do-not-print\n", encoding="utf-8")
+    example = tmp_path / ".env.example"
+    example.write_text("DB_OPTION=local\n# SECRET=your-secret\n", encoding="utf-8")
+    result = audit(env, example, profiles(profile_file(tmp_path))["local-core"])
+    assert result["profile_ready"] is False
+    assert result["unresolved_required"] == ["DB_OPTION"]
+    assert "do-not-print" not in json.dumps(result)
+
+
+def test_audit_detects_duplicate_malformed_and_extra(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text("DB_OPTION=local\nDB_OPTION=local\ninvalid\nEXTRA=yes\n", encoding="utf-8")
+    example = tmp_path / ".env.example"
+    example.write_text("DB_OPTION=local\n", encoding="utf-8")
+    result = audit(env, example, profiles(profile_file(tmp_path))["local-core"])
+    assert result["duplicate_keys"] == ["DB_OPTION"]
+    assert result["malformed_line_numbers"] == [3]
+    assert result["extra_keys"] == ["EXTRA"]
+
+
+def test_bootstrap_is_idempotent_and_preserves_values(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text(
+        "DB_OPTION=postgres\nPORT=unknown-variable\nSECRET=unknown-variable\n", encoding="utf-8"
+    )
+    example = tmp_path / ".env.example"
+    example.write_text(
+        "DB_OPTION=local\nPORT=8080\n# SECRET=your-secret\nNEW_PATH=./runs/data\n", encoding="utf-8"
+    )
+    first = bootstrap(env, example)
+    second = bootstrap(env, example)
+    content = env.read_text(encoding="utf-8")
+    assert (
+        "DB_OPTION=postgres" in content
+        and "PORT=8080" in content
+        and "SECRET=unknown-variable" in content
+    )
+    assert first["repaired"] == ["PORT"] and second == {"added": [], "repaired": []}
+
+
+def test_merge_reports_names_only_and_rejects_bad_source(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text("KEEP=local\nREPLACE=old\n", encoding="utf-8")
+    source = tmp_path / "source.env"
+    source.write_text("REPLACE=secret-one\nNEW=secret-two\n", encoding="utf-8")
+    result = merge(env, source)
+    assert result == {"added": ["NEW"], "updated": ["REPLACE"]}
+    assert "secret-one" not in json.dumps(result)
+    source.write_text("bad line\n", encoding="utf-8")
+    with pytest.raises(ValueError):
+        merge(env, source)


### PR DESCRIPTION
## Summary
- add redacted profile-aware environment audit, bootstrap, and authoritative merge tooling
- add pull-only developer synchronization from the encrypted USB store on jurisdigta-server with rollback on failure
- separate temporary Azure development settings into the explicit .env.dev profile
- disable legacy laptop-to-server pushes by default
- update AGENTS.md, setup documentation, and runnable examples

## Validation
- .\\conda\\python.exe -m pytest tests/test_env_config.py -q
- .\\conda\\python.exe -m ruff check scripts/env_config.py tests/test_env_config.py
- .\\scripts\\sync_env_profile.ps1 -Mode Audit -Profile codex-agent -Strict
- PowerShell parser checks for both sync scripts
- PYTHONPATH=src .\\conda\\python.exe examples\\minimal_demo.py
- git diff --check

Closes #532