### PR TITLE
Retain one previous production image

### DIFF
--- a/Deployment/self-managed-server-deployment.md
+++ b/Deployment/self-managed-server-deployment.md
@@ -7,6 +7,7 @@ Checked-in automation:
 - `Deployment/server/setup_jurisdigta_server.sh` installs Ubuntu packages, Docker, deployment directories, firewall baseline, and the first repository checkout.
 - `Deployment/server/deploy_jurisdigta_prod.sh` updates the server checkout, deploys PostgreSQL/API/MCP/email scheduler/web/document processor/laws collector/status monitoring, and validates local health checks.
 - `.github/workflows/self_managed_prod_deploy.yml` runs the production deploy script over SSH from the protected GitHub `prod` Environment.
+- Successful deployments retain only the active `:local` image and one `:previous` image for each JurisDigta-built service. Cleanup runs after health validation and never removes volumes or running images.
 
 Current target verified from Codex on 2026-06-13:
 
@@ -22,7 +23,7 @@ Current target verified from Codex on 2026-06-13:
 
 - Use the non-root account `jurisdigta-admin` for SSH and deployment operations.
 - Keep application secrets in server-local environment files or runtime secret stores, never in Git.
-- Restrict environment files to the deployment user and root: `chmod 600`.
+- Keep the runtime environment file owned by `root:jurisdigta-admin` with mode `640`, so only root can write it and the deployment account can read it. Keep standalone backup/profile copies at mode `600`.
 - Keep PostgreSQL runtime data under `/srv/jurisdigta/runs/storage/...` to mirror the repository layout.
 - Keep SQL assets in the repository under `databases/`; do not place database runtime files there.
 - Enable logs for traceability, but avoid logging personal data, legal facts, document contents, access tokens, API keys, or full PostgreSQL connection strings.
@@ -260,7 +261,8 @@ Create a server-local environment file from the repository example and edit it m
 ```bash
 cd /srv/jurisdigta/app
 cp .env.example /srv/jurisdigta/secrets/jurisdigta.env
-chmod 600 /srv/jurisdigta/secrets/jurisdigta.env
+sudo chown root:jurisdigta-admin /srv/jurisdigta/secrets/jurisdigta.env
+sudo chmod 640 /srv/jurisdigta/secrets/jurisdigta.env
 nano /srv/jurisdigta/secrets/jurisdigta.env
 ```
 
@@ -774,6 +776,25 @@ python examples/minimal_demo.py
 
 ## 14. Rollback
 
+For an image-only rollback, promote the retained previous image before restarting the affected service:
+
+```bash
+docker image inspect jurisdigta-web:previous
+docker image tag jurisdigta-web:previous jurisdigta-web:local
+docker rm -f jurisdigta-web
+docker run -d --name jurisdigta-web --restart unless-stopped -p 127.0.0.1:8090:80 jurisdigta-web:local
+```
+
+Use the service's normal production `docker run` options from `deploy_jurisdigta_prod.sh`; the shortened web command above is only an operator example. Validate the relevant local health endpoint after rollback. The next successful deployment recreates `:previous` from the image that was active before that deployment.
+
+Image-retention behavior:
+
+- Before each build, the active `:local` image is tagged `:rollback-candidate`.
+- If an earlier deployment was interrupted, its existing candidate is preserved instead of overwritten.
+- After all service health checks pass, the candidate becomes `:previous`.
+- Images older than `:previous` and unused build cache are pruned.
+- Failed deployments do not finalize or prune retention state.
+
 Stop containers:
 
 ```bash
@@ -955,7 +976,8 @@ The local workstation `.env` was copied to:
 Permissions:
 
 ```bash
