### PR TITLE
Fix follow-up routing after document generation

### DIFF
--- a/api/aijuristiction-api/README.md
+++ b/api/aijuristiction-api/README.md
@@ -1081,3 +1081,10 @@ Cross-session memory formatting demo:
 ```bash
 python examples/conversation_memory_minimal_demo.py
 ```
+
+### Follow-up routing after document generation
+
+Document-generation intent is evaluated from the current user turn. Prior requests remain available as factual
+context, but they do not authorize another PDF. Questions such as `Aké sú chýbajúce údaje?`, model-selection
+questions, and MCP capability questions continue through the normal answer route unless the current message
+explicitly requests a new or updated document.

--- a/api/aijuristiction-api/app/chat/api.py
+++ b/api/aijuristiction-api/app/chat/api.py
@@ -1119,10 +1119,15 @@ def _persist_direct_assistant_message(
     session: Session,
     content: str,
     agent_name: str,
+    allow_document_generation: bool = True,
 ) -> Message:
     content = _validate_lawyer_output_message(session=session, content=content)
     content = _attach_technical_payload_to_case_if_needed(session=session, content=content)
-    generated_doc_ids = _persist_generated_case_document_if_needed(session=session, content=content)
+    generated_doc_ids = (
+        _persist_generated_case_document_if_needed(session=session, content=content)
+        if allow_document_generation
+        else []
+    )
     content = _attach_generated_case_document_references(
         session=session,
         content=content,
@@ -1468,6 +1473,7 @@ def _run_direct_lawyer_turn(
             session=session,
             content=status_reply,
             agent_name="LawyerStatus",
+            allow_document_generation=False,
         )
         _record_case_ai_model_audit(
             session=session,
@@ -1498,6 +1504,17 @@ def _run_direct_lawyer_turn(
     )
     processing_events = list(preparation.processing_events)
     if preparation.direct_reply is not None:
+        _LOGGER.info(
+            "Chat route selected",
+            extra={
+                "chat_route": "country_direct_reply",
+                "current_turn_document_request": _user_requested_document_generation(
+                    content=content,
+                    previous_messages=prior_messages,
+                ),
+                "generated_artifact_payload": _extract_case_update(preparation.direct_reply) is not None,
+            },
+        )
         normalized_direct_reply = _finalize_document_ready_reply_if_needed(
             session=session,
             messages=history,
@@ -1508,6 +1525,10 @@ def _run_direct_lawyer_turn(
             session=session,
             content=normalized_direct_reply,
             agent_name="Assistant",
+            allow_document_generation=_user_requested_document_generation(
+                content=content,
+                previous_messages=prior_messages,
+            ),
         )
         _record_case_ai_model_audit(
             session=session,
@@ -1533,10 +1554,47 @@ def _run_direct_lawyer_turn(
         request_user_id=request_user_id,
         request_user_email=request_user_email,
     )
+    runtime_reply = _runtime_question_reply(
+        content=content,
+        route=routed_llm,
+        prior_messages=prior_messages,
+    )
+    if runtime_reply is not None:
+        persisted_lawyer = _persist_direct_assistant_message(
+            session_id=session_id,
+            session=session,
+            content=runtime_reply,
+            agent_name="Assistant",
+            allow_document_generation=False,
+        )
+        _record_case_ai_model_audit(
+            session=session,
+            question=persisted_user,
+            answer=persisted_lawyer,
+            task_type="chat_status",
+            source="chat.direct_reply",
+            model_used=False,
+            route=routed_llm,
+        )
+        return (
+            persisted_user,
+            persisted_lawyer,
+            _user_visible_text(persisted_lawyer.content),
+            processing_events,
+            routed_llm,
+        )
     lawyer = create_lawyer_agent(routed_llm.client, session.country)
     case_memory_note = _build_case_memory_refresh_note(prior_messages)
     user_profile_note = _build_signed_in_user_profile_prompt_note(session)
     document_generation_requested = _user_requested_document_generation(content=content, previous_messages=prior_messages)
+    _LOGGER.info(
+        "Chat route selected",
+        extra={
+            "chat_route": "model_answer",
+            "current_turn_document_request": document_generation_requested,
+            "generated_artifact_payload": False,
+        },
+    )
     use_compact_local_prompt = _is_free_local_reply_route(routed_llm)
     if use_compact_local_prompt:
         prompt_override = _build_compact_free_local_lawyer_prompt(
@@ -1626,6 +1684,7 @@ def _run_direct_lawyer_turn(
             session=session,
             content=mcp_status_context.direct_reply,
             agent_name="Assistant",
+            allow_document_generation=False,
         )
         processing_events.append(mcp_status_context.processing_event)
         if processing_event_callback is not None:
@@ -1697,6 +1756,7 @@ def _run_direct_lawyer_turn(
         session=session,
         content=normalized_lawyer_content,
         agent_name=lawyer_message.agent_name,
+        allow_document_generation=document_generation_requested,
     )
     _record_case_ai_model_audit(
         session=session,
@@ -1741,6 +1801,54 @@ def _warn_if_flow_pack_missing(*, session_id: UUID, session: Session, request_te
 
 def _is_free_local_reply_route(route: RoutedLLMClient) -> bool:
     return bool(route.route_type == "free_local" and route.provider == "local_ollama")
+
+
+def _runtime_question_reply(
+    *,
+    content: str,
+    route: RoutedLLMClient,
+    prior_messages: list[Message] | None = None,
+) -> str | None:
+    normalized = _canonicalize_document_text(content)
+    asks_missing_data = "chybajuc" in normalized and any(
+        marker in normalized for marker in ("udaj", "data", "inform")
+    )
+    if asks_missing_data:
+        prior_text = "\n".join(
+            _canonicalize_document_text(_user_visible_text(message.content))
+            for message in (prior_messages or [])
+            if message.role == MessageRole.ASSISTANT
+        )
+        missing_fields: list[str] = []
+        candidates = (
+            ("poskytovatel pozicky bude doplneny", "poskytovateľ/platiteľ"),
+            ("prijemca bude doplneny", "príjemca"),
+            ("datum bude doplneny", "dátum platby alebo splatnosti"),
+            ("[mesto]", "miesto vystavenia"),
+            ("[datum vystavenia]", "dátum vystavenia"),
+        )
+        for marker, label in candidates:
+            if marker in prior_text and label not in missing_fields:
+                missing_fields.append(label)
+        if missing_fields:
+            return "V pripravenom dokumente chýbajú tieto údaje: " + ", ".join(missing_fields) + "."
+        return "V predchádzajúcej odpovedi nie sú označené žiadne konkrétne chýbajúce údaje."
+
+    asks_model = "model" in normalized and any(
+        marker in normalized for marker in ("aky", "ktory", "nazov", "pouziv")
+    )
+    if asks_model:
+        return f"V tomto chate používam model {route.model} cez poskytovateľa {route.provider}."
+
+    asks_mcp_runtime = "mcp" in normalized and any(
+        marker in normalized for marker in ("lokal", "local", "pouziv")
+    )
+    if not asks_mcp_runtime:
+        return None
+    remote_mcp = os.getenv("INTERNAL_MCP_BASE_URL", os.getenv("MCP_PUBLIC_BASE_URL", "")).strip()
+    if remote_mcp and remote_mcp != "unknown-variable":
+        return "JurisDigta MCP používam cez interné sieťové pripojenie, nie lokálne v procese API."
+    return "Áno. JurisDigta MCP je v tomto nasadení volané lokálne v procese API."
 
 
 def _build_compact_free_local_lawyer_prompt(

--- a/api/aijuristiction-api/app/chat/country_services/slovakia.py
+++ b/api/aijuristiction-api/app/chat/country_services/slovakia.py
@@ -512,27 +512,31 @@ def _looks_like_payment_confirmation_final_request(
     current_content: str,
     prior_messages: list[Message],
 ) -> bool:
-    user_context = " ".join(
-        message.content for message in prior_messages if message.role == MessageRole.USER
-    )
-    normalized = _canonicalize_slovak_text(f"{user_context} {current_content}")
+    # A previous document request is context, not authorization to create another
+    # artifact. Only the current user turn may activate this direct-generation
+    # shortcut. Otherwise every later question inherits words such as "priprav",
+    # "pozicka" and "potvrdenie" and silently regenerates the old document.
+    del prior_messages
+    normalized = _canonicalize_slovak_text(current_content)
     payment_tokens = ("zaplat", "uhrad", "platb", "splatk")
     loan_tokens = ("pozic", "pozick", "pozical", "pozicala", "pozicali", "dlh", "dlzn")
     if "potvrdenie" not in normalized or not any(token in normalized for token in payment_tokens + loan_tokens):
         return False
-    final_markers = (
-        "chcem",
-        "pdf",
-        "vygeneruj",
-        "generuj",
-        "finalny",
-        "finalne",
-        "konecnu",
-        "konecna",
-        "priprav",
-        "vytvor",
+
+    # Keep the request marker close to the requested document noun. This avoids
+    # mistaking a loan-agreement clause such as "zmluva ma obsahovat potvrdenie
+    # jej prijatia" for a request to create a separate payment confirmation.
+    explicit_confirmation_request = re.search(
+        r"(?:chcem|vytvor|priprav|vygeneruj|generuj)"
+        r"(?: [a-z0-9]+){0,8} potvrdenie(?: o| na| k| za| vo|$)",
+        normalized,
     )
-    return any(marker in normalized for marker in final_markers)
+    confirmation_first_request = re.search(
+        r"potvrdenie(?: o| na| k| za| vo|$)"
+        r"(?: [a-z0-9]+){0,8} (?:pdf|vytvor|priprav|vygeneruj|generuj)",
+        normalized,
+    )
+    return explicit_confirmation_request is not None or confirmation_first_request is not None
 
 
 def _append_payment_confirmation_validation_events(

--- a/api/aijuristiction-api/e2e-playwright/e2e-test-catalog.json
+++ b/api/aijuristiction-api/e2e-playwright/e2e-test-catalog.json
@@ -123,7 +123,7 @@
     "file": "tests/frontend-auth-case-document.spec.ts",
     "title": "registration and login can create, reopen, and preview a generated potvrdenie PDF",
     "name": "Frontend registration to generated PDF preview",
-    "description": "Exercises the browser flow for registration, login, case creation, assistant document generation, reopening the case, and previewing a generated potvrdenie PDF.",
+    "description": "Exercises registration, login, case creation, assistant document generation, follow-up questions that must not regenerate the document, screenshot evidence, case reopening, and generated PDF preview.",
     "area": "Frontend case workspace",
     "scheduled": false,
     "prerequisite": "Requires FRONTEND_BASE_URL with a running frontend."

--- a/api/aijuristiction-api/e2e-playwright/tests/frontend-auth-case-document.spec.ts
+++ b/api/aijuristiction-api/e2e-playwright/tests/frontend-auth-case-document.spec.ts
@@ -10,8 +10,6 @@ const execFileAsync = promisify(execFile);
 
 const apiKey = process.env.API_KEY ?? 'aijuris';
 const frontendBaseURL = process.env.FRONTEND_BASE_URL ?? 'http://127.0.0.1:5173';
-const loginEmail = process.env.E2E_LOGIN_EMAIL ?? 'mmaideveloper@gmail.com';
-const loginPassword = process.env.E2E_LOGIN_PASSWORD ?? 'tesT2026!';
 const otpCode = process.env.E2E_OTP_CODE ?? '111111';
 
 type AuthUser = {
@@ -42,8 +40,8 @@ test('registration and login can create, reopen, and preview a generated potvrde
   page,
   request,
   baseURL,
-}) => {
-  test.setTimeout(240_000);
+}, testInfo) => {
+  test.setTimeout(300_000);
   const runId = Date.now();
   const registrationEmail = `playwright.${runId}@example.test`;
   const registrationPhone = `+421900${String(runId).slice(-6)}`;
@@ -59,18 +57,13 @@ test('registration and login can create, reopen, and preview a generated potvrde
     'Splatné do: 1.1.2027.',
     'Vygeneruj finálne PDF potvrdenie na stiahnutie.',
   ].join(' ');
-  const confirmationPrompt =
-    'Nie, adresu neoveruj. Údaje sú potvrdené používateľom a môžeš ich použiť bez ďalších kontrol. ' +
-    'Vygeneruj finálne potvrdenie o zaplatení vo formáte PDF na stiahnutie.';
-
   await registerThroughUi(page, registrationEmail, registrationPhone);
   await logout(page);
 
-  const user = await loginThroughUi(page, loginEmail, loginPassword);
+  const user = await loginThroughUi(page, registrationEmail, 'tesT2026!');
   await deletePriorE2ECases(request, baseURL, user.userId);
   await createCaseThroughUi(page, caseTitle);
   await sendWorkspaceMessage(page, prompt);
-  await sendWorkspaceMessage(page, confirmationPrompt);
 
   const createdCase = await findCaseByTitle(request, baseURL, user.userId, caseTitle);
   const history = await pollGeneratedDocument(request, baseURL, user.userId, createdCase.case_id);
@@ -79,6 +72,30 @@ test('registration and login can create, reopen, and preview a generated potvrde
   );
   expect(generatedDocuments).toHaveLength(1);
   expect(generatedDocuments[0].original_filename).toMatch(/^potvrdenie.*_\d{8}T\d{6}Z\.pdf$/);
+
+  const followupPrompts = [
+    'Ake su chybajuce udaje?',
+    'Aky je nazov modelu ktory pouzivam?',
+    'Pouzivas lokalny MCP?',
+  ];
+  for (const followupPrompt of followupPrompts) {
+    await sendWorkspaceMessage(page, followupPrompt);
+  }
+
+  const followupHistory = await pollFollowupAnswers(
+    request,
+    baseURL,
+    user.userId,
+    createdCase.case_id,
+    followupPrompts,
+  );
+  expect(followupHistory.documents.filter((document) => document.kind === 'generated_document')).toHaveLength(1);
+  const followupAnswers = answersFollowingPrompts(followupHistory, followupPrompts);
+  expect(followupAnswers).toHaveLength(followupPrompts.length);
+  for (const answer of followupAnswers) {
+    expect(answer.toLowerCase()).not.toContain('tu je konecna verzia dokumentu');
+    expect(answer.toLowerCase()).not.toContain('dokument je pripraveny na export');
+  }
 
   await openSelectedCasePanel(page);
   await expect(page.locator('.sidebar-section--documents .sidebar-document-link')).toHaveCount(1);
@@ -107,7 +124,8 @@ test('registration and login can create, reopen, and preview a generated potvrde
   const pdfText = await extractPdfText(Buffer.from(await pdf.body()));
   expect(pdfText).toContain('JurisDigta');
   expect(pdfText).toMatch(/Potvrdenie/i);
-  expect(pdfText).toContain('Matej Mat');
+  expect(pdfText).toContain('Platitel:');
+  expect(pdfText).toContain('Prijemca:');
   expect(pdfText).toContain('1000');
   expect(pdfText).toContain('API version:');
   expect(pdfText).toContain('Core Version:');
@@ -116,13 +134,10 @@ test('registration and login can create, reopen, and preview a generated potvrde
   await viewerPage.close();
 
   await logout(page);
-  await loginThroughUi(page, loginEmail, loginPassword);
+  await loginThroughUi(page, registrationEmail, 'tesT2026!');
   await selectExistingCase(page, caseTitle);
   await expect(page.getByText(prompt.slice(0, 70), { exact: false })).toBeVisible({ timeout: 20_000 });
-  await expect(page.getByText(confirmationPrompt.slice(0, 70), { exact: false })).toBeVisible({
-    timeout: 20_000,
-  });
-  await expect(page.locator('.chat-message').filter({ hasText: /Potvrdenie|potvrdenie/i }).first()).toBeVisible({
+  await expect(page.locator('.assistant-message').filter({ hasText: /Potvrdenie|potvrdenie/i }).first()).toBeVisible({
     timeout: 20_000,
   });
   await openSelectedCasePanel(page);
@@ -130,16 +145,54 @@ test('registration and login can create, reopen, and preview a generated potvrde
   await expect(page.locator('.sidebar-section--documents .sidebar-document-link').first()).toContainText(
     /potvrdenie.*\.pdf/
   );
+
+  const hydratedMessages = page.locator('.assistant-message');
+  await expect(hydratedMessages).toHaveCount(8, { timeout: 20_000 });
+  await expect(hydratedMessages.last()).toContainText(/MCP/i);
+  await hydratedMessages.nth(0).evaluate((element) => {
+    (element as HTMLElement).style.display = 'none';
+  });
+  await hydratedMessages.nth(1).evaluate((element) => {
+    (element as HTMLElement).style.display = 'none';
+  });
+  await page.addStyleTag({
+    content: `
+      .app-shell--assistant,
+      .app-shell__body--assistant,
+      .app-shell--assistant .main-content,
+      .app-shell--assistant .workspace-page,
+      .app-shell--assistant .workspace-shell,
+      .app-shell--assistant .workspace-grid,
+      .app-shell--assistant .workspace-center,
+      .app-shell--assistant .assistant-workspace,
+      .assistant-main,
+      .assistant-thread,
+      .assistant-thread__viewport {
+        height: auto !important;
+        max-height: none !important;
+        overflow: visible !important;
+      }
+      .assistant-thread__viewport { flex: none !important; }
+      .assistant-composer { display: none !important; }
+    `,
+  });
+  const screenshotPath = testInfo.outputPath('issue-591-followup-routing.png');
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  await testInfo.attach('issue-591-followup-routing', {
+    path: screenshotPath,
+    contentType: 'image/png',
+  });
 });
 
 async function registerThroughUi(page: Page, email: string, phone: string): Promise<void> {
   await page.goto(`${frontendBaseURL}/auth`);
+  await page.getByRole('button', { name: 'Sign up' }).click();
+  await page.getByLabel('Phone number').fill(phone);
   await page.getByLabel('Work email').fill(email);
   await page.getByLabel('Password').fill('tesT2026!');
-  await page.locator('.auth-aside input[type="tel"]').fill(phone);
-  await page.getByRole('button', { name: 'Send registration OTP' }).click();
+  await page.getByRole('button', { name: 'Continue to email verification' }).click();
   await expect(page.getByText('OTP code was sent to the selected email.')).toBeVisible({ timeout: 15_000 });
-  await page.locator('.auth-aside input[inputmode="numeric"]').fill(otpCode);
+  await page.getByLabel('OTP code').fill(otpCode);
   await page.getByRole('button', { name: 'Create account' }).click();
   await expect(page).toHaveURL(/\/app\/assistant/, { timeout: 30_000 });
 }
@@ -175,14 +228,33 @@ async function createCaseThroughUi(page: Page, caseTitle: string): Promise<void>
   await page.getByLabel('Jurisdiction').fill('Slovakia');
   await page.getByLabel('Opposing party').fill('bez protistrany');
   await page.getByRole('button', { name: 'Start AI lawyer chat' }).click();
-  await expect(page.getByRole('heading', { name: caseTitle })).toBeVisible({ timeout: 20_000 });
+  await expect(page.locator('.case-item').filter({ hasText: caseTitle })).toBeVisible({ timeout: 20_000 });
 }
 
 async function sendWorkspaceMessage(page: Page, prompt: string): Promise<void> {
-  await page.getByPlaceholder('Type your message...').fill(prompt);
-  await page.getByRole('button', { name: 'Send' }).click();
-  await expect(page.getByText('Waiting for API response...')).toBeVisible();
-  await expect(page.getByText('Connected through API chat.')).toBeVisible({ timeout: 120_000 });
+  const messages = page.locator('.assistant-message');
+  const composer = page.getByPlaceholder('Ask for legal research or document preparation...');
+  const sendButton = page.getByRole('button', { name: 'Send message' });
+  await expect(composer).toBeEnabled({ timeout: 120_000 });
+  await expect(async () => {
+    await composer.fill(prompt);
+    await expect(composer).toHaveValue(prompt);
+    await expect(sendButton).toBeEnabled();
+  }).toPass({ timeout: 60_000 });
+  await sendButton.click();
+  await expect(messages.filter({ hasText: prompt })).toBeVisible({ timeout: 30_000 });
+  await expect
+    .poll(
+      async () => {
+        const lastMessage = messages.last();
+        const role = (await lastMessage.locator('.assistant-message__role').textContent())?.trim();
+        const text = (await lastMessage.locator('.assistant-message__text').textContent())?.trim();
+        return role !== 'You' && Boolean(text);
+      },
+      { timeout: 120_000 },
+    )
+    .toBe(true);
+  await expect(composer).toBeEnabled({ timeout: 120_000 });
 }
 
 async function openSelectedCasePanel(page: Page): Promise<void> {
@@ -199,7 +271,7 @@ async function selectExistingCase(page: Page, caseTitle: string): Promise<void> 
   const caseButton = page.locator('.case-item').filter({ hasText: caseTitle }).first();
   await expect(caseButton).toBeVisible({ timeout: 20_000 });
   await caseButton.click();
-  await expect(page.getByRole('heading', { name: caseTitle })).toBeVisible({ timeout: 20_000 });
+  await expect(caseButton).toHaveClass(/active/, { timeout: 20_000 });
 }
 
 async function findCaseByTitle(
@@ -257,16 +329,61 @@ async function pollGeneratedDocument(
     );
     if (
       generatedDocuments.length === 1 &&
-      /^potvrdenie.*_\d{8}T\d{6}Z\.pdf$/.test(generatedDocuments[0].original_filename)
+      /^potvrdenie.*_\d{8}T\d{6}Z\.pdf$/.test(generatedDocuments[0].original_filename) &&
+      lastHistory.messages.some((message) => message.role === 'user') &&
+      lastHistory.messages.some((message) => message.role === 'assistant')
     ) {
-      expect(lastHistory.messages.some((message) => message.role === 'user')).toBeTruthy();
-      expect(lastHistory.messages.some((message) => message.role === 'assistant')).toBeTruthy();
       return lastHistory;
     }
     await new Promise((resolve) => setTimeout(resolve, 2000));
   }
 
   throw new Error(`Generated potvrdenie PDF was not persisted. Last history: ${JSON.stringify(lastHistory)}`);
+}
+
+async function pollFollowupAnswers(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  userId: string,
+  caseId: string,
+  prompts: string[],
+): Promise<CaseHistory> {
+  const deadline = Date.now() + 180_000;
+  let lastHistory: CaseHistory | null = null;
+
+  while (Date.now() < deadline) {
+    const response = await request.get(
+      `${baseURL}/v1/cases/${caseId}/history?user_id=${userId}&limit=200`,
+      { headers: { 'x-api-key': apiKey } },
+    );
+    expect(response.ok()).toBeTruthy();
+    lastHistory = (await response.json()) as CaseHistory;
+    if (answersFollowingPrompts(lastHistory, prompts).length === prompts.length) {
+      return lastHistory;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+
+  throw new Error(`Follow-up answers were not persisted. Last history: ${JSON.stringify(lastHistory)}`);
+}
+
+function answersFollowingPrompts(history: CaseHistory, prompts: string[]): string[] {
+  const answers: string[] = [];
+  for (const prompt of prompts) {
+    const promptIndex = history.messages.findIndex(
+      (message) => message.role === 'user' && message.content === prompt,
+    );
+    if (promptIndex < 0) {
+      continue;
+    }
+    const answer = history.messages
+      .slice(promptIndex + 1)
+      .find((message) => message.role === 'assistant');
+    if (answer) {
+      answers.push(answer.content);
+    }
+  }
+  return answers;
 }
 
 async function extractPdfText(pdf: Buffer): Promise<string> {

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260531"
+version = "1.0.260532"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_chat.py
+++ b/api/aijuristiction-api/tests/test_chat.py
@@ -4261,6 +4261,133 @@ def test_slovak_private_loan_confirmation_first_turn_generates_document() -> Non
     assert "CASE_UPDATE_JSON" not in drafts[0].body
 
 
+def test_slovak_loan_agreement_followups_do_not_regenerate_payment_confirmation() -> None:
+    from app.chat.country_services.slovakia import prepare_slovakia_direct_reply
+    from app.chat.models import Message, MessageRole, Session
+
+    session = Session(country="SK", language="sk-SK")
+    initial_content = (
+        "Priprav mi navrh Zmluvy o pozicke medzi fyzickymi osobami. "
+        "Veritel: Jan Testovaci. Dlznik: Peter Vzorovy. Vyska pozicky: 8 000 EUR. "
+        "Peniaze budu odovzdane bankovym prevodom 15. 8. 2026 a vratene 15. 8. 2027. "
+        "Zmluva ma obsahovat potvrdenie jej prijatia."
+    )
+    initial_message = Message(session_id=session.id, role=MessageRole.USER, content=initial_content)
+
+    initial_preparation = prepare_slovakia_direct_reply(
+        session=session,
+        messages=[initial_message],
+        current_content=initial_content,
+        prior_messages=[],
+        normalize_document_lines=lambda text: [text],
+        extract_document_facts=lambda lines: {},
+        current_turn_confirms_document_generation=lambda content, previous_messages: False,
+        build_share_transfer_lines=lambda facts: [],
+    )
+
+    assert initial_preparation.direct_reply is None
+
+    prior_messages = [
+        initial_message,
+        Message(
+            session_id=session.id,
+            role=MessageRole.ASSISTANT,
+            content=(
+                "Tu je konecna verzia dokumentu - dokument je pripraveny na export a stiahnutie. "
+                "Ktory konkretny chybajuci udaj mam potvrdit ako prvy?"
+            ),
+        ),
+    ]
+    followups = (
+        "Ake su chybajuce udaje?",
+        "daj mi zoznam chybajucich udajov?",
+        "aky je nazov modelu ktory pouzivam?",
+        "pouzivas lokalny mcp?",
+    )
+
+    for followup in followups:
+        current_message = Message(session_id=session.id, role=MessageRole.USER, content=followup)
+        preparation = prepare_slovakia_direct_reply(
+            session=session,
+            messages=[*prior_messages, current_message],
+            current_content=followup,
+            prior_messages=prior_messages,
+            normalize_document_lines=lambda text: [text],
+            extract_document_facts=lambda lines: {},
+            current_turn_confirms_document_generation=lambda content, previous_messages: False,
+            build_share_transfer_lines=lambda facts: [],
+        )
+
+        assert preparation.direct_reply is None, followup
+        assert preparation.processing_events == []
+
+
+def test_direct_assistant_persistence_requires_current_turn_document_authorization(monkeypatch) -> None:
+    from app.chat import api as chat_api
+    from app.chat.models import Message, Session
+
+    session = Session(country="SK", language="sk-SK", case_id="case-591")
+    persisted_documents: list[str] = []
+
+    def fake_persist_generated_document(*, session: Session, content: str) -> list[str]:
+        persisted_documents.append(content)
+        return ["document-591"]
+
+    monkeypatch.setattr(chat_api, "_persist_generated_case_document_if_needed", fake_persist_generated_document)
+    monkeypatch.setattr(chat_api, "_persist_case_message_if_needed", lambda **kwargs: None)
+    monkeypatch.setattr(chat_api._repository, "add_message", lambda message: message)
+
+    reply = "Tu je historicky CASE_UPDATE_JSON s dokumentom, ale aktualny tah je otazka."
+    persisted = chat_api._persist_direct_assistant_message(
+        session_id=session.id,
+        session=session,
+        content=reply,
+        agent_name="Assistant",
+        allow_document_generation=False,
+    )
+
+    assert isinstance(persisted, Message)
+    assert persisted_documents == []
+    assert "Generated case document:" not in persisted.content
+
+
+def test_runtime_questions_receive_direct_answers_without_model_or_document_generation(monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    from app.chat import api as chat_api
+
+    route = SimpleNamespace(model="qwen3:1.7b", provider="local_ollama")
+    assert chat_api._runtime_question_reply(
+        content="Aky je nazov modelu ktory pouzivam?",
+        route=route,
+    ) == "V tomto chate používam model qwen3:1.7b cez poskytovateľa local_ollama."
+
+    monkeypatch.delenv("INTERNAL_MCP_BASE_URL", raising=False)
+    monkeypatch.delenv("MCP_PUBLIC_BASE_URL", raising=False)
+    assert chat_api._runtime_question_reply(
+        content="Pouzivas lokalny MCP?",
+        route=route,
+    ) == "Áno. JurisDigta MCP je v tomto nasadení volané lokálne v procese API."
+
+    prior_message = chat_api.Message(
+        session_id=chat_api.Session().id,
+        role=chat_api.MessageRole.ASSISTANT,
+        content=(
+            "Platitel: Poskytovatel pozicky bude doplneny pred podpisom. "
+            "Prijemca: Prijemca bude doplneny pred podpisom. "
+            "V [mesto], dna [datum vystavenia]"
+        ),
+    )
+    missing_reply = chat_api._runtime_question_reply(
+        content="Ake su chybajuce udaje?",
+        route=route,
+        prior_messages=[prior_message],
+    )
+    assert missing_reply is not None
+    assert "poskytovateľ/platiteľ" in missing_reply
+    assert "miesto vystavenia" in missing_reply
+
+
 def test_document_export_uses_latest_legal_document_body_without_assistant_notes() -> None:
     from app.chat import api as chat_api
     from app.chat.country_services.slovakia import (


### PR DESCRIPTION
Closes #591

## What changed

- evaluate payment-confirmation generation from the current user turn instead of inheriting generation intent from prior messages
- require explicit, nearby confirmation-document wording before taking the Slovak direct-generation shortcut
- gate generated-document persistence behind current-turn authorization
- answer follow-up questions about missing fields, the routed model, and MCP runtime directly without generating artifacts
- add structured route logging, API documentation, regression coverage, and a live browser E2E scenario
- bump the API version to `1.0.260532`

## Root cause and impact

The Slovak shortcut concatenated earlier user messages with the latest question, so document keywords from the original request remained active indefinitely. The persistence layer could also interpret stale assistant metadata as authorization to save another PDF. As a result, questions such as `Aké sú chýbajúce údaje?` could repeat the previous final-document response and create duplicate documents.

The new behavior treats prior turns as factual context only. A new or updated document is created only when the current message explicitly requests it.

## Validation

- targeted pytest regression tests: passed
- `ruff check app tests`: passed
- `mypy app`: passed
- Playwright live frontend/API E2E: passed (`frontend-auth-case-document.spec.ts`)
- E2E case-history assertion confirms 8 messages and exactly 1 generated PDF after three follow-up questions

A wider API suite was also attempted with local storage overrides; unrelated tests that inherit PostgreSQL-backed email/case/MCP settings could not connect because the local PostgreSQL credentials are unavailable.