### PR TITLE
Pin API lint workflow to local Ruff config

### DIFF
--- a/.github/workflows/api_build_deploy.yml
+++ b/.github/workflows/api_build_deploy.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Lint
         working-directory: api/aijuristiction-api
-        run: ruff check app tests
+        run: ruff check --config pyproject.toml app tests
 
       - name: Type check
         working-directory: api/aijuristiction-api


### PR DESCRIPTION
## Summary
- make API lint step explicitly use the API-local \\pyproject.toml\\ config
- align GitHub Actions lint behavior with the verified local API lint command
- prevent nondeterministic workflow failures caused by an unexpected broader Ruff ruleset

## Verification
- uff check --config pyproject.toml app tests
