### PR TITLE
Prevent model-routing request deadlocks

### DIFF
--- a/api/aijuristiction-api/app/effective_model_routing_api.py
+++ b/api/aijuristiction-api/app/effective_model_routing_api.py
@@ -44,9 +44,7 @@ class SelectableModelProfilesResponse(BaseModel):
 
 
 def get_store() -> ApiDatabaseStore:
-    store = ApiDatabaseStore.from_env()
-    store.initialize()
-    return store
+    return ApiDatabaseStore.from_env()
 
 
 @router.get("/effective", response_model=EffectiveModelRouteResponse)

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260529"
+version = "1.0.260530"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_ai_model_routing.py
+++ b/api/aijuristiction-api/tests/test_ai_model_routing.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastapi.testclient import TestClient
 import pytest
 
+from app.effective_model_routing_api import get_store as get_effective_model_routing_store
 from app.main import app
 from aijurisdictionagents.api_db import ApiDatabaseStore
 from aijurisdictionagents.llm import routing
@@ -284,6 +285,7 @@ def test_effective_model_route_endpoint_reports_default_free_route_without_user(
     monkeypatch.setenv("DB_LOCAL", str(db_path))
     monkeypatch.setenv("STORAGE_OPTION", "local")
     monkeypatch.setenv("STORE_LOCAL", str(blob_root))
+    ApiDatabaseStore(db_path=db_path, blob_root=blob_root).initialize()
 
     response = client.get(
         "/v1/model-routing/effective?task_type=chat_reply",
@@ -328,7 +330,10 @@ def test_selectable_model_profiles_endpoint_returns_safe_metadata_for_eligible_u
     user = store.create_user(email="selector@example.com", password="secret", full_name="Selector")
 
     response = client.get(
-        f"/v1/model-routing/selectable?user_id={user.user_id}",
+        (
+            f"/v1/model-routing/selectable?user_id={user.user_id}"
+            "&user_email=selector@example.com"
+        ),
         headers={"x-api-key": "aijuris"},
     )
 
@@ -342,6 +347,25 @@ def test_selectable_model_profiles_endpoint_returns_safe_metadata_for_eligible_u
     assert "base_url" not in first_profile
     assert "api_key" not in response.text
     assert "protected_secret" not in response.text
+
+
+def test_effective_model_routing_request_store_does_not_initialize(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    monkeypatch.setattr(
+        ApiDatabaseStore,
+        "from_env",
+        classmethod(lambda cls: store),
+    )
+
+    def fail_request_time_initialize(self: ApiDatabaseStore) -> None:
+        raise AssertionError("Request dependencies must not initialize database schemas.")
+
+    monkeypatch.setattr(ApiDatabaseStore, "initialize", fail_request_time_initialize)
+
+    assert get_effective_model_routing_store() is store
 
 
 def test_selectable_model_profiles_endpoint_accepts_email_fallback_for_eligible_user(

--- a/docs/API_DATABASE_LAYER.md
+++ b/docs/API_DATABASE_LAYER.md
@@ -231,6 +231,12 @@ credentials, prompts, documents, or case content. Regular users receive
 transient: they apply to the current chat session/reply/stream workflow and
 reset on page reload or new case.
 
+The API applies SQL migrations and initializes database schemas once during
+application startup. Model-routing request dependencies only open a configured
+store and perform normal reads; they must not call `ApiDatabaseStore.initialize()`
+per request. This avoids concurrent schema/seed writes and PostgreSQL deadlocks
+when the frontend loads effective and selectable routes in parallel.
+
 Seeded defaults:
 
 - Free/default users route to `local_ollama_default`, provider `local_ollama`, model `qwen3:1.7b`. Local developer runs default to `http://127.0.0.1:11434/v1`; self-managed Docker production seeds the private Docker gateway URL so API containers can reach the host-local Ollama service.

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -11,6 +11,10 @@ print(
     "only key names/statuses are reported and secret values remain redacted."
 )
 print(
+    "model_routing_request_store => database migrations and schema initialization run at API "
+    "startup; effective/selectable request dependencies are read-only to avoid PostgreSQL deadlocks."
+)
+print(
     "web_mfa_reuse => MFA_REUSE_WINDOW_HOURS=12 skips repeat MFA for 12 hours after successful "
     "verification while logout still ends the session; set 0 to require MFA on every sign-in."
 )


### PR DESCRIPTION
Closes #561.

## What changed

- removed `ApiDatabaseStore.initialize()` from the effective/selectable model-routing request dependency
- retained migrations and schema initialization in the existing API startup hook
- covered the exact combined `user_id` + `user_email` selectable request
- added a regression test that fails if the request dependency initializes schemas
- updated the SQLite fixture to model startup initialization explicitly
- documented the startup-only lifecycle and bumped the API revision to `1.0.260530`
- updated the default minimal demo

## Root cause

Production logs from `jurisdigta-server` showed `psycopg.errors.DeadlockDetected` in `_ensure_user_schema()` while `GET /v1/model-routing/selectable` called `store.initialize()` concurrently with another request. The endpoint returned HTTP 500; retries returned 200.

## Impact

Model-routing requests now perform normal configured-store reads without request-time schema/seed writes. Authorization and privacy-minimized response metadata are unchanged.

## Validation

- `.\\scripts\\validate_api.ps1` — Ruff and mypy passed
- focused model-routing suite — 26 passed
- full API unit suite — 401 passed using isolated deterministic test settings (local SQLite, mock LLM, and profile values removed after app preload so tests control MFA/embedding settings)
- `.\\conda\\python.exe examples\\minimal_demo.py` — passed
- pre-commit API checks — passed