### PR TITLE
Constrain authentication card width

### DIFF
--- a/docs/FRONTEND_DEMO.md
+++ b/docs/FRONTEND_DEMO.md
@@ -18,6 +18,12 @@ npm run dev
 
 Open `http://localhost:5173`.
 
+## Authentication layout
+
+The sign-in and registration views share the card at `/auth`. On wide screens, the
+card is centered and limited to `480px`; on narrower screens, it shrinks with the
+page while the header and footer remain full-width.
+
 ## Minimal runnable example
 
 From repo root:

--- a/frontend/aijurisdictionfronend/e2e/auth-registration.spec.ts
+++ b/frontend/aijurisdictionfronend/e2e/auth-registration.spec.ts
@@ -1,5 +1,23 @@
 import { expect, test } from "@playwright/test";
 
+test("authentication card stays centered and constrained on wide screens", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/auth", { waitUntil: "domcontentloaded" });
+
+  const authPage = page.locator(".auth-page");
+  const authCard = page.locator(".auth-card");
+  await expect(authCard).toBeVisible();
+
+  const [pageBox, cardBox] = await Promise.all([authPage.boundingBox(), authCard.boundingBox()]);
+  expect(pageBox).not.toBeNull();
+  expect(cardBox).not.toBeNull();
+  expect(cardBox!.width).toBeLessThanOrEqual(480);
+
+  const pageCenter = pageBox!.x + pageBox!.width / 2;
+  const cardCenter = cardBox!.x + cardBox!.width / 2;
+  expect(Math.abs(pageCenter - cardCenter)).toBeLessThanOrEqual(1);
+});
+
 test("registration starts hidden and completes after email OTP verification", async ({ page }) => {
   let sendCodePayload: unknown;
   let completePayload: unknown;

--- a/frontend/aijurisdictionfronend/src/styles/app.css
+++ b/frontend/aijurisdictionfronend/src/styles/app.css
@@ -2645,7 +2645,8 @@
 
 .auth-page {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: minmax(0, 480px);
+  justify-content: center;
   gap: 2rem;
   align-items: start;
 }


### PR DESCRIPTION
## Summary

- center the login and registration card on wide screens
- constrain the shared authentication card to 480px while preserving responsive sizing
- document the layout contract and add E2E regression coverage

## Validation

- npm run lint (0 errors; 8 pre-existing warnings)
- npm run build
- npm test -- --run (114 passed)
- npx playwright test e2e/auth-registration.spec.ts (2 passed)
- python examples/minimal_demo.py

## Compliance

Presentation-only change. Authentication processing, consent, retention, logging, and legal-risk behavior are unchanged.