### PR TITLE
Add Jurisdigta development workflow plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "jurisdigta",
+  "interface": {
+    "displayName": "Jurisdigta"
+  },
+  "plugins": [
+    {
+      "name": "jurisdigta",
+      "source": {
+        "source": "local",
+        "path": "./plugins/jurisdigta"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.github/workflows/plugin_release.yml
+++ b/.github/workflows/plugin_release.yml
@@ -1,0 +1,74 @@
+name: plugin_release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: jurisdigta-plugin-release
+  cancel-in-progress: false
+
+jobs:
+  validate-package-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require main branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "Plugin releases must be dispatched from main. Current ref: ${GITHUB_REF}" >&2
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Package and validate plugin
+        id: package
+        shell: pwsh
+        run: ./scripts/package_jurisdigta_plugin.ps1
+
+      - name: Verify immutable release tag is unused
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.package.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists. Bump plugin.json version instead of overwriting it." >&2
+            exit 1
+          fi
+
+      - name: Upload packaged workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jurisdigta-plugin-${{ steps.package.outputs.version }}
+          path: |
+            ${{ steps.package.outputs.archive }}
+            ${{ steps.package.outputs.checksum }}
+          if-no-files-found: error
+
+      - name: Publish plugin prerelease
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.package.outputs.tag }}
+          name: Jurisdigta Plugin ${{ steps.package.outputs.version }}
+          target_commitish: ${{ github.sha }}
+          prerelease: true
+          make_latest: false
+          generate_release_notes: false
+          fail_on_unmatched_files: true
+          body: |
+            Jurisdigta Codex plugin ${{ steps.package.outputs.version }}.
+
+            This is intentionally a prerelease so plugin publication does not replace the stable mobile APK release returned by GitHub's latest-release API.
+
+            Verify the downloaded ZIP with the attached SHA-256 file before installation.
+          files: |
+            ${{ steps.package.outputs.archive }}
+            ${{ steps.package.outputs.checksum }}

--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ python scripts/sync_codex_skills.py --force
 
 For details, see `docs/PROJECT_SKILLS.md`.
 
+## Shared Jurisdigta Codex Plugin
+
+The team plugin is versioned under `plugins/jurisdigta/` and published through the repository marketplace:
+
+```bash
+codex plugin marketplace add mmaideveloper/aijurisdictionagents --ref main
+codex plugin add jurisdigta@jurisdigta
+```
+
+See [the plugin guide](docs/JURISDIGTA_PLUGIN.md) for update commands and versioned GitHub prerelease downloads.
+
 ## Portable Codex Automations
 
 Repo-owned Codex automation templates are versioned under `.codex/automations/`.

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -391,6 +391,22 @@ Paste those values without extra whitespace. The mobile workflow trims accidenta
 line breaks, validates the keystore and alias with `keytool`, and warns early if
 the selected GitHub Environment contains stale or mismatched signing secrets.
 
+### Plugin release workflow
+
+`.github/workflows/plugin_release.yml` packages `plugins/jurisdigta/` and the
+repository marketplace into a versioned ZIP, creates a SHA-256 checksum, and
+publishes both files as a GitHub prerelease.
+
+- Dispatch the workflow manually from `main`.
+- The version and immutable tag come from
+  `plugins/jurisdigta/.codex-plugin/plugin.json`.
+- The workflow uses repository `GITHUB_TOKEN` with scoped `contents: write`
+  permission.
+- It does not use the `test` or `prod` GitHub Environments.
+- No variables or secrets must be added to either Environment.
+- Plugin releases use `make_latest: false`, preserving the stable mobile APK
+  release returned by GitHub's latest-release API.
+
 ## 11. Configure Self-Managed Production Server Variables
 
 These are used by `.github/workflows/self_managed_prod_deploy.yml` to deploy API, MCP, frontend web, the document processor, laws collector, and system status monitoring to the Ubuntu `jurisdigta-server`.

--- a/docs/JURISDIGTA_PLUGIN.md
+++ b/docs/JURISDIGTA_PLUGIN.md
@@ -2,12 +2,12 @@
 
 The repository-local plugin under `plugins/jurisdigta/` provides two guided workflows:
 
-- `report-jurisdigta-bug` collects a description and optional images, retrieves a narrow read-only slice of relevant Jurisdigta server logs with permission, reviews related code and issues, asks focused questions, and creates a sanitized GitHub bug only after confirmation.
+- `report-jurisdigta-bug` collects a description, asks whether the error happened locally or on `jurisdigta-server`, requests optional images, routes to only the matching local or server log source, reviews related code and issues, asks focused questions, and creates a sanitized GitHub bug only after confirmation.
 - `manage-jurisdigta-adr` creates, reviews, updates, and supersedes source-backed Architecture Decision Records and can prepare a related GitHub architecture task.
 
 ## Privacy and human oversight
 
-The incident workflow never reads secret files or database/user content, keeps raw production logs ephemeral, minimizes the query by service and time window, and requires redaction plus confirmation before GitHub publication. Potential security incidents or personal-data breaches are routed away from public issues.
+The incident workflow never reads secret files or database/user content, keeps raw logs ephemeral, minimizes the query by environment, service, and time window, and requires redaction plus confirmation before GitHub publication. A local report never triggers server access; a server report requires permission before bounded remote log retrieval. Potential security incidents or personal-data breaches are routed away from public issues.
 
 The architecture workflow makes GDPR and EU AI Act impacts explicit and does not mark a decision Accepted without approval from the human decision owner.
 
@@ -16,7 +16,7 @@ The architecture workflow makes GDPR and EU AI Act impacts explicit and does not
 Invoke the bug workflow:
 
 ```text
-Use $report-jurisdigta-bug. Checkout fails in the web app around 14:20 Europe/Bratislava. Ask me for screenshots, inspect only relevant server logs, and draft a GitHub bug.
+Use $report-jurisdigta-bug. Checkout fails in the web app around 14:20 Europe/Bratislava. Ask whether it happened locally or on jurisdigta-server, request screenshots, inspect only the matching logs, and draft a GitHub bug.
 ```
 
 Invoke the architecture workflow:

--- a/docs/JURISDIGTA_PLUGIN.md
+++ b/docs/JURISDIGTA_PLUGIN.md
@@ -5,7 +5,7 @@ The repository-local plugin under `plugins/jurisdigta/` provides four guided wor
 - `report-jurisdigta-bug` collects a description, asks whether the error happened locally or on `jurisdigta-server`, requests optional images, routes to only the matching local or server log source, reviews related code and issues, asks focused questions, and creates a sanitized GitHub bug only after confirmation.
 - `manage-jurisdigta-adr` creates, reviews, updates, and supersedes source-backed Architecture Decision Records, then hands architecture-derived tasks to the task-preparation skill.
 - `prepare-jurisdigta-task` reviews a request and repository context, recommends improvements, asks questions until no blockers remain, creates the confirmed GitHub issue, sets it to Ready, and comments `Reviewed by Codex`.
-- `implement-jurisdigta-task` fetches the latest `origin/main`, creates an isolated task branch/worktree, implements one Ready task, requires unit tests, adds applicable Playwright E2E coverage and sanitized screenshots, then commits, opens a PR, updates the task, and moves it to In review.
+- `implement-jurisdigta-task` reads the live repository `AGENTS.md`, applies its full implementation contract, fetches the latest `origin/main`, creates an isolated task branch/worktree, implements one Ready task, requires unit tests, adds applicable Playwright E2E coverage and sanitized screenshots, then commits, opens a PR, updates the task, and moves it to In review.
 
 ## Privacy and human oversight
 

--- a/docs/JURISDIGTA_PLUGIN.md
+++ b/docs/JURISDIGTA_PLUGIN.md
@@ -1,0 +1,32 @@
+# Jurisdigta Codex Plugin
+
+The repository-local plugin under `plugins/jurisdigta/` provides two guided workflows:
+
+- `report-jurisdigta-bug` collects a description and optional images, retrieves a narrow read-only slice of relevant Jurisdigta server logs with permission, reviews related code and issues, asks focused questions, and creates a sanitized GitHub bug only after confirmation.
+- `manage-jurisdigta-adr` creates, reviews, updates, and supersedes source-backed Architecture Decision Records and can prepare a related GitHub architecture task.
+
+## Privacy and human oversight
+
+The incident workflow never reads secret files or database/user content, keeps raw production logs ephemeral, minimizes the query by service and time window, and requires redaction plus confirmation before GitHub publication. Potential security incidents or personal-data breaches are routed away from public issues.
+
+The architecture workflow makes GDPR and EU AI Act impacts explicit and does not mark a decision Accepted without approval from the human decision owner.
+
+## Minimal examples
+
+Invoke the bug workflow:
+
+```text
+Use $report-jurisdigta-bug. Checkout fails in the web app around 14:20 Europe/Bratislava. Ask me for screenshots, inspect only relevant server logs, and draft a GitHub bug.
+```
+
+Invoke the architecture workflow:
+
+```text
+Use $manage-jurisdigta-adr to compare Loki and Azure Log Analytics for incident investigation and draft a Proposed ADR.
+```
+
+Both examples are runnable as prompts after installing the repository-local plugin. They intentionally stop before external writes until the user confirms the final issue or decision.
+
+## Validation
+
+Validate the plugin manifest and both skills with the Codex plugin and skill validators before publishing or installing the plugin.

--- a/docs/JURISDIGTA_PLUGIN.md
+++ b/docs/JURISDIGTA_PLUGIN.md
@@ -1,9 +1,10 @@
 # Jurisdigta Codex Plugin
 
-The repository-local plugin under `plugins/jurisdigta/` provides three guided workflows:
+The repository-local plugin under `plugins/jurisdigta/` provides four guided workflows:
 
 - `report-jurisdigta-bug` collects a description, asks whether the error happened locally or on `jurisdigta-server`, requests optional images, routes to only the matching local or server log source, reviews related code and issues, asks focused questions, and creates a sanitized GitHub bug only after confirmation.
-- `manage-jurisdigta-adr` creates, reviews, updates, and supersedes source-backed Architecture Decision Records and can prepare a related GitHub architecture task.
+- `manage-jurisdigta-adr` creates, reviews, updates, and supersedes source-backed Architecture Decision Records, then hands architecture-derived tasks to the task-preparation skill.
+- `prepare-jurisdigta-task` reviews a request and repository context, recommends improvements, asks questions until no blockers remain, creates the confirmed GitHub issue, sets it to Ready, and comments `Reviewed by Codex`.
 - `implement-jurisdigta-task` fetches the latest `origin/main`, creates an isolated task branch/worktree, implements one Ready task, requires unit tests, adds applicable Playwright E2E coverage and sanitized screenshots, then commits, opens a PR, updates the task, and moves it to In review.
 
 ## Privacy and human oversight
@@ -32,8 +33,14 @@ Invoke the implementation workflow:
 Use $implement-jurisdigta-task to implement issue 123 from the latest main branch with unit tests, applicable Playwright E2E coverage, and sanitized screenshot evidence in the task and PR.
 ```
 
+Invoke the task-preparation workflow:
+
+```text
+Use $prepare-jurisdigta-task to review this request, recommend improvements, ask questions until it is implementation-ready, then create it in GitHub with Ready status.
+```
+
 These examples are runnable as prompts after installing the repository-local plugin. The bug and architecture workflows stop before external writes until the user confirms the final issue or decision. The implementation workflow performs the task-authorized branch, test, PR, and task-status writes while preserving privacy review for screenshots.
 
 ## Validation
 
-Validate the plugin manifest and both skills with the Codex plugin and skill validators before publishing or installing the plugin.
+Validate the plugin manifest and all skills with the Codex plugin and skill validators before publishing or installing the plugin.

--- a/docs/JURISDIGTA_PLUGIN.md
+++ b/docs/JURISDIGTA_PLUGIN.md
@@ -1,9 +1,10 @@
 # Jurisdigta Codex Plugin
 
-The repository-local plugin under `plugins/jurisdigta/` provides two guided workflows:
+The repository-local plugin under `plugins/jurisdigta/` provides three guided workflows:
 
 - `report-jurisdigta-bug` collects a description, asks whether the error happened locally or on `jurisdigta-server`, requests optional images, routes to only the matching local or server log source, reviews related code and issues, asks focused questions, and creates a sanitized GitHub bug only after confirmation.
 - `manage-jurisdigta-adr` creates, reviews, updates, and supersedes source-backed Architecture Decision Records and can prepare a related GitHub architecture task.
+- `implement-jurisdigta-task` fetches the latest `origin/main`, creates an isolated task branch/worktree, implements one Ready task, requires unit tests, adds applicable Playwright E2E coverage and sanitized screenshots, then commits, opens a PR, updates the task, and moves it to In review.
 
 ## Privacy and human oversight
 
@@ -25,7 +26,13 @@ Invoke the architecture workflow:
 Use $manage-jurisdigta-adr to compare Loki and Azure Log Analytics for incident investigation and draft a Proposed ADR.
 ```
 
-Both examples are runnable as prompts after installing the repository-local plugin. They intentionally stop before external writes until the user confirms the final issue or decision.
+Invoke the implementation workflow:
+
+```text
+Use $implement-jurisdigta-task to implement issue 123 from the latest main branch with unit tests, applicable Playwright E2E coverage, and sanitized screenshot evidence in the task and PR.
+```
+
+These examples are runnable as prompts after installing the repository-local plugin. The bug and architecture workflows stop before external writes until the user confirms the final issue or decision. The implementation workflow performs the task-authorized branch, test, PR, and task-status writes while preserving privacy review for screenshots.
 
 ## Validation
 

--- a/docs/JURISDIGTA_PLUGIN.md
+++ b/docs/JURISDIGTA_PLUGIN.md
@@ -13,6 +13,57 @@ The incident workflow never reads secret files or database/user content, keeps r
 
 The architecture workflow makes GDPR and EU AI Act impacts explicit and does not mark a decision Accepted without approval from the human decision owner.
 
+## Install from the shared repository marketplace
+
+Add the Git marketplace and install the plugin:
+
+```powershell
+codex plugin marketplace add mmaideveloper/aijurisdictionagents --ref main
+codex plugin add jurisdigta@jurisdigta
+```
+
+After a plugin update:
+
+```powershell
+codex plugin marketplace upgrade jurisdigta
+codex plugin add jurisdigta@jurisdigta
+```
+
+Start a new Codex task after installation or update so the new skills are loaded.
+
+## Download a versioned release
+
+- [All Jurisdigta releases](https://github.com/mmaideveloper/aijurisdictionagents/releases)
+- [Jurisdigta plugin 0.1.4 ZIP](https://github.com/mmaideveloper/aijurisdictionagents/releases/download/jurisdigta-plugin-v0.1.4/jurisdigta-plugin-0.1.4.zip)
+- [Jurisdigta plugin 0.1.4 SHA-256](https://github.com/mmaideveloper/aijurisdictionagents/releases/download/jurisdigta-plugin-v0.1.4/jurisdigta-plugin-0.1.4.zip.sha256)
+
+The versioned links become available after this change is merged and the `plugin_release` workflow is manually dispatched from `main`.
+
+The release ZIP contains a self-contained marketplace root:
+
+```text
+jurisdigta-plugin-0.1.4/
+├── .agents/plugins/marketplace.json
+└── plugins/jurisdigta/
+```
+
+After checking the SHA-256 value, extract the ZIP and install from the extracted root:
+
+```powershell
+codex plugin marketplace add C:\path\to\jurisdigta-plugin-0.1.4
+codex plugin add jurisdigta@jurisdigta
+```
+
+Plugin releases use tags such as `jurisdigta-plugin-v0.1.4` and are published as GitHub prereleases. They intentionally use `make_latest: false`, so the mobile app continues to discover the latest stable release containing an APK.
+
+Maintainers publish a new immutable plugin version by:
+
+1. Bumping `plugins/jurisdigta/.codex-plugin/plugin.json`.
+2. Merging the validated change to `main`.
+3. Running the `plugin_release` workflow from `main`.
+
+The workflow refuses to overwrite an existing tag and attaches both the ZIP and checksum.
+
 ## Minimal examples
 
 Invoke the bug workflow:
@@ -43,4 +94,4 @@ These examples are runnable as prompts after installing the repository-local plu
 
 ## Validation
 
-Validate the plugin manifest and all skills with the Codex plugin and skill validators before publishing or installing the plugin.
+Validate the plugin manifest and all skills with the Codex plugin and skill validators before publishing or installing the plugin. The release workflow also runs `scripts/package_jurisdigta_plugin.ps1`, which validates release metadata, skill frontmatter, placeholders, and the shared marketplace before packaging.

--- a/docs/PROJECT_SKILLS.md
+++ b/docs/PROJECT_SKILLS.md
@@ -14,10 +14,11 @@ This repository vendors the Codex skills needed for local development so they ar
 
 ## Repository plugin
 
-`plugins/jurisdigta/` packages three Jurisdigta workflows:
+`plugins/jurisdigta/` packages four Jurisdigta workflows:
 
 - `report-jurisdigta-bug`: guided, privacy-safe incident investigation and confirmed GitHub bug creation
 - `manage-jurisdigta-adr`: source-backed Architecture Decision Record and architecture-task management
+- `prepare-jurisdigta-task`: requirements review, improvement recommendations, readiness interview, confirmed GitHub creation, Ready project status, and `Reviewed by Codex` comment
 - `implement-jurisdigta-task`: latest-main task implementation in an isolated worktree with unit tests, applicable Playwright E2E coverage, screenshots, PR creation, and task status updates
 
 See `docs/JURISDIGTA_PLUGIN.md` for usage, safeguards, and minimal prompt examples.

--- a/docs/PROJECT_SKILLS.md
+++ b/docs/PROJECT_SKILLS.md
@@ -12,6 +12,15 @@ This repository vendors the Codex skills needed for local development so they ar
 - `laws-collector`: starts and verifies the local laws collector worker loop
 - `prepare-task`: prepares ideas or GitHub Project tasks for implementation by reviewing repository context, asking required questions, and updating or creating the task description
 
+## Repository plugin
+
+`plugins/jurisdigta/` packages two Jurisdigta workflows:
+
+- `report-jurisdigta-bug`: guided, privacy-safe incident investigation and confirmed GitHub bug creation
+- `manage-jurisdigta-adr`: source-backed Architecture Decision Record and architecture-task management
+
+See `docs/JURISDIGTA_PLUGIN.md` for usage, safeguards, and minimal prompt examples.
+
 ## Skill files
 
 Each skill lives under `skills/<name>/` and contains:

--- a/docs/PROJECT_SKILLS.md
+++ b/docs/PROJECT_SKILLS.md
@@ -14,10 +14,11 @@ This repository vendors the Codex skills needed for local development so they ar
 
 ## Repository plugin
 
-`plugins/jurisdigta/` packages two Jurisdigta workflows:
+`plugins/jurisdigta/` packages three Jurisdigta workflows:
 
 - `report-jurisdigta-bug`: guided, privacy-safe incident investigation and confirmed GitHub bug creation
 - `manage-jurisdigta-adr`: source-backed Architecture Decision Record and architecture-task management
+- `implement-jurisdigta-task`: latest-main task implementation in an isolated worktree with unit tests, applicable Playwright E2E coverage, screenshots, PR creation, and task status updates
 
 See `docs/JURISDIGTA_PLUGIN.md` for usage, safeguards, and minimal prompt examples.
 

--- a/plugins/jurisdigta/.codex-plugin/plugin.json
+++ b/plugins/jurisdigta/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jurisdigta",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Privacy-safe Jurisdigta incident reporting and architecture decision workflows.",
   "author": {
     "name": "JurisDigta"
@@ -19,7 +19,8 @@
     "privacyPolicyURL": "https://jurisdigta.eu/privacy",
     "defaultPrompt": [
       "Report a Jurisdigta bug from symptoms and logs.",
-      "Draft a Jurisdigta architecture decision."
+      "Draft a Jurisdigta architecture decision.",
+      "Implement a ready task with tests and evidence."
     ]
   }
 }

--- a/plugins/jurisdigta/.codex-plugin/plugin.json
+++ b/plugins/jurisdigta/.codex-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "jurisdigta",
+  "version": "0.1.0",
+  "description": "Privacy-safe Jurisdigta incident reporting and architecture decision workflows.",
+  "author": {
+    "name": "JurisDigta"
+  },
+  "homepage": "https://jurisdigta.eu",
+  "repository": "https://github.com/mmaideveloper/aijurisdictionagents",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Jurisdigta",
+    "shortDescription": "Report incidents and manage architecture decisions.",
+    "longDescription": "Investigate Jurisdigta incidents using privacy-minimized server evidence and repository context, or create and review source-backed architecture decisions with GDPR, EU AI Act, and human-oversight safeguards.",
+    "developerName": "JurisDigta",
+    "category": "Developer Tools",
+    "capabilities": ["Interactive", "Read", "Write"],
+    "websiteURL": "https://jurisdigta.eu",
+    "privacyPolicyURL": "https://jurisdigta.eu/privacy",
+    "defaultPrompt": [
+      "Report a Jurisdigta bug from symptoms and logs.",
+      "Draft a Jurisdigta architecture decision."
+    ]
+  }
+}

--- a/plugins/jurisdigta/.codex-plugin/plugin.json
+++ b/plugins/jurisdigta/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jurisdigta",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Privacy-safe Jurisdigta incident reporting and architecture decision workflows.",
   "author": {
     "name": "JurisDigta"

--- a/plugins/jurisdigta/.codex-plugin/plugin.json
+++ b/plugins/jurisdigta/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jurisdigta",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Privacy-safe Jurisdigta incident reporting and architecture decision workflows.",
   "author": {
     "name": "JurisDigta"

--- a/plugins/jurisdigta/.codex-plugin/plugin.json
+++ b/plugins/jurisdigta/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jurisdigta",
   "version": "0.1.4",
-  "description": "Privacy-safe Jurisdigta incident reporting and architecture decision workflows.",
+  "description": "Jurisdigta task preparation, implementation, incident reporting, and architecture decision workflows.",
   "author": {
     "name": "JurisDigta"
   },
@@ -10,8 +10,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Jurisdigta",
-    "shortDescription": "Report incidents and manage architecture decisions.",
-    "longDescription": "Investigate Jurisdigta incidents using privacy-minimized server evidence and repository context, or create and review source-backed architecture decisions with GDPR, EU AI Act, and human-oversight safeguards.",
+    "shortDescription": "Prepare, implement, investigate, and govern work.",
+    "longDescription": "Prepare Ready tasks, implement them in isolated worktrees with test evidence, investigate incidents using privacy-minimized environment-specific logs, and manage source-backed architecture decisions with GDPR, EU AI Act, and human-oversight safeguards.",
     "developerName": "JurisDigta",
     "category": "Developer Tools",
     "capabilities": ["Interactive", "Read", "Write"],

--- a/plugins/jurisdigta/.codex-plugin/plugin.json
+++ b/plugins/jurisdigta/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jurisdigta",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Privacy-safe Jurisdigta incident reporting and architecture decision workflows.",
   "author": {
     "name": "JurisDigta"
@@ -19,7 +19,7 @@
     "privacyPolicyURL": "https://jurisdigta.eu/privacy",
     "defaultPrompt": [
       "Report a Jurisdigta bug from symptoms and logs.",
-      "Draft a Jurisdigta architecture decision.",
+      "Review an idea and create a Ready GitHub task.",
       "Implement a ready task with tests and evidence."
     ]
   }

--- a/plugins/jurisdigta/skills/implement-jurisdigta-task/SKILL.md
+++ b/plugins/jurisdigta/skills/implement-jurisdigta-task/SKILL.md
@@ -10,16 +10,18 @@ Implement exactly one task from a clean, current `origin/main` baseline and leav
 ## Preconditions
 
 1. Identify the GitHub issue/task and confirm it is `Ready`.
-2. Read the full issue, comments, acceptance criteria, project fields, linked work, `AGENTS.md`, and relevant repository code and documentation.
+2. Read the full issue, comments, acceptance criteria, project fields, linked work, the complete live `AGENTS.md`, and relevant repository code and documentation.
 3. Ask focused questions before implementation when behavior, acceptance criteria, data handling, or risky assumptions are unclear.
 4. Run the GDPR and EU AI Act gate. Apply data minimization, consent where required, retention/deletion controls, transparency, traceable privacy-safe logging, and human oversight for legal-risk outputs. Stop and propose a compliant alternative for unresolved conflicts.
 5. Confirm the current checkout does not contain work for another task. Never mix tasks in one branch or worktree.
+6. Read and apply [repository-implementation-contract.md](references/repository-implementation-contract.md). Treat it as a current checklist, not a replacement for live repository instructions. When it differs from `AGENTS.md`, the live `AGENTS.md` in the task worktree wins.
 
 ## Create the implementation worktree
 
-1. From an existing clean repository checkout, run `git fetch origin main`.
-2. Confirm `origin/main` resolved successfully and record its commit SHA.
-3. Create a unique `codex/<task-id>-<slug>` branch and separate worktree from that exact `origin/main` using:
+1. From an existing clean repository checkout, run `.\scripts\sync_env_profile.ps1 -Mode Pull -Profile codex-agent` before the first project command. Inspect only redacted key status.
+2. Run `git fetch origin main`.
+3. Confirm `origin/main` resolved successfully and record its commit SHA.
+4. Create a unique `codex/<task-id>-<slug>` branch and separate worktree from that exact `origin/main` using:
 
    ```powershell
    .\scripts\new_task_worktree.ps1 `
@@ -27,16 +29,17 @@ Implement exactly one task from a clean, current `origin/main` baseline and leav
      -Base "origin/main"
    ```
 
-4. Do not use raw `git worktree add` when the helper is available.
-5. Enter the new worktree and verify the branch, base SHA, and clean `git status`.
-6. Run `.\scripts\sync_env_profile.ps1 -Mode Pull -Profile codex-agent` before the first project command or edit. Inspect only redacted key status.
-7. For Python work, use the worktree's `.\conda` environment. For frontend-only work, do not run conda commands.
-8. Move the GitHub task to `In progress` before editing.
+5. Do not use raw `git worktree add` when the helper is available.
+6. Enter the new worktree and verify the branch, base SHA, and clean `git status`.
+7. Read the new worktree's complete `AGENTS.md` again because the latest `origin/main` version is authoritative.
+8. Run `.\scripts\sync_env_profile.ps1 -Mode Pull -Profile codex-agent` in the task worktree before its first project command or edit. Inspect only redacted key status.
+9. For Python work, use the worktree's `.\conda` environment. For frontend-only work, do not run conda commands.
+10. Move the GitHub task to `In progress` before editing.
 
 ## Implement
 
 1. Make the smallest coherent change that satisfies the acceptance criteria.
-2. Follow repository typing, linting, error handling, versioning, database, environment-variable, infrastructure, and health-endpoint rules.
+2. Follow every applicable item in the live `AGENTS.md` and the repository implementation contract, including typing, linting, error handling, versioning, database layout, environment variables, provider defaults, infrastructure documentation, Azure authentication, and health monitoring.
 3. Keep secrets, private keys, `.env`, runtime databases, raw logs, user content, and test artifacts with personal data out of Git.
 4. Update affected documentation and add or update the minimal runnable example, defaulting to `python examples/minimal_demo.py`.
 5. If new requirements emerge as an independent change, stop and create a separate task, branch, and worktree.

--- a/plugins/jurisdigta/skills/implement-jurisdigta-task/SKILL.md
+++ b/plugins/jurisdigta/skills/implement-jurisdigta-task/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: implement-jurisdigta-task
+description: Implement one Ready Jurisdigta GitHub task from the latest origin/main in a dedicated branch and worktree, with repository review, GDPR and EU AI Act safeguards, unit tests for every new behavior, applicable Playwright E2E coverage, privacy-safe screenshot evidence, documentation, commit, pull request, and task status updates. Use when a user asks to implement, build, fix, or complete a task, issue, bug, or product change in mmaideveloper/aijurisdictionagents.
+---
+
+# Implement a Jurisdigta Task
+
+Implement exactly one task from a clean, current `origin/main` baseline and leave reviewable code, tests, evidence, documentation, and GitHub state.
+
+## Preconditions
+
+1. Identify the GitHub issue/task and confirm it is `Ready`.
+2. Read the full issue, comments, acceptance criteria, project fields, linked work, `AGENTS.md`, and relevant repository code and documentation.
+3. Ask focused questions before implementation when behavior, acceptance criteria, data handling, or risky assumptions are unclear.
+4. Run the GDPR and EU AI Act gate. Apply data minimization, consent where required, retention/deletion controls, transparency, traceable privacy-safe logging, and human oversight for legal-risk outputs. Stop and propose a compliant alternative for unresolved conflicts.
+5. Confirm the current checkout does not contain work for another task. Never mix tasks in one branch or worktree.
+
+## Create the implementation worktree
+
+1. From an existing clean repository checkout, run `git fetch origin main`.
+2. Confirm `origin/main` resolved successfully and record its commit SHA.
+3. Create a unique `codex/<task-id>-<slug>` branch and separate worktree from that exact `origin/main` using:
+
+   ```powershell
+   .\scripts\new_task_worktree.ps1 `
+     -Branch "codex/<task-id>-<slug>" `
+     -Base "origin/main"
+   ```
+
+4. Do not use raw `git worktree add` when the helper is available.
+5. Enter the new worktree and verify the branch, base SHA, and clean `git status`.
+6. Run `.\scripts\sync_env_profile.ps1 -Mode Pull -Profile codex-agent` before the first project command or edit. Inspect only redacted key status.
+7. For Python work, use the worktree's `.\conda` environment. For frontend-only work, do not run conda commands.
+8. Move the GitHub task to `In progress` before editing.
+
+## Implement
+
+1. Make the smallest coherent change that satisfies the acceptance criteria.
+2. Follow repository typing, linting, error handling, versioning, database, environment-variable, infrastructure, and health-endpoint rules.
+3. Keep secrets, private keys, `.env`, runtime databases, raw logs, user content, and test artifacts with personal data out of Git.
+4. Update affected documentation and add or update the minimal runnable example, defaulting to `python examples/minimal_demo.py`.
+5. If new requirements emerge as an independent change, stop and create a separate task, branch, and worktree.
+
+## Test gate
+
+Follow [test-and-evidence-gate.md](references/test-and-evidence-gate.md).
+
+1. Add or update unit tests for every new or changed behavior. A code feature is not complete without focused unit coverage.
+2. Run the narrow tests during development, then all repository-mandated validation for affected components.
+3. Evaluate E2E feasibility explicitly:
+   - add or extend Playwright tests when the change has a browser-visible flow, browser/API integration, authentication flow, download/upload, generated document, localization, responsive/layout, or other end-to-end behavior that Playwright can meaningfully verify;
+   - use the existing frontend or API-integrated Playwright suite selected by the reference;
+   - when Playwright is not applicable, record the concrete reason and the strongest alternative integration/contract test.
+4. For applicable Playwright coverage, assert behavior rather than relying only on screenshots.
+5. Capture privacy-safe screenshots for meaningful visual checkpoints, using synthetic test data and no secrets or personal/legal-case data.
+6. Rerun failing tests after fixing the cause. Do not hide failures by weakening assertions or silently changing providers.
+
+## Evidence and GitHub completion
+
+1. Review every screenshot for personal data, credentials, tokens, real emails, case facts, filenames, browser profile details, and unrelated desktop content. Redact or regenerate unsafe evidence.
+2. Store reproducible test artifacts under ignored `runs/` paths. Commit only intentionally selected, sanitized review screenshots under the repository's established `docs/screenshots/issue-<id>/` convention when durable evidence is useful.
+3. Prepare a validation summary containing:
+   - `origin/main` base SHA;
+   - unit tests added and commands/results;
+   - E2E feasibility decision;
+   - Playwright tests and results when applicable;
+   - screenshot paths/links when applicable;
+   - skipped or blocked checks with exact reasons;
+   - GDPR and EU AI Act controls verified.
+4. Commit only task-scoped files and push the task branch.
+5. Open a pull request targeting `main`. Include the validation summary and render or link sanitized screenshots in the PR body.
+6. Add the same completion summary and screenshot links to the GitHub issue/task. Add the comment `Implemented by Codex`.
+7. Move the task to `In review` only after the commit exists and the PR is open.
+8. Return the task, branch, commit, PR, test results, and evidence links to the user.
+
+## Completion rules
+
+- Do not claim a test passed unless its command completed successfully.
+- Do not claim E2E is impossible without evaluating the existing Playwright suites and recording a specific reason.
+- Do not use a screenshot as the sole assertion.
+- Do not publish screenshots before privacy review.
+- Do not move a task to `In review` when required tests fail, the PR is missing, or blocking compliance gaps remain.

--- a/plugins/jurisdigta/skills/implement-jurisdigta-task/agents/openai.yaml
+++ b/plugins/jurisdigta/skills/implement-jurisdigta-task/agents/openai.yaml
@@ -1,0 +1,12 @@
+interface:
+  display_name: "Implement Jurisdigta Task"
+  short_description: "Implement tasks with isolated tests and evidence"
+  default_prompt: "Use $implement-jurisdigta-task to implement a ready Jurisdigta task in an isolated worktree."
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "github"
+      description: "Read tasks and update issues and pull requests."
+      transport: "streamable_http"
+      url: "https://api.githubcopilot.com/mcp/"

--- a/plugins/jurisdigta/skills/implement-jurisdigta-task/references/repository-implementation-contract.md
+++ b/plugins/jurisdigta/skills/implement-jurisdigta-task/references/repository-implementation-contract.md
@@ -1,0 +1,73 @@
+# Repository Implementation Contract
+
+This checklist reflects the repository rules at plugin version 0.1.4. Always read the complete live `AGENTS.md` in the task worktree. The live file is authoritative when rules change.
+
+## Task source and lifecycle
+
+- Implement backend/system Ready tasks from GitHub Project 5.
+- Implement frontend Ready tasks from GitHub Project 6; do not run conda commands for frontend-only work.
+- Confirm requirements and acceptance criteria before implementation.
+- Move the task to `In progress` before editing.
+- Use `scripts/project_status.ps1` when possible and ensure `gh` has `read:project` and `project` scopes.
+- Before `In review`, commit the changes and create a PR targeting `main`.
+- On completion, comment exactly `Implemented by Codex`, move the task to `In review`, and notify the user.
+
+## Isolation and baseline
+
+- Use one branch and one worktree per task, bug, experiment, or product change.
+- Start from freshly fetched `origin/main`.
+- Check branch and `git status` before editing.
+- Use `.\scripts\new_task_worktree.ps1`; do not reuse a checkout containing another task.
+- If work expands into an independent task, leave the first task isolated and create another branch/worktree.
+
+## Environment and runtime
+
+- Before the first project command or edit, run:
+
+  ```powershell
+  .\scripts\sync_env_profile.ps1 -Mode Pull -Profile codex-agent
+  ```
+
+- Inspect only redacted key-name/status output; never inspect `.env` values.
+- If the server is unavailable, run `-Mode Audit -Profile codex-agent -Strict` and continue only with a previously verified local profile.
+- Never publish laptop secrets with the legacy sync script.
+- Add every new environment variable to `.env.example` in the same change. Update local `.env` through the repository process, using `unknown-variable` for missing keys.
+- Keep `.env`, `.env.dev`, private keys, and runtime secrets out of Git.
+- Use `azurefoundry` as the default local LLM provider. Do not silently fall back to `mock`; report exact missing `AZURE_OPENAI_*` settings.
+- For Python implementation, use/activate the task worktree's `.\conda` environment before the first project command. Do not use conda for frontend-only work.
+
+## Code, versions, and validation
+
+- Maintain typing, linting, tests, error handling, privacy-safe logs, and the project architecture for agents, orchestration, ingestion, evaluation/judging, and logging.
+- For mobile code or asset changes, increment only the build/revision after `+` in `mobile_app/pubspec.yaml`, unless semantic versioning is explicitly requested.
+- For API code under `api/aijuristiction-api`, increment only the revision in its `pyproject.toml`.
+- For core code under `src/`, increment only the revision in `src/aijurisdictionagents/__init__.py` and align the root package when applicable.
+- After API changes:
+  - run `ruff check app tests` from `api/aijuristiction-api`;
+  - run `mypy app` there;
+  - run `.\scripts\validate_api.ps1` from the root;
+  - run `.\conda\python.exe -m pytest api/aijuristiction-api/tests`;
+  - keep `git config core.hooksPath .githooks`.
+- Run component-specific unit tests and all applicable repository validation.
+- Add or update documentation and a minimal runnable example, defaulting to `python examples/minimal_demo.py`.
+
+## Database and storage
+
+- Keep only SQL assets in `databases/<projectname>/`.
+- Put local runtime database files in `runs/storage/<projectname>/`.
+- Use `runs/storage/<projectname>/postgres/data` for local PostgreSQL.
+- Use `runs/storage/<projectname>/sqlite/` for local SQLite.
+
+## Infrastructure and operations
+
+- When workflow parameters or infrastructure inputs change, update `docs/GITHUB_ENVIRONMENTS.md` for both test and prod.
+- When manual infrastructure setup is required, update `docs/manual_infrastucture_setup.md` with owners/accounts, secrets, environments, validation, and rollback.
+- When a production `/health` endpoint is added, exposed, renamed, or made public, update `.codex/automations/jurisdigta-monitoring-task/automation.toml`.
+- Before any `az` command against repository resources, authenticate with `.\infra\scripts\login_service_principal.ps1`. Never rely on the currently signed-in Azure user.
+
+## GDPR and EU AI Act
+
+- Apply privacy by design and data minimization.
+- Define consent where required, retention/deletion controls, transparency, traceable logging, and human oversight.
+- Keep secrets, personal data, legal-case content, prompts, documents, and credentials out of logs, screenshots, issues, and PRs.
+- Stop when a request conflicts with GDPR or EU AI Act expectations and propose a compliant alternative.

--- a/plugins/jurisdigta/skills/implement-jurisdigta-task/references/test-and-evidence-gate.md
+++ b/plugins/jurisdigta/skills/implement-jurisdigta-task/references/test-and-evidence-gate.md
@@ -1,0 +1,73 @@
+# Test and Evidence Gate
+
+## Unit-test requirement
+
+Map every acceptance criterion and changed behavior to at least one focused test. Cover:
+
+- success behavior;
+- relevant validation and error paths;
+- authorization, consent, or human-oversight boundary changes;
+- retention/deletion or audit behavior when affected;
+- regressions reproduced by bug fixes.
+
+Use the component's established test framework and conventions. Test externally observable behavior; avoid assertions coupled only to implementation details.
+
+## Playwright feasibility
+
+Mark Playwright **applicable** when a browser or browser-driven API flow can verify the acceptance criteria, including:
+
+- web UI behavior, layout, responsive states, accessibility-relevant interactions, or localization;
+- authentication, signup, MFA, consent, subscription, or browser session flows;
+- browser-to-API integration;
+- document preview, generation, download, upload, or navigation;
+- a bug whose reproduction steps occur in a web browser.
+
+Mark Playwright **not applicable** only for changes such as isolated internal algorithms, workers with no browser contract, documentation-only changes, or infrastructure behavior that cannot be meaningfully exercised through the existing browser suites. Record the reason and add the strongest practical integration, contract, or service test instead.
+
+## Select the existing suite
+
+| Scope | Preferred location | Typical command source |
+| --- | --- | --- |
+| Frontend with mocked API or UI-only behavior | `frontend/aijurisdictionfronend/e2e/` | `frontend/aijurisdictionfronend/package.json` and README |
+| Live frontend/API or API-driven browser scenario | `api/aijuristiction-api/e2e-playwright/tests/` | its `package.json`, Playwright config, and README/workflow |
+| Mobile-only Flutter behavior | Flutter integration/widget tests first | Use Playwright only when a web surface or browser contract is also in scope |
+
+Inspect the selected suite's configuration and nearby tests before adding a spec. Reuse its fixtures, web server startup, synthetic users, output paths, retries, and trace settings.
+
+## Screenshot evidence
+
+Capture screenshots only after the tested state is reached and assertions pass.
+
+- Use deterministic synthetic accounts and content.
+- Prefer the relevant page/region over unrelated full-desktop capture.
+- Use stable descriptive names such as `issue-<id>-<flow>-<state>.png`.
+- Save runtime output under `runs/e2e/` or Playwright's test output.
+- Attach screenshots to the Playwright report with `testInfo.attach` when that suite uses attachments.
+- For durable review evidence, copy only sanitized selected images to `docs/screenshots/issue-<id>/` and document the generation command.
+- Add Markdown image links to the PR and task result after the branch is pushed.
+- If the change has no visual state, do not manufacture a meaningless screenshot; state `Screenshot evidence: not applicable` with the E2E feasibility reason.
+
+## Privacy review
+
+Before publishing an image, verify it contains none of:
+
+- real names, email addresses, phone numbers, postal addresses, IP addresses, or user identifiers;
+- tokens, cookies, authorization headers, signed URLs, connection strings, or secret values;
+- real legal-case facts, uploaded document content, payment data, or private messages;
+- local usernames, browser bookmarks/history, notifications, or unrelated applications.
+
+Regenerate with synthetic data or crop/redact before commit or upload. Never rely on a PR reviewer to catch sensitive content.
+
+## Completion table
+
+Include this table in the task result and PR:
+
+| Gate | Result | Evidence |
+| --- | --- | --- |
+| Latest `origin/main` base | Pass/Fail | Commit SHA |
+| Unit tests | Pass/Fail | Command and test files |
+| Component validation | Pass/Fail | Commands |
+| Playwright feasibility | Applicable/Not applicable | Reason |
+| Playwright E2E | Pass/Fail/Not applicable | Command and spec |
+| Screenshots | Added/Not applicable | Sanitized links or reason |
+| GDPR/EU AI Act | Pass/Blocked | Controls reviewed |

--- a/plugins/jurisdigta/skills/manage-jurisdigta-adr/SKILL.md
+++ b/plugins/jurisdigta/skills/manage-jurisdigta-adr/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: manage-jurisdigta-adr
+description: Create, update, review, accept, reject, or supersede source-backed Architecture Decision Records and related GitHub architecture tasks for Jurisdigta. Use when a user asks for an ADR, architecture decision, technical option comparison, architecture review, or documentation of a significant Jurisdigta design choice in aijurisdictionagents.
+---
+
+# Manage a Jurisdigta Architecture Decision
+
+Document consequential architecture choices in `docs/adr/` with traceable evidence, explicit trade-offs, GDPR and EU AI Act analysis, operational consequences, and a human decision owner.
+
+## Select the operation
+
+- **Create:** assign the next `ADR-NNNN-<slug>.md` number and start with `Proposed`.
+- **Update:** preserve decision history and refine a proposed record.
+- **Review:** assess evidence, alternatives, compliance, risks, and implementation readiness without changing status unless requested.
+- **Accept or reject:** require explicit confirmation from the named human decision owner.
+- **Supersede:** create a new ADR, mark the old ADR `Superseded by ADR-NNNN`, and link both records.
+- **Create an architecture task:** draft a GitHub issue from the ADR or proposal and require confirmation before creating it.
+
+## Workflow
+
+1. Clarify the decision question, drivers, scope, constraints, decision owner, deadline, and whether the output is an ADR, GitHub task, or both.
+2. Review `AGENTS.md`, relevant code, tests, configuration, current architecture documentation, existing ADRs, operational runbooks, and authoritative external sources when needed.
+3. Determine whether the choice is significant enough for an ADR. Prefer ordinary documentation for reversible implementation detail with no broad consequences.
+4. Identify at least two viable options plus the status quo when meaningful. Apply consistent criteria: fitness, maintainability, security, privacy, compliance, cost, reliability, operability, reversibility, migration effort, and testability.
+5. Run the compliance gate:
+   - map personal-data flows, lawful purpose, minimization, access, retention, deletion, residency, and processor boundaries;
+   - identify AI-system role, risk classification assumptions, transparency, traceability, accuracy, monitoring, and human oversight;
+   - stop acceptance and propose a compliant alternative when a material GDPR or EU AI Act gap remains.
+6. Draft the record with [adr-template.md](references/adr-template.md). Distinguish verified source facts, repository observations, and reasoned inferences.
+7. Ask up to three focused questions when evidence, decision ownership, compliance, or acceptance criteria remain unclear.
+8. Present the proposed decision, strongest rejected alternative, irreversible consequences, compliance controls, and open risks for human review.
+9. Write or update the ADR only within the requested scope. Do not implement the architecture change unless separately authorized.
+10. For a GitHub architecture task, draft the complete issue, show it to the user, and require explicit confirmation before creating it in `mmaideveloper/aijurisdictionagents`.
+
+## Evidence rules
+
+- Link repository sources by path and external sources by canonical URL.
+- Prefer official documentation, standards, laws, and primary research.
+- Date time-sensitive evidence and record important assumptions.
+- Do not invent benchmarks, costs, legal classifications, or stakeholder approval.
+- Record dissent and uncertainty when they materially affect the decision.
+
+## Status and write boundaries
+
+- `Proposed` is the default for a new record.
+- `Accepted` and `Rejected` require explicit human decision-owner approval.
+- `Deprecated` and `Superseded` require a reason and replacement link when applicable.
+- Creating or editing an ADR or GitHub issue is a write action. Preview material changes before writing when the user has not already approved the exact change.
+- Keep legal and compliance interpretations reviewable by qualified humans; an ADR records engineering assumptions and controls, not binding legal advice.

--- a/plugins/jurisdigta/skills/manage-jurisdigta-adr/SKILL.md
+++ b/plugins/jurisdigta/skills/manage-jurisdigta-adr/SKILL.md
@@ -14,7 +14,7 @@ Document consequential architecture choices in `docs/adr/` with traceable eviden
 - **Review:** assess evidence, alternatives, compliance, risks, and implementation readiness without changing status unless requested.
 - **Accept or reject:** require explicit confirmation from the named human decision owner.
 - **Supersede:** create a new ADR, mark the old ADR `Superseded by ADR-NNNN`, and link both records.
-- **Create an architecture task:** draft a GitHub issue from the ADR or proposal and require confirmation before creating it.
+- **Create an architecture task:** hand the accepted ADR or scoped architecture investigation to `prepare-jurisdigta-task`; do not own generic task intake in this skill.
 
 ## Workflow
 
@@ -30,7 +30,7 @@ Document consequential architecture choices in `docs/adr/` with traceable eviden
 7. Ask up to three focused questions when evidence, decision ownership, compliance, or acceptance criteria remain unclear.
 8. Present the proposed decision, strongest rejected alternative, irreversible consequences, compliance controls, and open risks for human review.
 9. Write or update the ADR only within the requested scope. Do not implement the architecture change unless separately authorized.
-10. For a GitHub architecture task, draft the complete issue, show it to the user, and require explicit confirmation before creating it in `mmaideveloper/aijurisdictionagents`.
+10. For a GitHub architecture task, invoke or hand off to `prepare-jurisdigta-task`. Require it to review requirements, resolve questions, apply its Ready gate, create the confirmed issue, set Ready status, and add `Reviewed by Codex`.
 
 ## Evidence rules
 

--- a/plugins/jurisdigta/skills/manage-jurisdigta-adr/agents/openai.yaml
+++ b/plugins/jurisdigta/skills/manage-jurisdigta-adr/agents/openai.yaml
@@ -1,0 +1,12 @@
+interface:
+  display_name: "Manage Jurisdigta ADR"
+  short_description: "Create and review architecture decisions"
+  default_prompt: "Use $manage-jurisdigta-adr to prepare a source-backed architecture decision."
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "github"
+      description: "Read repository context and create confirmed architecture tasks."
+      transport: "streamable_http"
+      url: "https://api.githubcopilot.com/mcp/"

--- a/plugins/jurisdigta/skills/manage-jurisdigta-adr/references/adr-template.md
+++ b/plugins/jurisdigta/skills/manage-jurisdigta-adr/references/adr-template.md
@@ -1,0 +1,111 @@
+# Jurisdigta ADR Template
+
+```markdown
+# ADR-NNNN: <Decision title>
+
+## Status
+
+Proposed
+
+## Date
+
+YYYY-MM-DD
+
+## Decision owner
+
+<Named person or accountable role>
+
+## Decision question
+
+<One question this ADR answers>
+
+## Context and drivers
+
+- Current state:
+- Problem:
+- Constraints:
+- Decision drivers:
+- In scope:
+- Out of scope:
+
+## Sources and evidence
+
+- Repository evidence:
+- External primary sources:
+- Assumptions and evidence date:
+
+## Options considered
+
+### Option A: <name>
+
+- Approach:
+- Benefits:
+- Costs/risks:
+- Privacy/security/compliance:
+- Operations/testability:
+- Reversibility:
+
+### Option B: <name>
+
+<Use the same criteria>
+
+### Status quo
+
+<Use the same criteria when meaningful>
+
+## Decision
+
+<Chosen option and concise rationale>
+
+## Consequences
+
+### Positive
+
+- <Benefit>
+
+### Negative and trade-offs
+
+- <Trade-off>
+
+### Risks and mitigations
+
+- Risk:
+  - Mitigation:
+  - Owner:
+
+## GDPR and EU AI Act assessment
+
+- Personal-data flows and purpose:
+- Data minimization:
+- Access, retention, and deletion:
+- Residency/processors:
+- AI role and risk assumptions:
+- Transparency and traceability:
+- Accuracy, monitoring, and human oversight:
+- Required legal/security review:
+
+## Implementation and migration
+
+- Phases:
+- Compatibility:
+- Rollback:
+- Observability:
+- Documentation:
+- Minimal runnable example:
+
+## Validation
+
+- Unit/integration/e2e:
+- Security/privacy:
+- Operational acceptance:
+- Success metrics:
+
+## Follow-up actions
+
+- [ ] Action — owner — due date
+
+## Supersession
+
+- Supersedes: None
+- Superseded by: None
+```

--- a/plugins/jurisdigta/skills/prepare-jurisdigta-task/SKILL.md
+++ b/plugins/jurisdigta/skills/prepare-jurisdigta-task/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: prepare-jurisdigta-task
+description: Review a new Jurisdigta feature, bug, architecture follow-up, compliance change, technical-debt item, or other work request; inspect repository and GitHub context; recommend improvements; ask focused questions until requirements are implementation-ready; then create a GitHub issue in mmaideveloper/aijurisdictionagents, add it to the correct project with Ready status, and comment Reviewed by Codex after explicit confirmation. Use whenever a user asks to create, prepare, define, refine, or make a new Jurisdigta task Ready.
+---
+
+# Prepare a Jurisdigta Task
+
+Turn a request into one implementation-ready GitHub task. Review and improve the request before creating anything; do not implement it.
+
+## Intake
+
+1. Capture the request, desired user outcome, and source. Accept free text, an ADR, an incident draft, or an existing issue URL.
+2. Search `mmaideveloper/aijurisdictionagents` for duplicates or overlapping issues, pull requests, ADRs, and planned work.
+3. Read `AGENTS.md` plus relevant code, documentation, tests, workflows, examples, database assets, and deployment runbooks before asking detailed questions.
+4. Summarize what the repository already supports and distinguish verified facts from assumptions.
+
+## Review and improve
+
+1. Review the request for correctness, maintainability, simplicity, security, privacy, compliance, operability, observability, testability, rollout, and rollback.
+2. Recommend a better approach when it is safer, simpler, more maintainable, more compliant, less duplicative, or easier to test. Explain the trade-off and let the user decide when the recommendation changes scope or behavior.
+3. Run the GDPR and EU AI Act readiness gate:
+   - identify personal and special-category data, purpose, minimization, consent/transparency, access, retention/deletion, residency, processors, and audit needs;
+   - identify AI role/risk assumptions, accuracy, traceability, user disclosure, monitoring, limitations, and human oversight for legal-risk outputs;
+   - stop Ready status and propose a compliant alternative when a material gap remains.
+4. For user-visible outputs, define channel parity across chat simulator, API, mobile, and web. Record intentional differences.
+5. Ask no more than three focused questions per round. Continue review/question rounds until every blocking answer is resolved. Do not ask questions already answered by repository evidence.
+
+## Readiness gate
+
+Use [task-template.md](references/task-template.md). Mark a task Ready only when:
+
+- the problem, user outcome, scope, and non-goals are explicit;
+- affected components, interfaces, data, failure behavior, migration/versioning, rollout, and rollback are defined;
+- GDPR and EU AI Act risks have controls or are explicitly out of scope;
+- channel behavior and permissions are clear for every in-scope surface;
+- acceptance criteria are independently testable;
+- unit, integration, applicable Playwright E2E, privacy/compliance, and screenshot-evidence expectations are specified;
+- documentation and a minimal runnable example are named;
+- dependencies and owners are identified;
+- no blocking questions remain.
+
+Include both exact readiness markers in the issue body:
+
+```text
+Idea Task Status: Ready for prepare-task.
+Status: Ready for implementation.
+```
+
+If any criterion is unresolved, present a `Not Ready Yet` draft with the blockers and continue asking questions. Never create a task in Ready status merely because the user asks to skip unanswered requirements.
+
+## Confirm and create
+
+1. Show the user the final proposed:
+   - issue title and complete body;
+   - repository and project;
+   - labels, dependencies, and owners when known;
+   - Ready status;
+   - recommended improvements incorporated or declined.
+2. Ask for explicit confirmation before creating or updating the GitHub issue/project item. A slash-style invocation that explicitly says to create the task may count as creation authorization only after the user has answered all blocking questions and reviewed the final draft.
+3. Create the issue in `mmaideveloper/aijurisdictionagents`.
+4. Add it to:
+   - GitHub Project 5 for backend, system core, API, mobile, infrastructure, compliance, or cross-platform work;
+   - GitHub Project 6 only for frontend-web-only work.
+5. Set project status to `Ready`. Prefer `scripts/project_status.ps1` when available and verify `gh` has `read:project` and `project` scopes.
+6. Add exactly one issue comment:
+
+   ```text
+   Reviewed by Codex
+   ```
+
+7. Read the created issue and project item back to verify title, body, project, Ready status, and comment.
+8. Return the issue link, project, status, incorporated recommendations, and any non-blocking follow-ups.
+
+## ADR handoff
+
+Keep task creation separate from ADR management:
+
+- use `manage-jurisdigta-adr` to decide and document architecture;
+- use this skill to turn an accepted decision or a clearly scoped architecture investigation into a Ready GitHub task;
+- link the ADR in the issue and link the issue from the ADR when both exist;
+- do not create an implementation task for a still-undecided architecture choice unless the task itself is explicitly to complete that decision.
+
+## Write and safety boundaries
+
+- Repository/GitHub review is read-only until the final draft is confirmed.
+- Never include secrets, raw production logs, personal data, legal-case content, private screenshots, or credentials in the task.
+- Creating the issue, adding it to a project, changing status, and commenting are external writes; perform them only within the confirmed scope.
+- Do not split one cohesive request into multiple tasks without user agreement. Recommend separate tasks when work has independent delivery, ownership, or rollback boundaries.

--- a/plugins/jurisdigta/skills/prepare-jurisdigta-task/agents/openai.yaml
+++ b/plugins/jurisdigta/skills/prepare-jurisdigta-task/agents/openai.yaml
@@ -1,0 +1,12 @@
+interface:
+  display_name: "Prepare Jurisdigta Task"
+  short_description: "Review ideas and create Ready GitHub tasks"
+  default_prompt: "Use $prepare-jurisdigta-task to review my request and create a Ready GitHub task."
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "github"
+      description: "Search existing work and create confirmed Ready tasks."
+      transport: "streamable_http"
+      url: "https://api.githubcopilot.com/mcp/"

--- a/plugins/jurisdigta/skills/prepare-jurisdigta-task/references/task-template.md
+++ b/plugins/jurisdigta/skills/prepare-jurisdigta-task/references/task-template.md
@@ -1,0 +1,97 @@
+# Jurisdigta Ready Task Template
+
+```markdown
+## Problem and source
+
+- Source:
+- Current behavior/problem:
+- User outcome:
+- Success measure:
+
+## Scope
+
+### In scope
+
+- <Included outcome>
+
+### Non-goals
+
+- <Explicit exclusion>
+
+## Repository context reviewed
+
+- Related code:
+- Documentation/ADRs:
+- Existing tests/examples:
+- Related issues/PRs:
+
+## Recommended approach
+
+- Components and files:
+- API/UI/agent behavior:
+- Data and storage:
+- Errors and fallback:
+- Observability and audit:
+- Migration/versioning:
+- Rollout and rollback:
+
+## Recommendations reviewed
+
+- Incorporated:
+- Declined and rationale:
+
+## GDPR and EU AI Act readiness
+
+- Personal data and purpose:
+- Minimization:
+- Consent/transparency:
+- Access, retention, and deletion:
+- Residency/processors:
+- Traceable logging:
+- AI risk assumptions:
+- Accuracy and monitoring:
+- Human oversight:
+- Remaining compliance blockers: None
+
+## Channel parity
+
+| Channel | In scope | Expected behavior | Contract/auth | Error/offline UX |
+| --- | --- | --- | --- | --- |
+| Chat simulator |  |  |  |  |
+| API |  |  |  |  |
+| Mobile |  |  |  |  |
+| Web frontend |  |  |  |  |
+
+## Acceptance criteria
+
+- [ ]
+- [ ]
+
+## Test and evidence plan
+
+- Unit tests:
+- Integration/contract tests:
+- Playwright E2E feasibility:
+- Playwright scenarios:
+- Sanitized screenshots:
+- Privacy/compliance tests:
+
+## Documentation
+
+- Docs:
+- Minimal runnable example: `python examples/minimal_demo.py`
+
+## Dependencies and ownership
+
+- Dependencies:
+- Owner/reviewer:
+
+## Open questions
+
+None.
+
+## Readiness
+
+Idea Task Status: Ready for prepare-task.
+Status: Ready for implementation.
+```

--- a/plugins/jurisdigta/skills/report-jurisdigta-bug/SKILL.md
+++ b/plugins/jurisdigta/skills/report-jurisdigta-bug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: report-jurisdigta-bug
-description: Investigate a reported Jurisdigta defect using user-provided symptoms, optional screenshots, privacy-minimized production logs, and the aijurisdictionagents repository, then ask focused follow-up questions and create a structured GitHub issue only after human confirmation. Use when a user says Jurisdigta is broken, reports unexpected behavior or an incident, asks to inspect server logs for a defect, or wants a bug filed in mmaideveloper/aijurisdictionagents.
+description: Investigate a reported Jurisdigta defect using user-provided symptoms, optional screenshots, environment-routed local or jurisdigta-server logs, and the aijurisdictionagents repository, then ask focused follow-up questions and create a structured GitHub issue only after human confirmation. Use when a user says Jurisdigta is broken, reports unexpected behavior or an incident, asks to inspect local or server logs for a defect, or wants a bug filed in mmaideveloper/aijurisdictionagents.
 ---
 
 # Report a Jurisdigta Bug
@@ -10,28 +10,32 @@ Create a reproducible, evidence-based bug report without copying secrets, person
 ## Workflow
 
 1. Restate the reported symptom and distinguish fact from hypothesis.
-2. Ask whether the user has screenshots or screen recordings and invite them to attach any relevant images. Treat images as optional; continue if none exist.
-3. Collect the minimum intake details:
-   - concise description;
+2. Get a concise description of the error, including the visible message or behavior.
+3. Ask: **"Did this error happen locally or on `jurisdigta-server`?"** Do not inspect any logs until the user answers. If the original description already states the environment unambiguously, acknowledge and confirm that environment instead of asking a redundant question.
+4. Ask whether the user has screenshots or screen recordings and invite them to attach any relevant images. Treat images as optional; continue if none exist.
+5. Collect the remaining minimum intake details:
    - expected and actual behavior;
    - approximate time with timezone;
-   - environment and affected channel;
+   - affected channel and service;
    - reproduction steps, frequency, and user impact;
    - request ID or correlation ID when available.
-4. Review relevant repository code, tests, documentation, recent changes, and existing GitHub issues before diagnosing.
-5. Ask for permission before accessing production logs. Explain that only a narrow time window and relevant services will be queried.
-6. Collect server evidence read-only. Prefer existing repository diagnostics such as `infra/scripts/tail_api_logs.ps1`. For the self-managed host, use `ssh -o BatchMode=yes jurisdigta-server` with bounded `docker logs`, `journalctl`, or `tail` queries. Never access `.env`, private keys, database rows, uploaded documents, prompts, message bodies, or full legal-case content.
-7. Sanitize evidence before analysis or storage. Follow [privacy-and-log-handling.md](references/privacy-and-log-handling.md).
-8. Correlate the description, image evidence, logs, code paths, tests, and similar issues. State the likely component and confidence; do not present an unverified root cause as fact.
-9. Ask up to three focused questions only when missing answers materially affect reproducibility, severity, security/privacy handling, or acceptance criteria.
-10. Draft the issue using [github-issue-template.md](references/github-issue-template.md) for `mmaideveloper/aijurisdictionagents`.
-11. Show the complete title and body to the user. Require explicit confirmation before creating the GitHub issue or uploading sanitized images/log excerpts, unless the user has already explicitly approved that exact draft.
-12. Create the issue through the connected GitHub tool when available, with `gh` as fallback. Apply existing repository bug labels when confidently known; do not invent labels.
-13. Return the issue link and summarize what evidence was included and deliberately excluded.
+6. Review relevant repository code, tests, documentation, recent changes, and existing GitHub issues before diagnosing.
+7. Route diagnostics according to [diagnostic-routing.md](references/diagnostic-routing.md):
+   - for **local**, inspect only local terminal output, local `runs/` logs, and local container/service logs;
+   - for **`jurisdigta-server`**, ask for permission before remote log access, then use only bounded read-only SSH/server queries;
+   - never combine local and server logs unless evidence shows a cross-environment problem and the user approves expanding scope.
+8. Sanitize evidence before analysis or storage. Follow [privacy-and-log-handling.md](references/privacy-and-log-handling.md).
+9. Correlate the description, image evidence, environment-specific logs, code paths, tests, and similar issues. State the likely component and confidence; do not present an unverified root cause as fact.
+10. Ask up to three focused questions only when missing answers materially affect reproducibility, severity, security/privacy handling, or acceptance criteria.
+11. Draft the issue using [github-issue-template.md](references/github-issue-template.md) for `mmaideveloper/aijurisdictionagents`.
+12. Show the complete title and body to the user. Require explicit confirmation before creating the GitHub issue or uploading sanitized images/log excerpts, unless the user has already explicitly approved that exact draft.
+13. Create the issue through the connected GitHub tool when available, with `gh` as fallback. Apply existing repository bug labels when confidently known; do not invent labels.
+14. Return the issue link and summarize what evidence was included and deliberately excluded.
 
 ## Safety and compliance gates
 
 - Stop and report a potential security incident privately instead of filing a public issue when evidence contains credentials, authentication tokens, exploitable security details, or a suspected personal-data breach.
+- Do not access `jurisdigta-server` when the user says the error is local. Do not diagnose a server-reported error solely from local logs.
 - Minimize production-log access by service, time window, identifiers, and line count. Do not persist raw production logs in the repository.
 - Redact names, email addresses, phone numbers, IP addresses, session/user/case/document IDs, access tokens, cookies, authorization headers, connection strings, prompts, document text, and legal facts unless a specific non-personal identifier is essential and approved.
 - Treat screenshots as potentially sensitive. Inspect them before upload and ask for a redacted replacement when sensitive data is visible.

--- a/plugins/jurisdigta/skills/report-jurisdigta-bug/SKILL.md
+++ b/plugins/jurisdigta/skills/report-jurisdigta-bug/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: report-jurisdigta-bug
+description: Investigate a reported Jurisdigta defect using user-provided symptoms, optional screenshots, privacy-minimized production logs, and the aijurisdictionagents repository, then ask focused follow-up questions and create a structured GitHub issue only after human confirmation. Use when a user says Jurisdigta is broken, reports unexpected behavior or an incident, asks to inspect server logs for a defect, or wants a bug filed in mmaideveloper/aijurisdictionagents.
+---
+
+# Report a Jurisdigta Bug
+
+Create a reproducible, evidence-based bug report without copying secrets, personal data, legal-case content, or unnecessary production logs into GitHub.
+
+## Workflow
+
+1. Restate the reported symptom and distinguish fact from hypothesis.
+2. Ask whether the user has screenshots or screen recordings and invite them to attach any relevant images. Treat images as optional; continue if none exist.
+3. Collect the minimum intake details:
+   - concise description;
+   - expected and actual behavior;
+   - approximate time with timezone;
+   - environment and affected channel;
+   - reproduction steps, frequency, and user impact;
+   - request ID or correlation ID when available.
+4. Review relevant repository code, tests, documentation, recent changes, and existing GitHub issues before diagnosing.
+5. Ask for permission before accessing production logs. Explain that only a narrow time window and relevant services will be queried.
+6. Collect server evidence read-only. Prefer existing repository diagnostics such as `infra/scripts/tail_api_logs.ps1`. For the self-managed host, use `ssh -o BatchMode=yes jurisdigta-server` with bounded `docker logs`, `journalctl`, or `tail` queries. Never access `.env`, private keys, database rows, uploaded documents, prompts, message bodies, or full legal-case content.
+7. Sanitize evidence before analysis or storage. Follow [privacy-and-log-handling.md](references/privacy-and-log-handling.md).
+8. Correlate the description, image evidence, logs, code paths, tests, and similar issues. State the likely component and confidence; do not present an unverified root cause as fact.
+9. Ask up to three focused questions only when missing answers materially affect reproducibility, severity, security/privacy handling, or acceptance criteria.
+10. Draft the issue using [github-issue-template.md](references/github-issue-template.md) for `mmaideveloper/aijurisdictionagents`.
+11. Show the complete title and body to the user. Require explicit confirmation before creating the GitHub issue or uploading sanitized images/log excerpts, unless the user has already explicitly approved that exact draft.
+12. Create the issue through the connected GitHub tool when available, with `gh` as fallback. Apply existing repository bug labels when confidently known; do not invent labels.
+13. Return the issue link and summarize what evidence was included and deliberately excluded.
+
+## Safety and compliance gates
+
+- Stop and report a potential security incident privately instead of filing a public issue when evidence contains credentials, authentication tokens, exploitable security details, or a suspected personal-data breach.
+- Minimize production-log access by service, time window, identifiers, and line count. Do not persist raw production logs in the repository.
+- Redact names, email addresses, phone numbers, IP addresses, session/user/case/document IDs, access tokens, cookies, authorization headers, connection strings, prompts, document text, and legal facts unless a specific non-personal identifier is essential and approved.
+- Treat screenshots as potentially sensitive. Inspect them before upload and ask for a redacted replacement when sensitive data is visible.
+- Keep legal-risk conclusions subject to human review. The issue may describe software behavior but must not make legal determinations about an affected user.
+- Record the evidence source and collection time in the issue, but include only the smallest sanitized excerpt needed for reproduction and triage.
+
+## Image handling
+
+When images are attached:
+
+- confirm which action and timestamp each image represents;
+- inspect for sensitive content and metadata;
+- extract only relevant visible error text;
+- prefer a redacted crop over a full-screen upload;
+- obtain confirmation before attaching the sanitized image to GitHub.
+
+## GitHub write boundary
+
+Reading logs, code, and issues is diagnostic work. Creating or editing a GitHub issue is an external write. Never perform the write until the user has reviewed and confirmed the final sanitized draft.

--- a/plugins/jurisdigta/skills/report-jurisdigta-bug/agents/openai.yaml
+++ b/plugins/jurisdigta/skills/report-jurisdigta-bug/agents/openai.yaml
@@ -1,0 +1,12 @@
+interface:
+  display_name: "Report Jurisdigta Bug"
+  short_description: "Create evidence-based, privacy-safe bug reports"
+  default_prompt: "Use $report-jurisdigta-bug to investigate and draft a Jurisdigta bug report."
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "github"
+      description: "Read repository context and create confirmed GitHub issues."
+      transport: "streamable_http"
+      url: "https://api.githubcopilot.com/mcp/"

--- a/plugins/jurisdigta/skills/report-jurisdigta-bug/agents/openai.yaml
+++ b/plugins/jurisdigta/skills/report-jurisdigta-bug/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Report Jurisdigta Bug"
   short_description: "Create evidence-based, privacy-safe bug reports"
-  default_prompt: "Use $report-jurisdigta-bug to investigate and draft a Jurisdigta bug report."
+  default_prompt: "Use $report-jurisdigta-bug to route local or server logs and draft a Jurisdigta bug report."
 
 dependencies:
   tools:

--- a/plugins/jurisdigta/skills/report-jurisdigta-bug/references/diagnostic-routing.md
+++ b/plugins/jurisdigta/skills/report-jurisdigta-bug/references/diagnostic-routing.md
@@ -1,0 +1,37 @@
+# Diagnostic Routing
+
+Select exactly one initial diagnostic environment from the user's answer.
+
+| User answer | Allowed initial sources | Prohibited initial sources |
+| --- | --- | --- |
+| Local | Current terminal output; files under the repository's local `runs/` directory; log files named by the applicable local launcher skill; logs from locally running Docker containers or processes | SSH, remote server files, remote Docker, remote journald |
+| `jurisdigta-server` | Bounded read-only queries through `ssh -o BatchMode=yes jurisdigta-server`; relevant remote Docker logs; relevant journald unit; relevant file under `/srv/jurisdigta/runs/logs/` | Unrelated local application logs; secret files; database/user content |
+
+## Local path
+
+1. Identify the affected locally running component and how it was started.
+2. Prefer the terminal or log path printed by its repository launcher.
+3. Query only the relevant local file, process, or container and the reported time window.
+4. Do not start, stop, restart, reconfigure, or clear a service merely to obtain logs unless the user separately authorizes that action.
+5. If expected local logs do not exist, report that fact and ask how the component was launched rather than switching to the server.
+
+## `jurisdigta-server` path
+
+1. Explain the intended service, time window, and maximum output, then obtain permission for remote log access.
+2. Verify SSH reachability with a read-only bounded check.
+3. Query only the relevant source:
+   - `docker logs --since <time> --tail <limit> <container>`;
+   - `journalctl -u <unit> --since <time> -n <limit> --no-pager`;
+   - `tail -n <limit> /srv/jurisdigta/runs/logs/<relevant-file>.log`.
+4. Do not use broad recursive searches or read `/srv/jurisdigta/secrets/`.
+5. If the affected service is unclear, list only service/container names first and ask the user before retrieving content.
+
+## Scope expansion
+
+Inspect both environments only when:
+
+- the evidence indicates a local client calling the remote server;
+- the user confirms both sides are in scope; and
+- each source remains independently minimized and sanitized.
+
+Record the selected environment and actual log source in the GitHub issue.

--- a/plugins/jurisdigta/skills/report-jurisdigta-bug/references/github-issue-template.md
+++ b/plugins/jurisdigta/skills/report-jurisdigta-bug/references/github-issue-template.md
@@ -1,0 +1,64 @@
+# Bug Issue Template
+
+```markdown
+## Summary
+
+<One observable defect, without personal data>
+
+## Impact and severity
+
+- Affected channel/environment:
+- User impact:
+- Frequency:
+- Proposed severity and rationale:
+
+## Expected behavior
+
+<Expected result>
+
+## Actual behavior
+
+<Observed result>
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Evidence
+
+- Reported time and timezone:
+- Sanitized request/correlation ID:
+- Relevant screenshot(s), confirmed redacted:
+- Minimal sanitized log excerpt:
+- Related code/tests/docs:
+
+## Investigation
+
+- Likely component:
+- Working hypothesis:
+- Confidence:
+- Similar issues/regressions checked:
+
+## GDPR and EU AI Act
+
+- Personal data excluded/redacted:
+- Raw production logs retained: No
+- Legal-risk output impact:
+- Human-review requirement:
+
+## Acceptance criteria
+
+- [ ]
+- [ ]
+
+## Test notes
+
+- Regression test:
+- Relevant validation:
+
+## Additional context
+
+Raw production logs, secrets, user content, and legal-case data were intentionally excluded.
+```

--- a/plugins/jurisdigta/skills/report-jurisdigta-bug/references/github-issue-template.md
+++ b/plugins/jurisdigta/skills/report-jurisdigta-bug/references/github-issue-template.md
@@ -28,6 +28,8 @@
 
 ## Evidence
 
+- Diagnostic environment: Local / `jurisdigta-server`
+- Log source inspected:
 - Reported time and timezone:
 - Sanitized request/correlation ID:
 - Relevant screenshot(s), confirmed redacted:

--- a/plugins/jurisdigta/skills/report-jurisdigta-bug/references/privacy-and-log-handling.md
+++ b/plugins/jurisdigta/skills/report-jurisdigta-bug/references/privacy-and-log-handling.md
@@ -1,0 +1,39 @@
+# Privacy and Log Handling
+
+## Collection contract
+
+- Obtain permission for production-log access.
+- Query the smallest useful time range, starting with 15 minutes around the reported event.
+- Select only relevant services and cap output, normally at 200 lines.
+- Prefer request/correlation IDs and aggregate operational events over free-text searches for user data.
+- Keep commands read-only and report the exact source and UTC collection time.
+
+## Prohibited sources
+
+Do not read or copy:
+
+- `.env`, secret stores, private keys, tokens, cookies, or authorization headers;
+- database records, uploaded documents, prompt/response bodies, email bodies, or legal-case facts;
+- broad log archives when a bounded query can answer the question.
+
+## Redaction checklist
+
+Before showing or uploading evidence, remove or replace:
+
+- names, emails, phone numbers, postal addresses, IP addresses, and device identifiers;
+- user, tenant, case, document, session, and payment identifiers;
+- credentials, connection strings, query parameters containing personal data, and signed URLs;
+- document text, chat content, legal facts, filenames, and stack-frame local paths that reveal usernames.
+
+Use stable placeholders such as `[EMAIL_REDACTED]`, `[CASE_ID_REDACTED]`, and `[TOKEN_REDACTED]`. Preserve timestamps, error codes, service names, source locations, and request/correlation IDs only when non-personal and necessary.
+
+## Retention
+
+- Keep raw production output ephemeral in the current diagnostic session.
+- Do not write raw logs under the repository.
+- Put only sanitized excerpts in GitHub and state that raw logs were excluded.
+- Delete temporary local evidence after the draft is confirmed or abandoned.
+
+## Escalation
+
+If credentials, a suspected breach, special-category data, or exploitable security details appear, stop public issue creation. Notify the user that private security/privacy handling is required and provide only a sanitized summary.

--- a/plugins/jurisdigta/skills/report-jurisdigta-bug/references/privacy-and-log-handling.md
+++ b/plugins/jurisdigta/skills/report-jurisdigta-bug/references/privacy-and-log-handling.md
@@ -2,7 +2,8 @@
 
 ## Collection contract
 
-- Obtain permission for production-log access.
+- Ask whether the error happened locally or on `jurisdigta-server` before log collection.
+- For local errors, stay within local logs. For server errors, obtain permission for remote log access.
 - Query the smallest useful time range, starting with 15 minutes around the reported event.
 - Select only relevant services and cap output, normally at 200 lines.
 - Prefer request/correlation IDs and aggregate operational events over free-text searches for user data.

--- a/scripts/package_jurisdigta_plugin.ps1
+++ b/scripts/package_jurisdigta_plugin.ps1
@@ -47,9 +47,12 @@ foreach ($SkillFile in $SkillFiles) {
     }
 }
 
-$ResolvedOutput = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
-    (Join-Path $RepoRoot $OutputDirectory)
-)
+$OutputPath = if ([System.IO.Path]::IsPathRooted($OutputDirectory)) {
+    $OutputDirectory
+} else {
+    Join-Path $RepoRoot $OutputDirectory
+}
+$ResolvedOutput = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($OutputPath)
 if (-not (Test-Path -LiteralPath $ResolvedOutput)) {
     New-Item -ItemType Directory -Path $ResolvedOutput -Force | Out-Null
 }

--- a/scripts/package_jurisdigta_plugin.ps1
+++ b/scripts/package_jurisdigta_plugin.ps1
@@ -1,0 +1,91 @@
+param(
+    [string]$OutputDirectory = "dist/plugin-release"
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$PluginRoot = Join-Path $RepoRoot "plugins/jurisdigta"
+$ManifestPath = Join-Path $PluginRoot ".codex-plugin/plugin.json"
+$MarketplacePath = Join-Path $RepoRoot ".agents/plugins/marketplace.json"
+
+if (-not (Test-Path -LiteralPath $ManifestPath)) {
+    throw "Plugin manifest not found: $ManifestPath"
+}
+if (-not (Test-Path -LiteralPath $MarketplacePath)) {
+    throw "Repository marketplace not found: $MarketplacePath"
+}
+
+$Manifest = Get-Content -LiteralPath $ManifestPath -Raw | ConvertFrom-Json
+if ($Manifest.name -ne "jurisdigta") {
+    throw "Expected plugin name 'jurisdigta', found '$($Manifest.name)'."
+}
+if ($Manifest.version -notmatch "^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$") {
+    throw "Plugin version must be release-safe semantic version without build metadata: '$($Manifest.version)'."
+}
+
+$Marketplace = Get-Content -LiteralPath $MarketplacePath -Raw | ConvertFrom-Json
+$MarketplaceEntry = @($Marketplace.plugins | Where-Object { $_.name -eq "jurisdigta" })
+if ($Marketplace.name -ne "jurisdigta" -or $MarketplaceEntry.Count -ne 1) {
+    throw "Marketplace must be named 'jurisdigta' and contain exactly one Jurisdigta plugin entry."
+}
+if ($MarketplaceEntry[0].source.path -ne "./plugins/jurisdigta") {
+    throw "Marketplace source must point to ./plugins/jurisdigta."
+}
+
+$SkillFiles = @(Get-ChildItem -LiteralPath (Join-Path $PluginRoot "skills") -Filter "SKILL.md" -File -Recurse)
+if ($SkillFiles.Count -eq 0) {
+    throw "No plugin skills were found."
+}
+foreach ($SkillFile in $SkillFiles) {
+    $SkillText = Get-Content -LiteralPath $SkillFile.FullName -Raw
+    if ($SkillText -notmatch "(?s)^---\r?\nname:\s*[a-z0-9-]+\r?\ndescription:\s*.+?\r?\n---") {
+        throw "Invalid skill frontmatter: $($SkillFile.FullName)"
+    }
+    if ($SkillText.Contains("[TODO:")) {
+        throw "Unresolved TODO placeholder: $($SkillFile.FullName)"
+    }
+}
+
+$ResolvedOutput = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
+    (Join-Path $RepoRoot $OutputDirectory)
+)
+if (-not (Test-Path -LiteralPath $ResolvedOutput)) {
+    New-Item -ItemType Directory -Path $ResolvedOutput -Force | Out-Null
+}
+
+$Version = [string]$Manifest.version
+$BundleName = "jurisdigta-plugin-$Version"
+$BundleRoot = Join-Path $ResolvedOutput $BundleName
+$ArchivePath = Join-Path $ResolvedOutput "$BundleName.zip"
+$ChecksumPath = "$ArchivePath.sha256"
+
+foreach ($Target in @($BundleRoot, $ArchivePath, $ChecksumPath)) {
+    if (Test-Path -LiteralPath $Target) {
+        throw "Refusing to overwrite existing release output: $Target"
+    }
+}
+
+New-Item -ItemType Directory -Path (Join-Path $BundleRoot "plugins") -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $BundleRoot ".agents/plugins") -Force | Out-Null
+Copy-Item -LiteralPath $PluginRoot -Destination (Join-Path $BundleRoot "plugins/jurisdigta") -Recurse
+Copy-Item -LiteralPath $MarketplacePath -Destination (Join-Path $BundleRoot ".agents/plugins/marketplace.json")
+
+Compress-Archive -LiteralPath $BundleRoot -DestinationPath $ArchivePath -CompressionLevel Optimal
+$Hash = (Get-FileHash -LiteralPath $ArchivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+$ArchiveName = Split-Path -Leaf $ArchivePath
+Set-Content -LiteralPath $ChecksumPath -Value "$Hash  $ArchiveName" -Encoding ascii
+
+if ($env:GITHUB_OUTPUT) {
+    $ArchiveOutput = [System.IO.Path]::GetRelativePath($RepoRoot, $ArchivePath).Replace("\", "/")
+    $ChecksumOutput = [System.IO.Path]::GetRelativePath($RepoRoot, $ChecksumPath).Replace("\", "/")
+    Add-Content -LiteralPath $env:GITHUB_OUTPUT -Value "version=$Version"
+    Add-Content -LiteralPath $env:GITHUB_OUTPUT -Value "tag=jurisdigta-plugin-v$Version"
+    Add-Content -LiteralPath $env:GITHUB_OUTPUT -Value "archive=$ArchiveOutput"
+    Add-Content -LiteralPath $env:GITHUB_OUTPUT -Value "checksum=$ChecksumOutput"
+}
+
+Write-Output "Plugin version: $Version"
+Write-Output "Skills validated: $($SkillFiles.Count)"
+Write-Output "Archive: $ArchivePath"
+Write-Output "Checksum: $ChecksumPath"


### PR DESCRIPTION
## What changed

Add a repository-local `jurisdigta` Codex plugin with four guided workflows:

- environment-routed, privacy-safe bug reporting
- source-backed ADR management
- requirements review and Ready GitHub task creation
- latest-main isolated implementation with unit tests, applicable Playwright E2E, screenshots, PR, and task lifecycle updates

Add shared developer distribution:

- repository marketplace at `.agents/plugins/marketplace.json`
- direct Git marketplace installation as `jurisdigta@jurisdigta`
- deterministic PowerShell validation/packaging script
- self-contained versioned ZIP containing the marketplace and plugin
- SHA-256 checksum generation
- main-only manual `plugin_release` workflow
- immutable tag guard for `jurisdigta-plugin-vX.Y.Z`
- GitHub prerelease publication with `make_latest: false`
- developer install/update and versioned download documentation

## Why

The repository marketplace lets developers share the plugin directly from `main`. Versioned release archives provide immutable, checksum-verifiable distribution. Plugin releases are prereleases so they do not replace the stable mobile APK release returned by GitHub's latest-release API.

## Compliance and safety

- task preparation applies GDPR and EU AI Act readiness checks before Ready status
- unresolved requirements or compliance gaps remain `Not Ready Yet`
- screenshots must use synthetic data and pass privacy review before publication
- incident diagnostics are environment-scoped, bounded, read-only, minimized, and redacted
- release packaging contains source/plugin metadata only and no environment files or runtime data
- the release workflow requires no test/prod Environment variables or secrets and uses scoped `GITHUB_TOKEN` contents permission

## Validation

- plugin validator passed
- all four skill validators passed
- packaging smoke test produced `jurisdigta-plugin-0.1.4.zip`
- archive contents include `.agents/plugins/marketplace.json` and all four plugin skills
- SHA-256 output was generated
- workflow outputs were verified as portable relative paths
- workflow YAML parsed successfully
- `git diff --cached --check` passed before commit

## Release after merge

After merge, manually dispatch `plugin_release` from `main`. This creates prerelease tag `jurisdigta-plugin-v0.1.4` and activates the documented versioned ZIP/checksum links. The workflow refuses dispatches from other refs and refuses to overwrite an existing release tag.

## Environment note

The repository conda bootstrap was previously attempted as required but failed during package metadata retrieval because of a local corporate CA/SSL certificate verification error. Plugin validation and release packaging use the bundled validators and PowerShell tooling and passed locally.