### PR TITLE
Fix immutable court migration checksum

### DIFF
--- a/databases/court-decision-collector/migrations/0001_search_indexes.sql
+++ b/databases/court-decision-collector/migrations/0001_search_indexes.sql
@@ -1,5 +1,5 @@
-CREATE INDEX IF NOT EXISTS idx_court_decision_documents_status_issue_date_normalized
-ON court_decision_documents(current_status, issue_date_normalized DESC, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_court_decision_documents_status_issue_date
+ON court_decision_documents(current_status, issue_date DESC, updated_at DESC);
 
 CREATE INDEX IF NOT EXISTS idx_court_decision_documents_metadata_search_text
 ON court_decision_documents USING GIN (

--- a/docs/COURT_DECISION_COLLECTOR.md
+++ b/docs/COURT_DECISION_COLLECTOR.md
@@ -6,6 +6,10 @@ The collector is separate from `laws_collector` because court decisions have dif
 
 ## Storage
 
+Applied migration files are immutable because their checksums are recorded in the
+database. Add schema and index changes in a new numbered migration instead of
+editing an existing migration; deployment stops on a checksum mismatch.
+
 - SQL assets: `databases/court-decision-collector/`
 - Local runtime data: `runs/storage/court-decision-collector/`
 - Default database backend: PostgreSQL


### PR DESCRIPTION
## Summary
- restore the already-applied 0001 court-decision migration byte-for-byte
- retain normalized date indexes in the existing 0002 migration
- document migration immutability

## Validation
- current 0001 Git object matches production base e2a68cd exactly: ae11c9aa0bd56436c8cdc4caf22b7af900958098
- git diff --check passed

## Context
Unblocks production deployment of #541 after run 29352618313 correctly stopped on a migration checksum mismatch.