### PR TITLE
Fix TOTP choice for new-browser verification

### DIFF
--- a/api/aijuristiction-api/app/users/api.py
+++ b/api/aijuristiction-api/app/users/api.py
@@ -444,7 +444,15 @@ def sign_in(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid email or password",
         )
-    if _requires_mfa(store=store, user=user):
+    device_id = (payload.device_id or "").strip()
+    device_verification_required = _requires_web_device_verification(
+        store=store,
+        user=user,
+        device_id=device_id,
+    )
+    if _requires_mfa(store=store, user=user) or (
+        device_verification_required and _user_has_totp_enabled(store=store, user=user)
+    ):
         mfa_token = secrets.token_urlsafe(32)
         store.create_mfa_login_challenge(user_id=user.user_id, token=mfa_token)
         return MfaRequiredResponse(
@@ -454,27 +462,25 @@ def sign_in(
             methods=_available_mfa_methods(store=store, user=user),
             reuse_window_hours=_mfa_reuse_window_hours(),
         )
-    device_id = (payload.device_id or "").strip()
-    if device_id:
+    if device_verification_required:
         otp_purpose = _web_sign_in_otp_purpose(device_id=device_id)
-        if not store.has_valid_mcp_otp_verification(user_id=user.user_id, purpose=otp_purpose):
-            verification_code = (payload.verification_code or "").strip()
-            if not verification_code:
-                _send_web_sign_in_code(store=store, scheduler=scheduler, user=user, device_id=device_id)
-                raise HTTPException(
-                    status_code=status.HTTP_428_PRECONDITION_REQUIRED,
-                    detail="OTP code required",
-                )
-            if not _accepts_any_local_auth_code() and not store.verify_registration_code(
-                email=_web_sign_in_code_key(user_id=user.user_id, device_id=device_id),
-                code=verification_code,
-            ):
-                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid verification code")
-            store.save_mcp_otp_verification(
-                user_id=user.user_id,
-                purpose=otp_purpose,
-                expires_in_hours=_web_sign_in_otp_reuse_window_hours(),
+        verification_code = (payload.verification_code or "").strip()
+        if not verification_code:
+            _send_web_sign_in_code(store=store, scheduler=scheduler, user=user, device_id=device_id)
+            raise HTTPException(
+                status_code=status.HTTP_428_PRECONDITION_REQUIRED,
+                detail="OTP code required",
             )
+        if not _accepts_any_local_auth_code() and not store.verify_registration_code(
+            email=_web_sign_in_code_key(user_id=user.user_id, device_id=device_id),
+            code=verification_code,
+        ):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid verification code")
+        store.save_mcp_otp_verification(
+            user_id=user.user_id,
+            purpose=otp_purpose,
+            expires_in_hours=_web_sign_in_otp_reuse_window_hours(),
+        )
     token: str | None = None
     if device_id:
         token = store.issue_device_auth_token(user_id=user.user_id, device_id=device_id)
@@ -532,9 +538,16 @@ def verify_mfa(
     else:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported MFA method")
     _save_mfa_verification(store=store, user=user)
+    device_id = (payload.device_id or "").strip()
+    if device_id:
+        store.save_mcp_otp_verification(
+            user_id=user.user_id,
+            purpose=_web_sign_in_otp_purpose(device_id=device_id),
+            expires_in_hours=_web_sign_in_otp_reuse_window_hours(),
+        )
     token: str | None = None
-    if payload.device_id:
-        token = store.issue_device_auth_token(user_id=user.user_id, device_id=payload.device_id)
+    if device_id:
+        token = store.issue_device_auth_token(user_id=user.user_id, device_id=device_id)
     return _to_device_auth_user_profile_response(user=user, token=token, store=store)
 
 
@@ -962,6 +975,15 @@ def _web_sign_in_otp_purpose(*, device_id: str) -> str:
     return f"web-login:{device_id.strip().lower()}"
 
 
+def _requires_web_device_verification(*, store: ApiDatabaseStore, user: User, device_id: str) -> bool:
+    if not device_id:
+        return False
+    return not store.has_valid_mcp_otp_verification(
+        user_id=user.user_id,
+        purpose=_web_sign_in_otp_purpose(device_id=device_id),
+    )
+
+
 def _web_sign_in_otp_reuse_window_hours() -> int:
     raw_value = os.getenv("MCP_OTP_REUSE_WINDOW_HOURS", "24").strip()
     try:
@@ -1008,12 +1030,15 @@ def _mfa_reuse_window_hours() -> int:
 
 
 def _requires_mfa(*, store: ApiDatabaseStore, user: User) -> bool:
-    settings = store.get_user_mfa_settings(user_id=user.user_id)
-    if not settings.totp_enabled:
+    if not _user_has_totp_enabled(store=store, user=user):
         return False
     if _mfa_reuse_window_hours() < 1:
         return True
     return not store.has_valid_mfa_verification(user_id=user.user_id, purpose=_GLOBAL_MFA_PURPOSE)
+
+
+def _user_has_totp_enabled(*, store: ApiDatabaseStore, user: User) -> bool:
+    return bool(store.get_user_mfa_settings(user_id=user.user_id).totp_enabled)
 
 
 def _save_mfa_verification(*, store: ApiDatabaseStore, user: User) -> None:

--- a/api/aijuristiction-api/pyproject.toml
+++ b/api/aijuristiction-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aijuristiction-api"
-version = "1.0.260532"
+version = "1.0.260533"
 description = "Dedicated API service for aijurisdictionagents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/aijuristiction-api/tests/test_users.py
+++ b/api/aijuristiction-api/tests/test_users.py
@@ -547,7 +547,11 @@ def test_totp_enrollment_and_web_mfa_login_reuse(monkeypatch, tmp_path: Path) ->
     first_login = client.post(
         "/v1/users/sign-in",
         headers=AUTH_HEADERS,
-        json={"email": "totp-web@example.com", "password": "secret-pass"},
+        json={
+            "email": "totp-web@example.com",
+            "password": "secret-pass",
+            "device_id": "totp-device-1",
+        },
     )
     assert first_login.status_code == 200
     first_challenge = first_login.json()
@@ -562,6 +566,7 @@ def test_totp_enrollment_and_web_mfa_login_reuse(monkeypatch, tmp_path: Path) ->
             "mfa_token": first_challenge["mfa_token"],
             "method": "totp",
             "verification_code": current_totp_code(secret=enrollment["manual_setup_key"]),
+            "device_id": "totp-device-1",
         },
     )
     assert verify_response.status_code == 200
@@ -570,11 +575,74 @@ def test_totp_enrollment_and_web_mfa_login_reuse(monkeypatch, tmp_path: Path) ->
     reused_login = client.post(
         "/v1/users/sign-in",
         headers=AUTH_HEADERS,
-        json={"email": "totp-web@example.com", "password": "secret-pass"},
+        json={
+            "email": "totp-web@example.com",
+            "password": "secret-pass",
+            "device_id": "totp-device-1",
+        },
     )
     assert reused_login.status_code == 200
     assert reused_login.json()["user_id"] == user_id
     assert "mfa_token" not in reused_login.json()
+
+    new_device_login = client.post(
+        "/v1/users/sign-in",
+        headers=AUTH_HEADERS,
+        json={
+            "email": "totp-web@example.com",
+            "password": "secret-pass",
+            "device_id": "totp-device-2",
+        },
+    )
+    assert new_device_login.status_code == 200
+    new_device_challenge = new_device_login.json()
+    assert new_device_challenge["mfa_required"] is True
+    assert new_device_challenge["methods"] == ["email", "totp"]
+
+    send_email_response = client.post(
+        "/v1/users/sign-in/mfa/send-email-code",
+        headers=AUTH_HEADERS,
+        json={"mfa_token": new_device_challenge["mfa_token"]},
+    )
+    assert send_email_response.status_code == 202
+
+    with sqlite3.connect(tmp_path / "api.sqlite3") as conn:
+        code_hash = conn.execute(
+            "SELECT code_hash FROM registration_codes WHERE email = ?",
+            (f"mfa-login:{user_id}",),
+        ).fetchone()[0]
+    valid_email_code = None
+    for candidate in range(0, 1_000_000):
+        code = f"{candidate:06d}"
+        if hashlib.sha256(code.encode("utf-8")).hexdigest() == code_hash:
+            valid_email_code = code
+            break
+    assert valid_email_code is not None
+
+    verify_email_response = client.post(
+        "/v1/users/sign-in/mfa/verify",
+        headers=AUTH_HEADERS,
+        json={
+            "mfa_token": new_device_challenge["mfa_token"],
+            "method": "email",
+            "verification_code": valid_email_code,
+            "device_id": "totp-device-2",
+        },
+    )
+    assert verify_email_response.status_code == 200
+
+    reused_new_device_login = client.post(
+        "/v1/users/sign-in",
+        headers=AUTH_HEADERS,
+        json={
+            "email": "totp-web@example.com",
+            "password": "secret-pass",
+            "device_id": "totp-device-2",
+        },
+    )
+    assert reused_new_device_login.status_code == 200
+    assert reused_new_device_login.json()["user_id"] == user_id
+    assert "mfa_token" not in reused_new_device_login.json()
 
 
 def test_sign_up_rejects_duplicate_phone_and_email(monkeypatch, tmp_path: Path) -> None:

--- a/docs/ENV_VARIABLES.md
+++ b/docs/ENV_VARIABLES.md
@@ -24,8 +24,13 @@ profile. Optional inactive keys should be absent or commented, not active with
 `MFA_REUSE_WINDOW_HOURS=12` keeps a successful web MFA verification valid for
 12 hours. Logging out still invalidates the active authenticated session, but a
 subsequent password sign-in during that window does not require another MFA
-code. Set `MFA_REUSE_WINDOW_HOURS=0` to require MFA on every sign-in. The API
-runtime fallback remains `0` when the variable is absent or invalid.
+code on an already verified browser. If a different browser requires device
+verification and the account has TOTP enabled, the API returns an MFA challenge
+offering both authenticator TOTP and email OTP. Completing either method verifies
+that browser for `MCP_OTP_REUSE_WINDOW_HOURS` and avoids an email-only prompt.
+Accounts without TOTP continue to use the email OTP device-verification flow.
+Set `MFA_REUSE_WINDOW_HOURS=0` to require MFA on every sign-in. The API runtime
+fallback remains `0` when the variable is absent or invalid.
 
 ## Commands
 

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -16,7 +16,8 @@ print(
 )
 print(
     "web_mfa_reuse => MFA_REUSE_WINDOW_HOURS=12 skips repeat MFA for 12 hours after successful "
-    "verification while logout still ends the session; set 0 to require MFA on every sign-in."
+    "verification on a verified browser; a new browser for a TOTP-enabled account offers both "
+    "authenticator and email verification, while logout still ends the active session."
 )
 
 agent = AIAudioToolRecognizerAgent()


### PR DESCRIPTION
Closes #594

## Summary
- preserve TOTP as an available sign-in method when a new browser requires device verification
- mark the browser verified after successful TOTP or email MFA
- retain the existing email-only OTP flow for accounts without TOTP
- document the reuse behavior and bump the API revision

## Validation
- `pytest api/aijuristiction-api/tests/test_users.py -q` (19 passed)
- `scripts/validate_api.ps1` (Ruff and mypy passed)
- `python examples/minimal_demo.py` (passed)
- full API suite reached 100%; configuration-sensitive MCP OAuth reuse profiles were also verified separately under their intended environment settings

## Compliance
No new data categories or external processing are introduced. Existing purpose-scoped, expiring device-verification markers are reused; authentication choices are made more transparent and no MFA control is weakened.