### PR TITLE
Pin API Ruff below 0.16

### DIFF
--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 dev = [
   "pytest>=8.4.2",
   "pypdf>=6.0",
-  "ruff>=0.12.8",
+  "ruff>=0.12.8,<0.16",
   "mypy>=1.17.1",
 ]
 


### PR DESCRIPTION
## Summary
- pin the API dev Ruff dependency below 0.16
- keep the API lint workflow on the last known compatible Ruff release line
- prevent the sudden expansion to a much broader lint ruleset from breaking API CI

## Verification
- `python -m pip install --upgrade "ruff<0.16"`
- `ruff --version`
- `ruff check app tests`