-chmod 600 /srv/jurisdigta/secrets/jurisdigta.env
+sudo chown root:jurisdigta-admin /srv/jurisdigta/secrets/jurisdigta.env
+sudo chmod 640 /srv/jurisdigta/secrets/jurisdigta.env
 ```
 
 ### Repository And Images
@@ -1229,7 +1251,7 @@ rm -f /srv/jurisdigta/ops/run_laws_collector_daily.sh
 
 ### Compliance Notes From Execution
 
-- Secrets were stored in `/srv/jurisdigta/secrets/jurisdigta.env` with `600` permissions.
+- Secrets were stored in `/srv/jurisdigta/secrets/jurisdigta.env` as `root:jurisdigta-admin` with `640` permissions, giving the deployment account read-only access.
 - Full secret values are not documented in this runbook.
 - The laws backup contains legal corpus data and embeddings; keep it under controlled storage and define retention/deletion policy.
 - The restore created a rollback backup before replacing `laws_sk`.

--- a/Deployment/server/deploy_jurisdigta_prod.sh
+++ b/Deployment/server/deploy_jurisdigta_prod.sh
@@ -35,6 +35,8 @@ LOCAL_LLM_HEALTH_URL="${LOCAL_LLM_HEALTH_URL:-http://127.0.0.1:11434/api/tags}"
 OLLAMA_HOST_BIND="${OLLAMA_HOST_BIND:-}"
 export DOCKER_BUILDKIT=0
 
+PREPARED_IMAGE_REPOSITORIES=()
+
 log() {
   printf '[jurisdigta-deploy] %s\n' "$*"
 }
@@ -46,6 +48,50 @@ fail() {
 
 require_command() {
   command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+prepare_image_rollback_candidate() {
+  local repository="$1"
+  local candidate="${repository}:rollback-candidate"
+  local current="${repository}:local"
+
+  if docker image inspect "$candidate" >/dev/null 2>&1; then
+    PREPARED_IMAGE_REPOSITORIES+=("$repository")
+    log "preserving existing rollback candidate for $repository from an earlier interrupted deployment"
+    return
+  fi
+  if ! docker image inspect "$current" >/dev/null 2>&1; then
+    log "no existing $current image to preserve on first deployment"
+    return
+  fi
+
+  docker image tag "$current" "$candidate"
+  PREPARED_IMAGE_REPOSITORIES+=("$repository")
+  log "preserved $current as $candidate"
+}
+
+finalize_image_retention() {
+  local repository
+  local candidate
+  local previous
+
+  log "finalizing Docker image retention after successful health validation"
+  for repository in "${PREPARED_IMAGE_REPOSITORIES[@]}"; do
+    candidate="${repository}:rollback-candidate"
+    previous="${repository}:previous"
+    if ! docker image inspect "$candidate" >/dev/null 2>&1; then
+      continue
+    fi
+    docker image tag "$candidate" "$previous"
+    docker image rm "$candidate" >/dev/null
+    log "retained $previous for one-version rollback"
+  done
+
+  # Re-tagging the rollback candidate leaves versions older than :previous
+  # dangling. Prune only images not referenced by a tag or container; volumes
+  # and running images are outside this operation.
+  docker image prune -f
+  docker builder prune -a -f
 }
 
 postgres_url() {
@@ -326,6 +372,7 @@ start_postgres_and_build_image() {
   compose_env
   cd "$APP_DIR/api/aijuristiction-api"
   docker compose --env-file "$ENV_FILE" up -d postgres
+  prepare_image_rollback_candidate "aijuristiction-api"
   docker compose --env-file "$ENV_FILE" build api
 }
 
@@ -539,6 +586,7 @@ deploy_web() {
   log "building and starting frontend web container"
   cd "$APP_DIR/frontend/aijurisdictionfronend"
   local chat_model_label="${AZURE_OPENAI_DEPLOYMENT:-Azure Foundry model}"
+  prepare_image_rollback_candidate "jurisdigta-web"
   docker build \
     --build-arg "VITE_API_BASE_URL=$WEB_API_BASE_URL" \
     --build-arg "VITE_CHAT_MODEL_LABEL=$chat_model_label" \
@@ -556,6 +604,7 @@ deploy_web() {
 build_laws_collector() {
   log "building laws collector image"
   cd "$APP_DIR"
+  prepare_image_rollback_candidate "jurisdigta-laws-collector"
   docker build -t jurisdigta-laws-collector:local -f src/services/laws_collector/Dockerfile .
 }
 
@@ -611,6 +660,7 @@ start_court_decision_collector() {
 build_document_processor() {
   log "building document processor image"
   cd "$APP_DIR"
+  prepare_image_rollback_candidate "jurisdigta-document-processor"
   docker build -t jurisdigta-document-processor:local -f src/services/document_processor/Dockerfile .
 }
 
@@ -622,6 +672,7 @@ build_document_engine() {
 
   log "building document engine image"
   cd "$APP_DIR/services/document-engine-service"
+  prepare_image_rollback_candidate "jurisdigta-document-engine"
   docker build -t jurisdigta-document-engine:local .
 }
 
@@ -1043,5 +1094,6 @@ install_log_retention_cron
 start_monitoring
 connect_api_to_monitoring_network
 validate_health
+finalize_image_retention
 
 log "production deployment complete"

--- a/docs/manual_infrastucture_setup.md
+++ b/docs/manual_infrastucture_setup.md
@@ -646,6 +646,16 @@ The self-managed production deployment script performs the Ollama install, priva
 - Remove Docker/GitHub CLI/nginx packages only if the server is being decommissioned.
 - Remove the deploy-only public key from `/home/jurisdigta-admin/.ssh/authorized_keys` and delete/rotate `JURISDIGTA_SSH_PRIVATE_KEY` if GitHub deployment access must be revoked.
 
+### Production Docker Image Retention
+
+- Required owner: the `jurisdigta-admin` deployment operator with Docker access.
+- Every successful `Deployment/server/deploy_jurisdigta_prod.sh` run keeps `:local` plus one `:previous` tag for API, web, document processor, document engine, and laws collector images.
+- Retention is finalized only after health validation. Older dangling images and unused build cache are then removed; Docker volumes and `/srv/jurisdigta/runs` are never cleanup targets.
+- Validate with `docker image ls --format '{{.Repository}}:{{.Tag}}' | grep -E '^(aijuristiction-api|jurisdigta-(web|document-processor|document-engine|laws-collector)):(local|previous)$'` and `docker system df`.
+- Roll back by tagging the affected `:previous` image as `:local`, recreating that service with its normal production arguments, and validating its local health endpoint.
+- If cleanup itself causes an operational concern, omit `finalize_image_retention` in a controlled rollback deployment; do not replace it with global volume or runtime-storage deletion.
+- Keep `/srv/jurisdigta/secrets/jurisdigta.env` owned by `root:jurisdigta-admin` at mode `0640`; validate with `stat -c '%a %U %G %n' /srv/jurisdigta/secrets/jurisdigta.env`. This is distinct from encrypted USB profile files, which remain mode `0600`.
+
 ### Privacy And Compliance Notes
 
 - Treat server environment files, PostgreSQL data, document storage, logs, and backups as sensitive operational data.

--- a/examples/docker_image_retention_minimal_demo.py
+++ b/examples/docker_image_retention_minimal_demo.py
@@ -1,0 +1,36 @@
+"""Minimal runnable verification for production Docker image retention.
+
+Run:
+    python examples/docker_image_retention_minimal_demo.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEPLOY_SCRIPT = REPO_ROOT / "Deployment" / "server" / "deploy_jurisdigta_prod.sh"
+
+
+def require(token: str, message: str) -> None:
+    content = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    if token not in content:
+        raise AssertionError(f"{message}\nMissing token: {token}")
+
+
+if __name__ == "__main__":
+    require("prepare_image_rollback_candidate", "Deployments must preserve the active image.")
+    require('candidate="${repository}:rollback-candidate"', "Interrupted deploys need a stable candidate tag.")
+    require('previous="${repository}:previous"', "One previous version must remain tagged.")
+    require(
+        'for repository in "${PREPARED_IMAGE_REPOSITORIES[@]}"',
+        "Only images prepared by the current deployment may be finalized.",
+    )
+    require("validate_health\nfinalize_image_retention", "Cleanup must run only after health validation.")
+    require("docker image prune -f", "Images older than the previous version must be pruned.")
+    require("docker builder prune -a -f", "Unused build cache must be pruned.")
+    if "docker volume prune" in DEPLOY_SCRIPT.read_text(encoding="utf-8"):
+        raise AssertionError("Image retention must never prune Docker volumes.")
+
+    print("Docker image retention minimal demo checks passed.")


### PR DESCRIPTION
## What changed
- preserve each deployed JurisDigta `:local` image as an interruption-safe rollback candidate before rebuilding
- after successful health validation, retain that candidate as the single `:previous` version
- prune images older than `:previous` and unused builder cache only after deployment succeeds
- document validation, rollback, ownership, and safety boundaries
- add a minimal runnable retention verification

## Why
The production host accumulated hundreds of gigabytes of old Docker layers. Deployment had no image lifecycle policy, so repeated fixed-tag builds left older images dangling indefinitely.

## Safety
- failed deployments do not finalize or prune retention state
- an existing candidate from an interrupted deployment is not overwritten
- only images prepared by the current deployment are promoted
- running images, containers, Docker volumes, databases, and `/srv/jurisdigta/runs` are outside cleanup scope

## Validation
- `python examples/docker_image_retention_minimal_demo.py`
- `bash -n Deployment/server/deploy_jurisdigta_prod.sh` on `jurisdigta-server`
- mocked Bash prepare/finalize lifecycle
- `git diff --check`
- live unused-image and builder-cache cleanup completed with 334 GB free remaining