### PR TITLE
Fix court-decision metadata search index

### DIFF
--- a/databases/court-decision-collector/initdb/001_schema.sql
+++ b/databases/court-decision-collector/initdb/001_schema.sql
@@ -75,8 +75,12 @@ ON court_decision_documents(current_status, issue_date DESC, updated_at DESC);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_court_decision_documents_metadata_search_text
 ON court_decision_documents USING GIN (
     to_tsvector(
-        'simple',
-        concat_ws(' ', court_name, court_type, file_number, case_number, ecli)
+        'simple'::regconfig,
+        COALESCE(court_name, '') || ' ' ||
+        COALESCE(court_type, '') || ' ' ||
+        COALESCE(file_number, '') || ' ' ||
+        COALESCE(case_number, '') || ' ' ||
+        COALESCE(ecli, '')
     )
 );
 

--- a/databases/court-decision-collector/migrations/0001_search_indexes.sql
+++ b/databases/court-decision-collector/migrations/0001_search_indexes.sql
@@ -4,8 +4,12 @@ ON court_decision_documents(current_status, issue_date DESC, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_court_decision_documents_metadata_search_text
 ON court_decision_documents USING GIN (
     to_tsvector(
-        'simple',
-        concat_ws(' ', court_name, court_type, file_number, case_number, ecli)
+        'simple'::regconfig,
+        COALESCE(court_name, '') || ' ' ||
+        COALESCE(court_type, '') || ' ' ||
+        COALESCE(file_number, '') || ' ' ||
+        COALESCE(case_number, '') || ' ' ||
+        COALESCE(ecli, '')
     )
 );
 

--- a/docs/manual_infrastucture_setup.md
+++ b/docs/manual_infrastucture_setup.md
@@ -97,7 +97,7 @@ Required owner: infrastructure operator with PostgreSQL administrator access.
 
 1. Create a separate database such as `court_decisions_sk`.
 2. Enable `pgvector` with `CREATE EXTENSION IF NOT EXISTS vector;`.
-3. Apply `databases/court-decision-collector/initdb/001_schema.sql`, then run the tracked SQL migrations in `databases/court-decision-collector/migrations/` when upgrading an existing database.
+3. Apply `databases/court-decision-collector/initdb/001_schema.sql`, then run the tracked SQL migrations in `databases/court-decision-collector/migrations/` when upgrading an existing database. Keep the metadata full-text search index expression immutable for PostgreSQL production deploys.
 4. Store the connection string only in local/server secrets as `COURT_DECISIONS_DB_CLOUD`.
 5. Set `COURT_DECISIONS_DB_BACKEND=postgres`, `COURT_DECISIONS_STORAGE_LOCAL=./runs/storage/court-decision-collector/files/sk`, `COURT_DECISION_MCP_SEARCH_TIMEOUT_MS=600000`, and `COURT_DECISIONS_WORKER_POLL_HOURS=1`.
 6. Run a bounded fixture import first: `python -m services.court_decision_collector --fixture`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aijurisdictionagents"
-version = "1.0.260426"
+version = "1.0.260427"
 description = "Multi-agent legal discussion scaffold."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260426"
+__version__ = "1.0.260427"

--- a/src/services/court_decision_collector/postgres_store.py
+++ b/src/services/court_decision_collector/postgres_store.py
@@ -259,15 +259,12 @@ class PostgresCourtDecisionStore:
                         d.decision_id,
                         ts_rank_cd(
                             to_tsvector(
-                                'simple',
-                                concat_ws(
-                                    ' ',
-                                    d.court_name,
-                                    d.court_type,
-                                    d.file_number,
-                                    d.case_number,
-                                    d.ecli
-                                )
+                                'simple'::regconfig,
+                                COALESCE(d.court_name, '') || ' ' ||
+                                COALESCE(d.court_type, '') || ' ' ||
+                                COALESCE(d.file_number, '') || ' ' ||
+                                COALESCE(d.case_number, '') || ' ' ||
+                                COALESCE(d.ecli, '')
                             ),
                             search_query.tsq
                         ) AS lexical_rank
@@ -276,15 +273,12 @@ class PostgresCourtDecisionStore:
                     WHERE d.current_status = 'published'
                       AND (
                           to_tsvector(
-                              'simple',
-                              concat_ws(
-                                  ' ',
-                                  d.court_name,
-                                  d.court_type,
-                                  d.file_number,
-                                  d.case_number,
-                                  d.ecli
-                              )
+                              'simple'::regconfig,
+                              COALESCE(d.court_name, '') || ' ' ||
+                              COALESCE(d.court_type, '') || ' ' ||
+                              COALESCE(d.file_number, '') || ' ' ||
+                              COALESCE(d.case_number, '') || ' ' ||
+                              COALESCE(d.ecli, '')
                           ) @@ search_query.tsq
                           OR LOWER(d.court_name) LIKE %(pattern)s
                           OR LOWER(d.court_type) LIKE %(pattern)s
@@ -663,8 +657,12 @@ _SCHEMA_SQL = (
     CREATE INDEX IF NOT EXISTS idx_court_decision_documents_metadata_search_text
     ON court_decision_documents USING GIN (
         to_tsvector(
-            'simple',
-            concat_ws(' ', court_name, court_type, file_number, case_number, ecli)
+            'simple'::regconfig,
+            COALESCE(court_name, '') || ' ' ||
+            COALESCE(court_type, '') || ' ' ||
+            COALESCE(file_number, '') || ' ' ||
+            COALESCE(case_number, '') || ' ' ||
+            COALESCE(ecli, '')
         )
     )
     """,

--- a/tests/test_db_migrations.py
+++ b/tests/test_db_migrations.py
@@ -108,3 +108,19 @@ def test_postgres_migration_apply_uses_lock_and_records_execution(
         "unlock:api",
     ]
 
+
+def test_court_decision_metadata_search_index_uses_immutable_expression() -> None:
+    migration = Path(
+        "databases/court-decision-collector/migrations/0001_search_indexes.sql"
+    ).read_text(encoding="utf-8")
+    init_schema = Path(
+        "databases/court-decision-collector/initdb/001_schema.sql"
+    ).read_text(encoding="utf-8")
+
+    for sql in (migration, init_schema):
+        metadata_index = sql.split(
+            "idx_court_decision_documents_metadata_search_text", maxsplit=1
+        )[1].split(");", maxsplit=1)[0]
+        assert "concat_ws" not in metadata_index
+        assert "'simple'::regconfig" in metadata_index
+        assert "COALESCE(court_name, '')" in metadata_index


### PR DESCRIPTION
## Summary
- replace the court-decision metadata full-text index expression with immutable PostgreSQL-safe concatenation
- keep runtime schema, init SQL, and migration SQL aligned
- add regression coverage for the migration expression and document the deployment constraint

## Validation
- `./conda/python.exe -m pytest tests/test_db_migrations.py tests/test_self_managed_deploy_script.py`
- `./conda/python.exe -m ruff check src/services/court_decision_collector/postgres_store.py tests/test_db_migrations.py`
- `./conda/python.exe examples/minimal_demo.py`

Closes #536