### PR TITLE
Implement golden-case validation runner seed for #472

### DIFF
--- a/api/aijuristiction-api/app/cases_api.py
+++ b/api/aijuristiction-api/app/cases_api.py
@@ -821,6 +821,7 @@ def _build_case_export_zip(
         "message_count": len(messages),
         "document_count": len(documents),
         "ai_model_audit_count": len(audit_entries),
+        "models_used": _case_export_models_used(audit_entries),
         "citation_count": len(citations),
         "documents": document_manifest,
     }
@@ -845,6 +846,31 @@ def _build_case_export_zip(
         for path in sorted(files):
             _writestr_deterministic(archive, path, files[path])
     return buffer.getvalue()
+
+
+def _case_export_models_used(
+    audit_entries: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Return a privacy-minimized model summary while detailed usage stays in the audit file."""
+    grouped: dict[tuple[str, str, str, str], int] = {}
+    for entry in audit_entries:
+        key = (
+            str(entry.get("provider") or "unknown"),
+            str(entry.get("model") or "unknown"),
+            str(entry.get("route_type") or "unknown"),
+            str(entry.get("status") or "unknown"),
+        )
+        grouped[key] = grouped.get(key, 0) + 1
+    return [
+        {
+            "provider": provider,
+            "model": model,
+            "route_type": route_type,
+            "status": status,
+            "usage_count": count,
+        }
+        for (provider, model, route_type, status), count in sorted(grouped.items())
+    ]
 
 
 def _render_generated_case_document_pdf_bytes(

--- a/api/aijuristiction-api/e2e-playwright/e2e-test-catalog.json
+++ b/api/aijuristiction-api/e2e-playwright/e2e-test-catalog.json
@@ -1,5 +1,14 @@
 [
   {
+    "id": "golden-case-model-validation-offline",
+    "file": "../../../examples/model_validation_runner_demo.py",
+    "title": "scenario 01 golden case fixture loads and passes deterministic comparison",
+    "name": "Golden-case model validation offline smoke",
+    "description": "Loads the synthetic private-loan confirmation seed and validates normalized text assertions without model calls.",
+    "area": "Model validation",
+    "scheduled": false
+  },
+  {
     "id": "api-health",
     "file": "tests/health.spec.ts",
     "title": "health endpoint is healthy",

--- a/api/aijuristiction-api/e2e-playwright/package.json
+++ b/api/aijuristiction-api/e2e-playwright/package.json
@@ -7,7 +7,8 @@
     "test:free-plan-api": "playwright test tests/free-plan-api-connectivity.spec.ts",
     "test:free-plan-document": "playwright test tests/free-plan-ollama-document-pdf.spec.ts",
     "test:outdated-rental": "playwright test tests/outdated-rental-agreement.spec.ts",
-    "test:payment": "playwright test tests/payment-process.spec.ts"
+    "test:payment": "playwright test tests/payment-process.spec.ts",
+    "test:model-validation:offline": "python ../../../examples/model_validation_runner_demo.py"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2"

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260528"
+version = "1.0.260529"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_cases.py
+++ b/api/aijuristiction-api/tests/test_cases.py
@@ -699,6 +699,15 @@ def test_paid_user_can_export_case_zip_with_documents_model_audit_and_checksums(
         assert manifest["message_count"] == 2
         assert manifest["document_count"] == 2
         assert manifest["ai_model_audit_count"] == 1
+        assert manifest["models_used"] == [
+            {
+                "provider": "azurefoundry",
+                "model": "gpt-4.1",
+                "route_type": "external",
+                "status": "ok",
+                "usage_count": 1,
+            }
+        ]
         audit = json.loads(archive.read("ai-model-audit.json"))
         assert audit["entries"][0]["usage_id"] == usage_id
         assert audit["entries"][0]["provider"] == "azurefoundry"

--- a/docs/MODEL_VALIDATION_RUNNER.md
+++ b/docs/MODEL_VALIDATION_RUNNER.md
@@ -1,0 +1,42 @@
+# Golden-case model validation runner
+
+Issue #472 uses exported JurisDigta cases as reviewed inputs for repeatable model and legal-document
+checks. The source of truth is a manually reviewed export made with synthetic facts. A ZIP assembled
+outside JurisDigta is only a development seed because it does not prove the real case, chat,
+document-rendering and model-audit path.
+
+## Offline validation
+
+Run the minimal scenario-01 fixture check:
+
+```powershell
+.\conda\python.exe examples\model_validation_runner_demo.py
+.\conda\python.exe -m pytest tests\test_golden_cases.py tests\test_models_testing_fixtures.py
+```
+
+The reusable loader accepts the native `jurisdigta.case-export.v1` ZIP and the legacy scenario-01
+seed. It extracts user prompts, assistant answers, generated document sources, actual model audit
+entries and export warnings. Comparison normalizes Unicode, diacritics, case and whitespace, then
+checks similarity plus required and forbidden text. PDF byte equality is intentionally unsupported.
+
+## Live replay contract
+
+A live runner should create isolated synthetic free and paid accounts, verify the free route is
+local Ollama, activate the paid Case plan through the sandbox payment flow, replay the exported user
+turns, and answer matching assistant questions from the golden transcript. An unmatched question may
+receive a conservative configured answer, but the result must contain a warning.
+
+For each run, write ignored artifacts under `runs/model-validation/<run-id>/`: transcript, warnings,
+actual `provider`, `model`, `route_type`, status, fallback reason, timing/token/cost fields, exported
+ZIP/PDF text and comparison JSON. Authentication secrets and payment details must never be copied to
+fixtures or reports.
+
+Passing deterministic checks means the output conforms to the reviewed fixture; it is not automatic
+approval of legal correctness. A qualified human must review material legal changes and any output
+intended for signing, filing or reliance.
+
+## Adding coverage
+
+Follow the native-export steps in `tests/modelsTesting/README.md`. Keep missing fixture coverage
+separate from model-validation failures. Create another GitHub issue only if the scenario exposes a
+missing product behavior, document template/flow pack, or legal-source integration.

--- a/docs/MODEL_VALIDATION_RUNNER.md
+++ b/docs/MODEL_VALIDATION_RUNNER.md
@@ -42,6 +42,48 @@ Passing deterministic checks means the output conforms to the reviewed fixture; 
 approval of legal correctness. A qualified human must review material legal changes and any output
 intended for signing, filing or reliance.
 
+## Tester workflow: build golden-case data
+
+Use this checklist for every scenario that will become automated golden-test data:
+
+1. Create a dedicated JurisDigta test account. Do not use a customer or personal account.
+2. Create a new case with a stable scenario ID, for example
+   `01-private-loan-payment-confirmation`.
+3. Enter only synthetic data: invented names and addresses, clearly fake identity numbers, fixed
+   amounts and dates, and no customer or production data.
+4. Run the complete conversation through JurisDigta using the same channel and wording that the
+   automated replay will exercise.
+5. Answer assistant follow-up questions with the predefined synthetic facts. Keep the answers stable
+   and record any unmatched or improvised answer as a warning.
+6. Generate the final legal document and rendered PDF through JurisDigta.
+7. Manually review the parties and identifiers, amount and currency, transfer/payment method and
+   date, receipt-versus-repayment meaning, signature blocks, citations, legal wording, and the
+   human-review disclosure. Record the reviewer and review date outside sensitive fixture content.
+8. Export the reviewed case through the JurisDigta case-export UI or endpoint. Do not assemble the
+   production golden ZIP manually.
+9. Verify the ZIP contains `manifest.json`, `case.json`, `messages.jsonl`,
+   `ai-model-audit.json`, `citations.json`, `warnings.json`, source/generated document artifacts,
+   rendered PDFs, and `sha256sums.txt`.
+10. Verify model traceability in both `manifest.json.models_used` and
+    `ai-model-audit.json.entries`. Every audit entry must contain the actual non-empty `provider`,
+    `model`, `route_type`, and `status` persisted by the server. Never type these values into the
+    fixture manually.
+11. Copy the reviewed immutable ZIP to `tests/modelsTesting/cases/` using a stable filename.
+12. Register the fixture in `tests/modelsTesting/index.json`, including its SHA-256, scenario ID,
+    classification, expected route, required/forbidden assertions, citations, document type/count,
+    and similarity thresholds.
+13. Set `fixture_status` to `native_reviewed` only after the content review and model-audit checks
+    pass. Legacy or incomplete fixtures must remain marked as seeds and are not automation-ready.
+14. Run `.\conda\python.exe examples\model_validation_runner_demo.py --fixture <zip-path>` and
+    `.\conda\python.exe -m pytest tests\test_golden_cases.py
+    tests\test_models_testing_fixtures.py`.
+15. Keep every later replay export separate under ignored `runs/model-validation/<run-id>/` and
+    compare normalized text, required facts, citations, document type/count, decision/status, and
+    model audit. Never compare raw PDF bytes or overwrite the reviewed golden ZIP.
+
+If any step fails, do not promote the ZIP to `native_reviewed`. Correct the synthetic case in
+JurisDigta, repeat the human review, create a new export, and update the registered checksum.
+
 ## Adding coverage
 
 Follow the native-export steps in `tests/modelsTesting/README.md`. Keep missing fixture coverage

--- a/docs/MODEL_VALIDATION_RUNNER.md
+++ b/docs/MODEL_VALIDATION_RUNNER.md
@@ -31,6 +31,13 @@ actual `provider`, `model`, `route_type`, status, fallback reason, timing/token/
 ZIP/PDF text and comparison JSON. Authentication secrets and payment details must never be copied to
 fixtures or reports.
 
+The native export records the models used twice: `manifest.json.models_used` provides a compact
+summary and `ai-model-audit.json.entries` preserves the detailed trace. A fixture is automation-ready
+only when at least one audit entry exists and every entry contains non-empty `provider`, `model`,
+`route_type` and `status`. Whether the case facts were entered manually or generated synthetically
+does not change this requirement: the model identity must come from the persisted server audit, never
+from a manually typed fixture label.
+
 Passing deterministic checks means the output conforms to the reviewed fixture; it is not automatic
 approval of legal correctness. A qualified human must review material legal changes and any output
 intended for signing, filing or reliance.

--- a/examples/model_validation_runner_demo.py
+++ b/examples/model_validation_runner_demo.py
@@ -6,7 +6,7 @@ import argparse
 import json
 from pathlib import Path
 
-from aijurisdictionagents.golden_cases import compare_text, load_golden_case
+from aijurisdictionagents.golden_cases import compare_text, load_golden_case, validate_model_audit
 
 
 def main() -> None:
@@ -18,6 +18,7 @@ def main() -> None:
     )
     args = parser.parse_args()
     golden = load_golden_case(args.fixture)
+    model_validation = validate_model_audit(golden)
     answer_result = compare_text(
         golden.expected_answer,
         golden.expected_answer,
@@ -30,6 +31,8 @@ def main() -> None:
         "prompt_count": len(golden.prompts),
         "document_count": len(golden.expected_documents),
         "model_audit_count": len(golden.model_audit),
+        "automation_ready": model_validation.automation_ready,
+        "model_audit_errors": model_validation.errors,
         "warnings": list(golden.warnings),
         "answer": {
             "passed": answer_result.passed,

--- a/examples/model_validation_runner_demo.py
+++ b/examples/model_validation_runner_demo.py
@@ -1,0 +1,47 @@
+"""Offline minimal demo for validating a JurisDigta golden-case fixture."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from aijurisdictionagents.golden_cases import compare_text, load_golden_case
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        default=Path("tests/modelsTesting/cases/issue-513-loan-confirmation-case-export.zip"),
+    )
+    args = parser.parse_args()
+    golden = load_golden_case(args.fixture)
+    answer_result = compare_text(
+        golden.expected_answer,
+        golden.expected_answer,
+        required=("Potvrdenie o pozicke", "AI navrh pred pouzitim skontrolujte clovekom"),
+        forbidden=("CASE_UPDATE_JSON",),
+        similarity_min=0.82,
+    )
+    report = {
+        "case_key": golden.case_key,
+        "prompt_count": len(golden.prompts),
+        "document_count": len(golden.expected_documents),
+        "model_audit_count": len(golden.model_audit),
+        "warnings": list(golden.warnings),
+        "answer": {
+            "passed": answer_result.passed,
+            "similarity": answer_result.similarity,
+            "missing_required": answer_result.missing_required,
+            "present_forbidden": answer_result.present_forbidden,
+        },
+    }
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    if not answer_result.passed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aijurisdictionagents"
-version = "1.0.260428"
+version = "1.0.260429"
 description = "Multi-agent legal discussion scaffold."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260428"
+__version__ = "1.0.260429"

--- a/src/aijurisdictionagents/golden_cases.py
+++ b/src/aijurisdictionagents/golden_cases.py
@@ -31,6 +31,12 @@ class GoldenCase:
     warnings: tuple[dict[str, object], ...]
 
 
+@dataclass(frozen=True)
+class ModelAuditValidation:
+    automation_ready: bool
+    errors: tuple[str, ...]
+
+
 def canonical_text(value: str) -> str:
     """Normalize text for stable semantic-ish comparison without byte-matching PDFs."""
     decomposed = unicodedata.normalize("NFKD", value)
@@ -65,6 +71,20 @@ def sha256_file(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest().upper()
+
+
+def validate_model_audit(golden: GoldenCase) -> ModelAuditValidation:
+    """Require traceable model identity before a fixture can be automated as golden evidence."""
+    if not golden.model_audit:
+        return ModelAuditValidation(False, ("missing_model_audit",))
+    required = ("provider", "model", "route_type", "status")
+    errors: list[str] = []
+    for index, entry in enumerate(golden.model_audit):
+        for field in required:
+            value = str(entry.get(field) or "").strip()
+            if not value or value == "unknown":
+                errors.append(f"model_audit[{index}].{field}_missing")
+    return ModelAuditValidation(not errors, tuple(errors))
 
 
 def load_golden_case(path: Path) -> GoldenCase:

--- a/src/aijurisdictionagents/golden_cases.py
+++ b/src/aijurisdictionagents/golden_cases.py
@@ -1,0 +1,139 @@
+"""Deterministic loading and comparison of JurisDigta golden-case exports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import cast
+import unicodedata
+from zipfile import ZipFile
+
+
+@dataclass(frozen=True)
+class ComparisonResult:
+    passed: bool
+    similarity: float
+    missing_required: tuple[str, ...]
+    present_forbidden: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class GoldenCase:
+    case_key: str
+    prompts: tuple[str, ...]
+    expected_answer: str
+    expected_documents: tuple[str, ...]
+    model_audit: tuple[dict[str, object], ...]
+    warnings: tuple[dict[str, object], ...]
+
+
+def canonical_text(value: str) -> str:
+    """Normalize text for stable semantic-ish comparison without byte-matching PDFs."""
+    decomposed = unicodedata.normalize("NFKD", value)
+    ascii_text = "".join(char for char in decomposed if not unicodedata.combining(char))
+    return re.sub(r"\s+", " ", ascii_text.casefold()).strip()
+
+
+def compare_text(
+    actual: str,
+    expected: str,
+    *,
+    required: tuple[str, ...] = (),
+    forbidden: tuple[str, ...] = (),
+    similarity_min: float = 0.0,
+) -> ComparisonResult:
+    normalized_actual = canonical_text(actual)
+    normalized_expected = canonical_text(expected)
+    similarity = SequenceMatcher(None, normalized_actual, normalized_expected).ratio()
+    missing = tuple(item for item in required if canonical_text(item) not in normalized_actual)
+    present = tuple(item for item in forbidden if canonical_text(item) in normalized_actual)
+    return ComparisonResult(
+        passed=not missing and not present and similarity >= similarity_min,
+        similarity=similarity,
+        missing_required=missing,
+        present_forbidden=present,
+    )
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest().upper()
+
+
+def load_golden_case(path: Path) -> GoldenCase:
+    """Load either a native case-export v1 ZIP or the legacy scenario-01 seed ZIP."""
+    with ZipFile(path) as archive:
+        names = set(archive.namelist())
+        if "manifest.json" in names:
+            return _load_native_export(archive)
+        if "case-export.json" in names:
+            return _load_legacy_export(archive)
+    raise ValueError(f"Unsupported golden-case ZIP schema: {path}")
+
+
+def _read_json(archive: ZipFile, name: str) -> dict[str, object]:
+    value = json.loads(archive.read(name).decode("utf-8-sig"))
+    if not isinstance(value, dict):
+        raise ValueError(f"Expected JSON object in {name}")
+    return cast(dict[str, object], value)
+
+
+def _object_list(payload: dict[str, object], key: str) -> tuple[dict[str, object], ...]:
+    value = payload.get(key, [])
+    if not isinstance(value, list):
+        raise ValueError(f"Expected a list in field {key}")
+    return tuple(cast(dict[str, object], item) for item in value if isinstance(item, dict))
+
+
+def _load_legacy_export(archive: ZipFile) -> GoldenCase:
+    metadata = _read_json(archive, "case-export.json")
+    answer = archive.read("fixed-assistant-answer.txt").decode("utf-8-sig")
+    document = archive.read("generated-document.txt").decode("utf-8-sig")
+    return GoldenCase(
+        case_key=str(metadata["case_key"]),
+        prompts=(str(metadata["prompt"]),),
+        expected_answer=answer,
+        expected_documents=(document,),
+        model_audit=(),
+        warnings=(
+            {
+                "code": "legacy_fixture",
+                "message": "Replace with a manually reviewed native JurisDigta case export.",
+            },
+        ),
+    )
+
+
+def _load_native_export(archive: ZipFile) -> GoldenCase:
+    manifest = _read_json(archive, "manifest.json")
+    messages = [
+        json.loads(line)
+        for line in archive.read("messages.jsonl").decode("utf-8-sig").splitlines()
+        if line.strip()
+    ]
+    prompts = tuple(str(item["content"]) for item in messages if item.get("role") == "user")
+    answers = [str(item["content"]) for item in messages if item.get("role") == "assistant"]
+    documents: list[str] = []
+    for item in _object_list(manifest, "documents"):
+        if item.get("kind") != "generated_document":
+            continue
+        artifact = item.get("source_artifact")
+        if isinstance(artifact, str) and artifact in archive.namelist():
+            documents.append(archive.read(artifact).decode("utf-8-sig", errors="replace"))
+    audit = _read_json(archive, "ai-model-audit.json") if "ai-model-audit.json" in archive.namelist() else {}
+    warnings = _read_json(archive, "warnings.json") if "warnings.json" in archive.namelist() else {}
+    return GoldenCase(
+        case_key=str(manifest.get("case_id", manifest.get("case_title", "unknown"))),
+        prompts=prompts,
+        expected_answer="\n\n".join(answers),
+        expected_documents=tuple(documents),
+        model_audit=_object_list(audit, "entries"),
+        warnings=_object_list(warnings, "items"),
+    )

--- a/tests/modelsTesting/README.md
+++ b/tests/modelsTesting/README.md
@@ -53,7 +53,9 @@ created through JurisDigta using the process below before marking scenario 01 le
 4. A human reviewer verifies the document type, parties, amount, handover/payment date, signatures,
    repayment wording, legal citations and the AI/human-review disclosure.
 5. Export the case using the paid case-export endpoint/UI and verify that the ZIP contains the native
-   export manifest, transcript, model audit, warnings and generated PDF.
+   export manifest, transcript, model audit, warnings and generated PDF. Confirm
+   `manifest.json.models_used` and `ai-model-audit.json.entries` identify the actual provider, model,
+   route type and status used for the case. Do not enter these values manually.
 6. Store the reviewed ZIP under `cases/`, update its SHA-256 and rules in `index.json`, and set
    `fixture_status` to `native_reviewed`.
 

--- a/tests/modelsTesting/README.md
+++ b/tests/modelsTesting/README.md
@@ -33,4 +33,30 @@ Each case is stored as a ZIP under `cases/` and registered in `index.json`. The 
 .\conda\python.exe -m pytest tests\test_models_testing_fixtures.py
 ```
 
-Future model runners should use `index.json` as the stable entry point and treat each ZIP as immutable fixture input.
+The runner in `aijurisdictionagents.golden_cases` supports both the native export from issue #471
+(`manifest.json`, `messages.jsonl`, `ai-model-audit.json`, documents and warnings) and the older
+scenario-01 seed format. New fixtures must use the native format.
+
+Future model runners should use `index.json` as the stable entry point and treat each reviewed ZIP
+as immutable fixture input. Compare normalized text and configured assertions, never PDF bytes.
+
+## Scenario 01: private-loan payment confirmation
+
+The tracked `issue-513-loan-confirmation` ZIP is a synthetic legacy seed. It is useful for offline
+runner tests, but it is not yet evidence of a full production replay. Replace it with a native export
+created through JurisDigta using the process below before marking scenario 01 legally approved:
+
+1. Create a dedicated automation account and a new case in JurisDigta.
+2. Use invented names, addresses, identifiers, dates and amounts. Do not adapt a customer case.
+3. Ask for a receipt/payment confirmation for a private loan and answer follow-up questions with the
+   same stable synthetic facts.
+4. A human reviewer verifies the document type, parties, amount, handover/payment date, signatures,
+   repayment wording, legal citations and the AI/human-review disclosure.
+5. Export the case using the paid case-export endpoint/UI and verify that the ZIP contains the native
+   export manifest, transcript, model audit, warnings and generated PDF.
+6. Store the reviewed ZIP under `cases/`, update its SHA-256 and rules in `index.json`, and set
+   `fixture_status` to `native_reviewed`.
+
+The export contains personal-looking synthetic data and model audit metadata, so retain only the
+minimum fixture, never credentials or payment details. Failed/live outputs belong under ignored
+`runs/model-validation/` and should be deleted according to the test-data retention policy.

--- a/tests/modelsTesting/index.json
+++ b/tests/modelsTesting/index.json
@@ -28,6 +28,8 @@
   "cases": [
     {
       "case_key": "issue-513-loan-confirmation",
+      "scenario_id": "01-private-loan-payment-confirmation",
+      "fixture_status": "legacy_seed_requires_native_export_replacement",
       "zip_path": "cases/issue-513-loan-confirmation-case-export.zip",
       "sha256": "2057CAB079A8BCA76C9115CCBC87413B26CE86C8C62DDCC576CED7B18275442E",
       "source_issue": "https://github.com/mmaideveloper/aijurisdictionagents/issues/513",
@@ -39,6 +41,15 @@
       "data_classification": "synthetic_test_fixture",
       "fixture_purpose": "Compare whether a model generates a Slovak loan-confirmation answer and legal-document draft instead of echoing the user prompt.",
       "prompt_kind": "single_turn_case_creation",
+      "expected_route": {
+        "free": {
+          "provider": "local_ollama",
+          "is_external": false
+        },
+        "paid": {
+          "record_actual_provider_model_and_route_type": true
+        }
+      },
       "expected_outputs": {
         "answer": {
           "must_contain": [

--- a/tests/test_golden_cases.py
+++ b/tests/test_golden_cases.py
@@ -1,0 +1,54 @@
+import json
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
+from aijurisdictionagents.golden_cases import canonical_text, compare_text, load_golden_case
+
+
+def test_compare_text_normalizes_diacritics_and_reports_rules() -> None:
+    result = compare_text(
+        "Potvrdenie o prijatí 1 000 EUR. Kontrola človekom.",
+        "Potvrdenie o prijati 1000 EUR. Kontrola clovekom.",
+        required=("potvrdenie", "človekom"),
+        forbidden=("CASE_UPDATE_JSON",),
+        similarity_min=0.9,
+    )
+    assert result.passed
+    assert canonical_text("Prijatí") == "prijati"
+
+
+def test_loads_native_case_export(tmp_path: Path) -> None:
+    fixture = tmp_path / "case.zip"
+    manifest = {
+        "schema": "jurisdigta.case-export.v1",
+        "case_id": "case-01",
+        "documents": [{"kind": "generated_document", "source_artifact": "documents/01.txt"}],
+    }
+    with ZipFile(fixture, "w", ZIP_DEFLATED) as archive:
+        archive.writestr("manifest.json", json.dumps(manifest))
+        archive.writestr(
+            "messages.jsonl",
+            '\n'.join(
+                [
+                    json.dumps({"role": "user", "content": "Priprav potvrdenie."}),
+                    json.dumps({"role": "assistant", "content": "Tu je návrh."}),
+                ]
+            ),
+        )
+        archive.writestr("documents/01.txt", "Potvrdenie o prijatí peňazí")
+        archive.writestr("ai-model-audit.json", json.dumps({"entries": [{"provider": "local_ollama"}]}))
+        archive.writestr("warnings.json", json.dumps({"items": []}))
+    loaded = load_golden_case(fixture)
+    assert loaded.case_key == "case-01"
+    assert loaded.prompts == ("Priprav potvrdenie.",)
+    assert loaded.expected_documents == ("Potvrdenie o prijatí peňazí",)
+    assert loaded.model_audit[0]["provider"] == "local_ollama"
+
+
+def test_scenario_01_seed_is_loadable() -> None:
+    fixture = Path("tests/modelsTesting/cases/issue-513-loan-confirmation-case-export.zip")
+    loaded = load_golden_case(fixture)
+    assert loaded.case_key == "issue-513-loan-confirmation"
+    assert loaded.prompts
+    assert loaded.expected_documents
+    assert loaded.warnings[0]["code"] == "legacy_fixture"

--- a/tests/test_golden_cases.py
+++ b/tests/test_golden_cases.py
@@ -2,7 +2,12 @@ import json
 from pathlib import Path
 from zipfile import ZIP_DEFLATED, ZipFile
 
-from aijurisdictionagents.golden_cases import canonical_text, compare_text, load_golden_case
+from aijurisdictionagents.golden_cases import (
+    canonical_text,
+    compare_text,
+    load_golden_case,
+    validate_model_audit,
+)
 
 
 def test_compare_text_normalizes_diacritics_and_reports_rules() -> None:
@@ -36,13 +41,28 @@ def test_loads_native_case_export(tmp_path: Path) -> None:
             ),
         )
         archive.writestr("documents/01.txt", "Potvrdenie o prijatí peňazí")
-        archive.writestr("ai-model-audit.json", json.dumps({"entries": [{"provider": "local_ollama"}]}))
+        archive.writestr(
+            "ai-model-audit.json",
+            json.dumps(
+                {
+                    "entries": [
+                        {
+                            "provider": "local_ollama",
+                            "model": "qwen3:1.7b",
+                            "route_type": "free_local",
+                            "status": "success",
+                        }
+                    ]
+                }
+            ),
+        )
         archive.writestr("warnings.json", json.dumps({"items": []}))
     loaded = load_golden_case(fixture)
     assert loaded.case_key == "case-01"
     assert loaded.prompts == ("Priprav potvrdenie.",)
     assert loaded.expected_documents == ("Potvrdenie o prijatí peňazí",)
     assert loaded.model_audit[0]["provider"] == "local_ollama"
+    assert validate_model_audit(loaded).automation_ready
 
 
 def test_scenario_01_seed_is_loadable() -> None:
@@ -52,3 +72,22 @@ def test_scenario_01_seed_is_loadable() -> None:
     assert loaded.prompts
     assert loaded.expected_documents
     assert loaded.warnings[0]["code"] == "legacy_fixture"
+    assert validate_model_audit(loaded).errors == ("missing_model_audit",)
+
+
+def test_model_audit_rejects_incomplete_identity(tmp_path: Path) -> None:
+    fixture = tmp_path / "case.zip"
+    with ZipFile(fixture, "w", ZIP_DEFLATED) as archive:
+        archive.writestr(
+            "manifest.json",
+            json.dumps({"case_id": "case-02", "documents": []}),
+        )
+        archive.writestr("messages.jsonl", "")
+        archive.writestr(
+            "ai-model-audit.json",
+            json.dumps({"entries": [{"provider": "azurefoundry", "model": "gpt-4.1"}]}),
+        )
+    validation = validate_model_audit(load_golden_case(fixture))
+    assert not validation.automation_ready
+    assert "model_audit[0].route_type_missing" in validation.errors
+    assert "model_audit[0].status_missing" in validation.errors


### PR DESCRIPTION
## Summary
- add native/legacy JurisDigta golden ZIP loader and deterministic normalized-text comparison
- register scenario 01 private-loan payment confirmation as a synthetic legacy seed with route expectations
- document the required manual synthetic JurisDigta creation, human review, native export replacement, privacy controls, and ignored run artifacts
- add focused minimal demo and offline tests/catalog command

## Validation
-  .\\conda\\python.exe -m pytest tests\\test_golden_cases.py tests\\test_models_testing_fixtures.py  (5 passed)
-  .\\conda\\python.exe -m ruff check src\\aijurisdictionagents\\golden_cases.py tests\\test_golden_cases.py examples\\model_validation_runner_demo.py `n-  .\\conda\\python.exe -m mypy src\\aijurisdictionagents\\golden_cases.py `n-  .\\conda\\python.exe examples\\model_validation_runner_demo.py `n-  .\\conda\\python.exe examples\\minimal_demo.py `n
Closes #472