### PR TITLE
Gate Azure ACR image publication behind create_image

### DIFF
--- a/.github/workflows/api_build_deploy.yml
+++ b/.github/workflows/api_build_deploy.yml
@@ -18,6 +18,11 @@ on:
       - ".github/workflows/api_build_deploy.yml"
   workflow_dispatch:
     inputs:
+      create_image:
+        description: "Build and upload a new API image to Azure Container Registry"
+        required: false
+        type: boolean
+        default: false
       deploy:
         description: "Deploy to Azure Container Apps"
         required: false
@@ -66,7 +71,7 @@ jobs:
   deploy_to_azure:
     runs-on: ubuntu-latest
     needs: test_and_build
-    if: github.event_name == 'workflow_dispatch' && inputs.deploy
+    if: github.event_name == 'workflow_dispatch' && (inputs.create_image || inputs.deploy)
     environment: ${{ inputs.github_environment }}
     permissions:
       id-token: write
@@ -119,20 +124,30 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Summarize requested operation
+        run: |
+          echo "create_image_requested=${{ inputs.create_image }}"
+          echo "deploy_requested=${{ inputs.deploy }}"
+          echo "effective_create_image=${{ inputs.create_image || inputs.deploy }}"
+
       - name: Validate required environment variables
         run: |
           missing=0
-          for key in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_RESOURCE_GROUP AZURE_CONTAINERAPPS_ENVIRONMENT AZURE_CONTAINER_APP_NAME AZURE_CONTAINER_REGISTRY AZURE_LOG_ANALYTICS_WORKSPACE_NAME AZURE_MANAGED_IDENTITY_NAME AZURE_POSTGRES_SERVER_NAME AZURE_POSTGRES_DATABASE_NAME AZURE_POSTGRES_ADMIN_USERNAME AZURE_POSTGRES_ADMIN_PASSWORD AZURE_OPENAI_API_KEY; do
+          required=(AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_CONTAINER_REGISTRY)
+          if [ "${{ inputs.deploy }}" = "true" ]; then
+            required+=(AZURE_RESOURCE_GROUP AZURE_CONTAINERAPPS_ENVIRONMENT AZURE_CONTAINER_APP_NAME AZURE_LOG_ANALYTICS_WORKSPACE_NAME AZURE_MANAGED_IDENTITY_NAME AZURE_POSTGRES_SERVER_NAME AZURE_POSTGRES_DATABASE_NAME AZURE_POSTGRES_ADMIN_USERNAME AZURE_POSTGRES_ADMIN_PASSWORD AZURE_OPENAI_API_KEY)
+          fi
+          for key in "${required[@]}"; do
             if [ -z "${!key}" ]; then
               echo "Missing GitHub Environment variable: $key"
               missing=1
             fi
           done
-          if [ "${EMAIL_TRANSPORT,,}" = "smtp" ] && [ -z "${EMAIL_SMTP_PASSWORD:-}" ]; then
+          if [ "${{ inputs.deploy }}" = "true" ] && [ "${EMAIL_TRANSPORT,,}" = "smtp" ] && [ -z "${EMAIL_SMTP_PASSWORD:-}" ]; then
             echo "Missing GitHub Environment secret: EMAIL_SMTP_PASSWORD is required when EMAIL_TRANSPORT=smtp"
             missing=1
           fi
-          if [ "${CONTACT_CAPTCHA_REQUIRED,,}" = "true" ] && [ -z "${TURNSTILE_SECRET_KEY:-}" ]; then
+          if [ "${{ inputs.deploy }}" = "true" ] && [ "${CONTACT_CAPTCHA_REQUIRED,,}" = "true" ] && [ -z "${TURNSTILE_SECRET_KEY:-}" ]; then
             echo "Missing GitHub Environment secret: TURNSTILE_SECRET_KEY is required when CONTACT_CAPTCHA_REQUIRED=true"
             missing=1
           fi
@@ -167,6 +182,7 @@ jobs:
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
       - uses: actions/setup-python@v6
+        if: inputs.deploy
         with:
           python-version: "3.11"
 
@@ -177,6 +193,7 @@ jobs:
           docker push ${{ steps.acr.outputs.acr_login_server }}/aijuristiction-api:${{ github.sha }}
 
       - name: Preconfigure API secrets for existing Container App
+        if: inputs.deploy
         shell: bash
         run: |
           is_retryable_containerapp_failure() {
@@ -347,6 +364,7 @@ jobs:
             --output none
 
       - name: Deploy to Azure Container Apps
+        if: inputs.deploy
         uses: azure/container-apps-deploy-action@v2
         with:
           acrName: ${{ steps.acr.outputs.acr_name }}
@@ -356,6 +374,7 @@ jobs:
           imageToDeploy: ${{ steps.acr.outputs.acr_login_server }}/aijuristiction-api:${{ github.sha }}
 
       - name: Wait for Container App provisioning to settle
+        if: inputs.deploy
         shell: bash
         run: |
           wait_for_container_app_ready() {
@@ -391,6 +410,7 @@ jobs:
           wait_for_container_app_ready
 
       - name: Configure API database environment
+        if: inputs.deploy
         shell: bash
         run: |
           wait_for_container_app_ready() {
@@ -616,6 +636,7 @@ jobs:
             --output none
 
       - name: Allow GitHub runner IP on PostgreSQL firewall
+        if: inputs.deploy
         id: runner_ip
         shell: bash
         run: |
@@ -631,11 +652,13 @@ jobs:
             --output none
 
       - name: Install migration dependencies
+        if: inputs.deploy
         run: |
           python -m pip install --upgrade pip
           pip install -e .
 
       - name: Apply API schema migrations on Azure PostgreSQL
+        if: inputs.deploy
         shell: bash
         run: |
           export DB_OPTION=azure
@@ -652,6 +675,7 @@ jobs:
           python scripts/databases/apply_api_db_schema.py
 
       - name: Summarize ACA deployment
+        if: inputs.deploy
         shell: bash
         run: |
           fqdn="$(az containerapp show \
@@ -674,7 +698,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Remove GitHub runner firewall rule
-        if: always()
+        if: always() && inputs.deploy
         shell: bash
         run: |
           az postgres flexible-server firewall-rule delete \

--- a/.github/workflows/document_processor_build_deploy.yml
+++ b/.github/workflows/document_processor_build_deploy.yml
@@ -22,11 +22,16 @@ on:
       - ".github/workflows/document_processor_build_deploy.yml"
   workflow_dispatch:
     inputs:
+      create_image:
+        description: "Build and upload a new document processor image to Azure Container Registry"
+        required: false
+        type: boolean
+        default: false
       deploy:
         description: "Deploy the document processor ACA job"
         required: false
         type: boolean
-        default: true
+        default: false
       github_environment:
         description: "GitHub Environment that contains Azure variables"
         required: true
@@ -68,7 +73,7 @@ jobs:
   deploy_to_azure:
     runs-on: windows-latest
     needs: test_and_build
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.deploy)
+    if: github.event_name == 'workflow_dispatch' && (inputs.create_image || inputs.deploy)
     environment: ${{ github.event_name == 'workflow_dispatch' && inputs.github_environment || 'dev' }}
     permissions:
       id-token: write
@@ -102,6 +107,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Summarize requested operation
+        shell: pwsh
+        run: |
+          Write-Host "create_image_requested=${{ inputs.create_image }}"
+          Write-Host "deploy_requested=${{ inputs.deploy }}"
+          Write-Host "effective_create_image=${{ inputs.create_image || inputs.deploy }}"
+
       - name: Validate required environment variables
         shell: pwsh
         run: |
@@ -115,21 +127,26 @@ jobs:
             "AZURE_CLIENT_ID",
             "AZURE_TENANT_ID",
             "AZURE_SUBSCRIPTION_ID",
-            "AZURE_RESOURCE_GROUP",
-            "AZURE_CONTAINERAPPS_ENVIRONMENT",
-            "AZURE_CONTAINER_REGISTRY",
-            "AZURE_MANAGED_IDENTITY_NAME",
-            "AZURE_POSTGRES_SERVER_NAME",
-            "AZURE_POSTGRES_ADMIN_USERNAME",
-            "AZURE_POSTGRES_ADMIN_PASSWORD",
-            "AZURE_STORAGE_ACCOUNT_NAME"
+            "AZURE_CONTAINER_REGISTRY"
           )
 
-          if ($embeddingOption -ne "local") {
+          $deployRequested = [System.Convert]::ToBoolean("${{ inputs.deploy }}")
+          if ($deployRequested) {
             $required += @(
-              "AZURE_OPENAI_ENDPOINT",
-              "AZURE_OPENAI_API_KEY"
+              "AZURE_RESOURCE_GROUP",
+              "AZURE_CONTAINERAPPS_ENVIRONMENT",
+              "AZURE_MANAGED_IDENTITY_NAME",
+              "AZURE_POSTGRES_SERVER_NAME",
+              "AZURE_POSTGRES_ADMIN_USERNAME",
+              "AZURE_POSTGRES_ADMIN_PASSWORD",
+              "AZURE_STORAGE_ACCOUNT_NAME"
             )
+            if ($embeddingOption -ne "local") {
+              $required += @(
+                "AZURE_OPENAI_ENDPOINT",
+                "AZURE_OPENAI_API_KEY"
+              )
+            }
           }
 
           $missing = @()
@@ -182,10 +199,11 @@ jobs:
           pip install -e .
 
       - name: Ensure Azure Container Apps extension
+        if: inputs.deploy
         shell: pwsh
         run: az extension add --name containerapp --upgrade --only-show-errors
 
-      - name: Deploy document processor job
+      - name: Build and optionally deploy document processor job
         shell: pwsh
         run: |
           Write-Host "Document processor deploy location: $env:AZURE_DOCUMENT_PROCESSOR_LOCATION"
@@ -221,6 +239,8 @@ jobs:
             $env:AZURE_STORAGE_CONTAINER_NAME
           }
 
+          $buildOnly = -not [System.Convert]::ToBoolean("${{ inputs.deploy }}")
+
           ./infra/scripts/deploy_document_processor.ps1 `
             -SkipEnvFile `
             -SubscriptionId $env:AZURE_SUBSCRIPTION_ID `
@@ -246,4 +266,5 @@ jobs:
             -AzureOpenAIApiKey $env:AZURE_OPENAI_API_KEY `
             -CronExpression $cronExpression `
             -DocumentProcessorMaxRunningTime $env:DOCUMENT_PROCESSOR_MAX_RUNNING_TIME `
-            -ImageTag $imageTag
+            -ImageTag $imageTag `
+            -BuildOnly:$buildOnly

--- a/.github/workflows/email_build_deploy.yml
+++ b/.github/workflows/email_build_deploy.yml
@@ -20,6 +20,11 @@ on:
       - ".github/workflows/email_build_deploy.yml"
   workflow_dispatch:
     inputs:
+      create_image:
+        description: "Build and upload a new email scheduler image to Azure Container Registry"
+        required: false
+        type: boolean
+        default: false
       deploy:
         description: "Deploy the email scheduler ACA job"
         required: false
@@ -63,7 +68,7 @@ jobs:
   deploy_to_azure:
     runs-on: windows-latest
     needs: test_and_build
-    if: github.event_name == 'workflow_dispatch' && inputs.deploy
+    if: github.event_name == 'workflow_dispatch' && (inputs.create_image || inputs.deploy)
     environment: ${{ github.event_name == 'workflow_dispatch' && inputs.github_environment || 'dev' }}
     permissions:
       id-token: write
@@ -94,6 +99,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Summarize requested operation
+        shell: pwsh
+        run: |
+          Write-Host "create_image_requested=${{ inputs.create_image }}"
+          Write-Host "deploy_requested=${{ inputs.deploy }}"
+          Write-Host "effective_create_image=${{ inputs.create_image || inputs.deploy }}"
+
       - name: Validate required environment variables
         shell: pwsh
         run: |
@@ -101,15 +113,21 @@ jobs:
             "AZURE_CLIENT_ID",
             "AZURE_TENANT_ID",
             "AZURE_SUBSCRIPTION_ID",
-            "AZURE_RESOURCE_GROUP",
-            "AZURE_LOCATION",
-            "AZURE_CONTAINERAPPS_ENVIRONMENT",
-            "AZURE_CONTAINER_REGISTRY",
-            "AZURE_MANAGED_IDENTITY_NAME",
-            "AZURE_POSTGRES_SERVER_NAME",
-            "AZURE_POSTGRES_ADMIN_USERNAME",
-            "AZURE_POSTGRES_ADMIN_PASSWORD"
+            "AZURE_CONTAINER_REGISTRY"
           )
+
+          $deployRequested = [System.Convert]::ToBoolean("${{ inputs.deploy }}")
+          if ($deployRequested) {
+            $required += @(
+              "AZURE_RESOURCE_GROUP",
+              "AZURE_LOCATION",
+              "AZURE_CONTAINERAPPS_ENVIRONMENT",
+              "AZURE_MANAGED_IDENTITY_NAME",
+              "AZURE_POSTGRES_SERVER_NAME",
+              "AZURE_POSTGRES_ADMIN_USERNAME",
+              "AZURE_POSTGRES_ADMIN_PASSWORD"
+            )
+          }
 
           $missing = @()
           foreach ($name in $required) {
@@ -118,7 +136,7 @@ jobs:
             }
           }
 
-          if ($env:EMAIL_TRANSPORT.Trim().ToLowerInvariant() -eq "smtp" -and [string]::IsNullOrWhiteSpace($env:EMAIL_SMTP_PASSWORD)) {
+          if ($deployRequested -and $env:EMAIL_TRANSPORT.Trim().ToLowerInvariant() -eq "smtp" -and [string]::IsNullOrWhiteSpace($env:EMAIL_SMTP_PASSWORD)) {
             $missing += "EMAIL_SMTP_PASSWORD"
           }
 
@@ -159,10 +177,12 @@ jobs:
           python-version: "3.11"
 
       - name: Ensure Azure Container Apps extension
+        if: inputs.deploy
         shell: pwsh
         run: az extension add --name containerapp --upgrade --only-show-errors
 
       - name: Allow GitHub runner IP on PostgreSQL firewall
+        if: inputs.deploy
         shell: pwsh
         run: |
           $runnerIp = (Invoke-RestMethod -Uri "https://api.ipify.org").Trim()
@@ -176,12 +196,13 @@ jobs:
             --output none
 
       - name: Install deployment dependencies
+        if: inputs.deploy
         shell: pwsh
         run: |
           python -m pip install --upgrade pip
           pip install -e .
 
-      - name: Deploy email scheduler job
+      - name: Build and optionally deploy email scheduler job
         shell: pwsh
         run: |
           $imageTagInput = "${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}"
@@ -190,6 +211,8 @@ jobs:
           } else {
             $imageTagInput
           }
+
+          $buildOnly = -not [System.Convert]::ToBoolean("${{ inputs.deploy }}")
 
           ./infra/scripts/deploy_email_scheduler.ps1 `
             -SkipEnvFile `
@@ -213,10 +236,11 @@ jobs:
             -EmailSmtpUsername $env:EMAIL_SMTP_USERNAME `
             -EmailSmtpPassword $env:EMAIL_SMTP_PASSWORD `
             -CronExpression $env:AZURE_EMAIL_SCHEDULER_CRON_EXPRESSION `
-            -ImageTag $imageTag
+            -ImageTag $imageTag `
+            -BuildOnly:$buildOnly
 
       - name: Remove GitHub runner firewall rule
-        if: always()
+        if: always() && inputs.deploy
         shell: pwsh
         run: |
           az postgres flexible-server firewall-rule delete `

--- a/.github/workflows/laws_collector_build_deploy.yml
+++ b/.github/workflows/laws_collector_build_deploy.yml
@@ -28,6 +28,11 @@ on:
       - ".github/workflows/laws_collector_build_deploy.yml"
   workflow_dispatch:
     inputs:
+      create_image:
+        description: "Build and upload a new laws collector image to Azure Container Registry"
+        required: false
+        type: boolean
+        default: false
       deploy:
         description: "Deploy the laws collector ACA job"
         required: false
@@ -66,7 +71,7 @@ jobs:
   deploy_to_azure:
     runs-on: windows-latest
     needs: test_and_build
-    if: github.event_name == 'workflow_dispatch' && inputs.deploy
+    if: github.event_name == 'workflow_dispatch' && (inputs.create_image || inputs.deploy)
     environment: ${{ github.event_name == 'workflow_dispatch' && inputs.github_environment || 'dev' }}
     permissions:
       id-token: write
@@ -98,6 +103,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Summarize requested operation
+        shell: pwsh
+        run: |
+          Write-Host "create_image_requested=${{ inputs.create_image }}"
+          Write-Host "deploy_requested=${{ inputs.deploy }}"
+          Write-Host "effective_create_image=${{ inputs.create_image || inputs.deploy }}"
+
       - name: Validate required environment variables
         shell: pwsh
         run: |
@@ -105,16 +117,21 @@ jobs:
             "AZURE_CLIENT_ID",
             "AZURE_TENANT_ID",
             "AZURE_SUBSCRIPTION_ID",
-            "AZURE_RESOURCE_GROUP",
-            "AZURE_LOCATION",
-            "AZURE_CONTAINERAPPS_ENVIRONMENT",
-            "AZURE_CONTAINER_REGISTRY",
-            "AZURE_STORAGE_ACCOUNT_NAME",
-            "AZURE_MANAGED_IDENTITY_NAME",
-            "AZURE_POSTGRES_SERVER_NAME",
-            "AZURE_POSTGRES_ADMIN_USERNAME",
-            "AZURE_POSTGRES_ADMIN_PASSWORD"
+            "AZURE_CONTAINER_REGISTRY"
           )
+
+          if ([System.Convert]::ToBoolean("${{ inputs.deploy }}")) {
+            $required += @(
+              "AZURE_RESOURCE_GROUP",
+              "AZURE_LOCATION",
+              "AZURE_CONTAINERAPPS_ENVIRONMENT",
+              "AZURE_STORAGE_ACCOUNT_NAME",
+              "AZURE_MANAGED_IDENTITY_NAME",
+              "AZURE_POSTGRES_SERVER_NAME",
+              "AZURE_POSTGRES_ADMIN_USERNAME",
+              "AZURE_POSTGRES_ADMIN_PASSWORD"
+            )
+          }
 
           $missing = @()
           foreach ($name in $required) {
@@ -160,10 +177,12 @@ jobs:
           python-version: "3.11"
 
       - name: Ensure Azure Container Apps extension
+        if: inputs.deploy
         shell: pwsh
         run: az extension add --name containerapp --upgrade --only-show-errors
 
       - name: Allow GitHub runner IP on PostgreSQL firewall
+        if: inputs.deploy
         shell: pwsh
         run: |
           $runnerIp = (Invoke-RestMethod -Uri "https://api.ipify.org").Trim()
@@ -182,7 +201,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
 
-      - name: Deploy laws collector app
+      - name: Build and optionally deploy laws collector app
         shell: pwsh
         run: |
           $containerAppName = if ([string]::IsNullOrWhiteSpace($env:AZURE_LAWS_COLLECTOR_CONTAINER_APP_NAME)) {
@@ -216,6 +235,8 @@ jobs:
             $imageTagInput
           }
 
+          $buildOnly = -not [System.Convert]::ToBoolean("${{ inputs.deploy }}")
+
           ./infra/scripts/deploy_laws_collector.ps1 `
             -SkipEnvFile `
             -SubscriptionId $env:AZURE_SUBSCRIPTION_ID `
@@ -239,10 +260,11 @@ jobs:
             -CronExpression $cronExpression `
             -WorkerMaxProbes $workerMaxProbes `
             -LawsCollectorMaxRunningTime $env:LAWS_COLLECTOR_MAX_RUNNING_TIME `
-            -ImageTag $imageTag
+            -ImageTag $imageTag `
+            -BuildOnly:$buildOnly
 
       - name: Remove GitHub runner firewall rule
-        if: always()
+        if: always() && inputs.deploy
         shell: pwsh
         run: |
           az postgres flexible-server firewall-rule delete `

--- a/.github/workflows/web_build_deploy.yml
+++ b/.github/workflows/web_build_deploy.yml
@@ -14,10 +14,16 @@ on:
       - ".github/workflows/web_build_deploy.yml"
   workflow_dispatch:
     inputs:
+      create_image:
+        description: "Build and upload a new frontend image to Azure Container Registry"
+        required: false
+        type: boolean
+        default: false
       deploy:
         description: "Deploy frontend to Azure Container Apps"
-        required: true
-        default: "true"
+        required: false
+        type: boolean
+        default: false
       github_environment:
         description: "GitHub Environment that contains Azure variables"
         required: true
@@ -59,7 +65,7 @@ jobs:
   deploy_to_azure:
     runs-on: ubuntu-latest
     needs: test_and_build
-    if: inputs.deploy == 'true'
+    if: github.event_name == 'workflow_dispatch' && (inputs.create_image || inputs.deploy)
     environment: ${{ inputs.github_environment }}
     permissions:
       id-token: write
@@ -77,10 +83,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Summarize requested operation
+        run: |
+          echo "create_image_requested=${{ inputs.create_image }}"
+          echo "deploy_requested=${{ inputs.deploy }}"
+          echo "effective_create_image=${{ inputs.create_image || inputs.deploy }}"
+
       - name: Validate required environment variables
         run: |
           missing=0
-          for key in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_RESOURCE_GROUP AZURE_LOCATION AZURE_CONTAINERAPPS_ENVIRONMENT AZURE_FRONTEND_CONTAINER_APP_NAME AZURE_CONTAINER_REGISTRY AZURE_MANAGED_IDENTITY_NAME; do
+          required=(AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_CONTAINER_REGISTRY)
+          if [ "${{ inputs.deploy }}" = "true" ]; then
+            required+=(AZURE_RESOURCE_GROUP AZURE_LOCATION AZURE_CONTAINERAPPS_ENVIRONMENT AZURE_FRONTEND_CONTAINER_APP_NAME AZURE_MANAGED_IDENTITY_NAME)
+          fi
+          for key in "${required[@]}"; do
             if [ -z "${!key}" ]; then
               echo "Missing GitHub Environment variable: $key"
               missing=1
@@ -117,6 +133,7 @@ jobs:
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
       - name: Ensure Azure Container Apps extension
+        if: inputs.deploy
         run: az extension add --name containerapp --upgrade --only-show-errors
 
       - name: Build and push image to ACR
@@ -126,6 +143,7 @@ jobs:
           docker push ${{ steps.acr.outputs.acr_login_server }}/aijurisdiction-frontend:${{ github.sha }}
 
       - name: Deploy to Azure Container Apps
+        if: inputs.deploy
         run: |
           app_name="${AZURE_FRONTEND_CONTAINER_APP_NAME}"
           rg="${AZURE_RESOURCE_GROUP}"
@@ -237,6 +255,7 @@ jobs:
           fi
 
       - name: Verify deployment and print diagnostics on failure
+        if: inputs.deploy
         run: |
           app_name="${AZURE_FRONTEND_CONTAINER_APP_NAME}"
           rg="${AZURE_RESOURCE_GROUP}"
@@ -275,6 +294,7 @@ jobs:
           exit 1
 
       - name: Summarize ACA deployment
+        if: inputs.deploy
         run: |
           app_name="${AZURE_FRONTEND_CONTAINER_APP_NAME}"
           rg="${AZURE_RESOURCE_GROUP}"

--- a/docs/GITHUB_ENVIRONMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS.md
@@ -608,6 +608,47 @@ At minimum, you should expect these values to differ between `test` and `prod`:
 
 Use manual workflow dispatch and set `github_environment` to `test` or `prod`.
 
+The five ACR-backed application workflows expose the same safety controls:
+
+| `create_image` | `deploy` | Result |
+| --- | --- | --- |
+| `false` | `false` | Run validation/tests only; do not authenticate to or upload to ACR |
+| `true` | `false` | Build and upload the commit/image tag; do not mutate Container Apps or Jobs |
+| `false` | `true` | Treat image creation as enabled, upload a new image, then deploy that image |
+| `true` | `true` | Upload a new image, then deploy that image |
+
+Both inputs default to `false`. This applies to `API Build and Deploy`,
+`web_build_deploy`, `Laws Collector Build and Deploy`, `Email Scheduler Build and
+Deploy`, and `Document Processor Build and Deploy`. Deployment always forces image
+creation, so a deployment cannot silently reuse a stale tag. No new GitHub Environment
+variables or secrets are required in `test` or `prod`.
+
+Minimal build-only examples from an authenticated repository checkout:
+
+```powershell
+gh workflow run api_build_deploy.yml -f create_image=true -f deploy=false -f github_environment=test
+gh workflow run web_build_deploy.yml -f create_image=true -f deploy=false -f github_environment=test
+gh workflow run laws_collector_build_deploy.yml -f create_image=true -f deploy=false -f github_environment=test
+gh workflow run email_build_deploy.yml -f create_image=true -f deploy=false -f github_environment=test
+gh workflow run document_processor_build_deploy.yml -f create_image=true -f deploy=false -f github_environment=test
+```
+
+Run the offline workflow/build-only contract validation before pushing changes:
+
+```powershell
+.\scripts\validate_acr_workflow_controls.ps1
+```
+
+The validation replaces `az` and `python` with process-local test doubles and does not
+authenticate to Azure, upload images, or mutate infrastructure.
+
+For a deployment, set only `deploy=true` (and the target environment); the workflow
+computes effective image creation as `create_image || deploy`:
+
+```powershell
+gh workflow run api_build_deploy.yml -f deploy=true -f github_environment=prod
+```
+
 Typical order:
 
 1. `infra_deploy`
@@ -638,21 +679,23 @@ Observability note:
 
 ## 14. Current Workflow Defaults
 
-Some workflows default to `dev` for push-based execution. The laws collector and email scheduler workflows are build/test by default and deploy only when manually dispatched with `deploy=true`.
+Push and pull-request execution is validation-only for the five ACR-backed application workflows. It may build a local Docker image as a test artifact, but it does not authenticate to or upload to ACR. ACR image publication and Azure deployment require manual dispatch.
 
 That means:
 
 - `API Build and Deploy` runs tests and builds the Docker image on pull requests and pushes to `main`, but does not deploy by default.
-- `API Build and Deploy` has a manual `workflow_dispatch` input `deploy` with default `false`; set `deploy=true` and choose `github_environment` to deploy to Azure Container Apps.
+- `API Build and Deploy` has manual boolean `create_image` and `deploy` inputs, both defaulting to `false`; `deploy=true` forces image creation before deployment.
 - `API Build and Deploy` waits for Azure Container App provisioning to settle before applying secret and environment updates, which reduces transient `ContainerAppOperationInProgress` failures during deployment
 - `API Build and Deploy` now fails during environment validation when `AZURE_OPENAI_API_KEY` is empty, because the deployed API always requires that secret for Azure OpenAI access
 - `API Build and Deploy` injects `EMAIL_DB_OPTION=azure`, `EMAIL_DB_CLOUD=secretref:db-cloud`, and `EMAIL_DB_LOCAL=/tmp/email.sqlite3` automatically, so email outbox storage follows the API PostgreSQL deployment.
 - `API Build and Deploy` injects SMTP settings and vehicle validation settings into the API Container App; `EMAIL_SMTP_PASSWORD` and `CAR_VALIDATION_API_KEY` are stored as Container App secrets.
 - `API Build and Deploy` fails during environment validation when `EMAIL_TRANSPORT=smtp` and `EMAIL_SMTP_PASSWORD` is empty.
 - `Laws Collector Build and Deploy` runs tests and builds the laws collector image on pull requests and pushes to `main`, but does not deploy by default.
-- `Laws Collector Build and Deploy` has a manual `workflow_dispatch` input `deploy` with default `false`; set `deploy=true` and choose `github_environment` to deploy the ACA Job.
+- `Laws Collector Build and Deploy` has manual boolean `create_image` and `deploy` inputs, both defaulting to `false`; build-only mode does not open a PostgreSQL firewall rule or apply migrations.
 - `Email Scheduler Build and Deploy` runs tests and builds the scheduler API image on pull requests and pushes to `main`, but does not deploy by default.
-- `Email Scheduler Build and Deploy` has a manual `workflow_dispatch` input `deploy` with default `false`; set `deploy=true` and choose `github_environment` to deploy the dedicated ACA Job.
+- `Email Scheduler Build and Deploy` has manual boolean `create_image` and `deploy` inputs, both defaulting to `false`; build-only mode does not open a PostgreSQL firewall rule or apply migrations.
+- `Document Processor Build and Deploy` no longer publishes or deploys on push; its manual boolean `create_image` and `deploy` inputs both default to `false`.
+- `web_build_deploy` uses the same two boolean inputs with safe `false` defaults and preserves its full lint/unit/E2E/build gate before image publication.
 - `test` and `prod` remain manual `workflow_dispatch` targets unless a workflow is explicitly changed to auto-deploy them
 - `Self-Managed Prod Deploy` is manual-only and always uses the protected `prod` GitHub Environment
 - `Self-Managed Prod Deploy` builds `jurisdigta-document-processor:local`, starts API with `DOCUMENT_PROCESSOR_OPTION=azure`, and installs `/srv/jurisdigta/ops/run_document_processor.sh` when `JURISDIGTA_INSTALL_DOCUMENT_PROCESSOR_CRON=1`

--- a/infra/README.md
+++ b/infra/README.md
@@ -305,9 +305,11 @@ az ad app federated-credential create --id $ClientId --parameters $tempFile
 5. Run the workflow:
 
 - Workflow: `API Build and Deploy`
-- Push to `main`: automatically deploys to the `dev` GitHub Environment after tests/build pass
-- Inputs: `deploy=true`, `github_environment=<environment>`
-  - Manual `workflow_dispatch` is still the path for non-`dev` environments such as `test` and `prod`
+- Push to `main`: runs validation and a local Docker build, without uploading to ACR or deploying
+- Inputs: `create_image=true|false`, `deploy=true|false`, `github_environment=<environment>`
+  - Both booleans default to `false`; `create_image=true` publishes without deploying
+  - `deploy=true` always forces creation and upload of the image that is deployed
+  - Manual `workflow_dispatch` is required for `dev`, `test`, and `prod` ACR publication/deployment
 - After the image deploy step, the workflow now waits for the Container App provisioning state to return to `Succeeded` before applying secrets and environment variables.
 - If Azure still reports `ContainerAppOperationInProgress`, the workflow retries the secret/env update commands automatically instead of failing on the first race.
 

--- a/infra/scripts/deploy_document_processor.ps1
+++ b/infra/scripts/deploy_document_processor.ps1
@@ -25,7 +25,8 @@ param(
     [string]$DocumentProcessorMaxRunningTime = "",
     [string]$ImageTag = "latest",
     [string]$EnvFilePath = ".env",
-    [switch]$SkipEnvFile
+    [switch]$SkipEnvFile,
+    [switch]$BuildOnly
 )
 
 Set-StrictMode -Version Latest
@@ -181,6 +182,60 @@ function Write-WorkflowSummary {
         Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 }
 
+function Publish-DocumentProcessorImage {
+    param(
+        [Parameter(Mandatory = $true)][string]$RegistryName,
+        [Parameter(Mandatory = $true)][string]$Tag,
+        [Parameter(Mandatory = $true)][string]$EmbeddingModelOption,
+        [Parameter(Mandatory = $true)][string]$EmbeddingModel
+    )
+
+    $repository = "document-processor"
+    $imageReference = "$RegistryName.azurecr.io/$repository`:$Tag"
+
+    if ($EmbeddingModelOption -eq "local") {
+        Write-Host "Prefetching local embedding model into build context: $EmbeddingModel"
+        $previousEmbeddingModelOption = $env:SYSTEM_EMBEDDING_MODEL_OPTION
+        $previousEmbeddingModel = $env:SYSTEM_EMBEDDING_MODEL
+        $previousPythonPath = $env:PYTHONPATH
+        try {
+            $env:SYSTEM_EMBEDDING_MODEL_OPTION = "local"
+            $env:SYSTEM_EMBEDDING_MODEL = $EmbeddingModel
+            $repoSrcPath = (Resolve-Path "src").Path
+            $env:PYTHONPATH = if ([string]::IsNullOrWhiteSpace($previousPythonPath)) {
+                $repoSrcPath
+            }
+            else {
+                "$repoSrcPath$([IO.Path]::PathSeparator)$previousPythonPath"
+            }
+            python "scripts/models/prefetch_local_embedding_model.py" | ForEach-Object { Write-Host $_ }
+            if ($LASTEXITCODE -ne 0) {
+                throw "Local embedding model prefetch failed for '$EmbeddingModel'."
+            }
+        }
+        finally {
+            Restore-EnvVar -Name "SYSTEM_EMBEDDING_MODEL_OPTION" -PreviousValue $previousEmbeddingModelOption
+            Restore-EnvVar -Name "SYSTEM_EMBEDDING_MODEL" -PreviousValue $previousEmbeddingModel
+            Restore-EnvVar -Name "PYTHONPATH" -PreviousValue $previousPythonPath
+        }
+    }
+
+    Write-Host "Building document processor image in ACR: $imageReference"
+    az acr build `
+      --registry $RegistryName `
+      --image "$repository`:$Tag" `
+      --file "src/services/document_processor/Dockerfile" `
+      . `
+      --no-logs `
+      --only-show-errors `
+      --output none | ForEach-Object { Write-Host $_ }
+    if ($LASTEXITCODE -ne 0) {
+        throw "ACR build failed for document processor image '$imageReference'."
+    }
+
+    return $imageReference
+}
+
 Assert-ToolInstalled -ToolName "az"
 Assert-ToolInstalled -ToolName "python"
 
@@ -250,27 +305,48 @@ if ([string]::IsNullOrWhiteSpace($AzureOpenAIEmbeddingsModel)) {
 if ([string]::IsNullOrWhiteSpace($AzureOpenAIApiVersion)) {
     $AzureOpenAIApiVersion = "2024-12-01-preview"
 }
-$CronExpression = Resolve-AcaCronExpression -Name "CronExpression" -Value $CronExpression -DefaultValue "*/15 * * * *"
-$DocumentProcessorMaxRunningTime = Resolve-NonNegativeInteger -Name "DocumentProcessorMaxRunningTime" -Value $DocumentProcessorMaxRunningTime -DefaultValue 15
+if (-not $BuildOnly) {
+    $CronExpression = Resolve-AcaCronExpression -Name "CronExpression" -Value $CronExpression -DefaultValue "*/15 * * * *"
+    $DocumentProcessorMaxRunningTime = Resolve-NonNegativeInteger -Name "DocumentProcessorMaxRunningTime" -Value $DocumentProcessorMaxRunningTime -DefaultValue 15
+}
 
 Require-Value -Name "SubscriptionId" -Value $SubscriptionId
-Require-Value -Name "ResourceGroupName" -Value $ResourceGroupName
-Require-Value -Name "Location" -Value $Location
-Require-Value -Name "ContainerAppEnvironmentName" -Value $ContainerAppEnvironmentName
 Require-Value -Name "AcrName" -Value $AcrName
-Require-Value -Name "ManagedIdentityName" -Value $ManagedIdentityName
-Require-Value -Name "PostgresServerName" -Value $PostgresServerName
-Require-Value -Name "PostgresDatabaseName" -Value $PostgresDatabaseName
-Require-Value -Name "PostgresAdminUsername" -Value $PostgresAdminUsername
-Require-Value -Name "PostgresAdminPassword" -Value $PostgresAdminPassword
-Require-Value -Name "StorageAccountName" -Value $StorageAccountName
-Require-Value -Name "StorageContainerName" -Value $StorageContainerName
-if ($SystemEmbeddingModelOption -ne "local") {
-    Require-Value -Name "AzureOpenAIEndpoint" -Value $AzureOpenAIEndpoint
-    Require-Value -Name "AzureOpenAIApiKey" -Value $AzureOpenAIApiKey
+if (-not $BuildOnly) {
+    Require-Value -Name "ResourceGroupName" -Value $ResourceGroupName
+    Require-Value -Name "Location" -Value $Location
+    Require-Value -Name "ContainerAppEnvironmentName" -Value $ContainerAppEnvironmentName
+    Require-Value -Name "ManagedIdentityName" -Value $ManagedIdentityName
+    Require-Value -Name "PostgresServerName" -Value $PostgresServerName
+    Require-Value -Name "PostgresDatabaseName" -Value $PostgresDatabaseName
+    Require-Value -Name "PostgresAdminUsername" -Value $PostgresAdminUsername
+    Require-Value -Name "PostgresAdminPassword" -Value $PostgresAdminPassword
+    Require-Value -Name "StorageAccountName" -Value $StorageAccountName
+    Require-Value -Name "StorageContainerName" -Value $StorageContainerName
+    if ($SystemEmbeddingModelOption -ne "local") {
+        Require-Value -Name "AzureOpenAIEndpoint" -Value $AzureOpenAIEndpoint
+        Require-Value -Name "AzureOpenAIApiKey" -Value $AzureOpenAIApiKey
+    }
 }
 
 az account set --subscription $SubscriptionId | Out-Null
+$image = Publish-DocumentProcessorImage `
+    -RegistryName $AcrName `
+    -Tag $ImageTag `
+    -EmbeddingModelOption $SystemEmbeddingModelOption `
+    -EmbeddingModel $SystemEmbeddingModel
+
+if ($BuildOnly) {
+    Write-Host "Document processor image build complete. Deployment was not requested."
+    Write-WorkflowSummary -Lines @(
+        "## ACR image build summary",
+        "| Image | Result | Deployment |",
+        "| --- | --- | --- |",
+        "| $image | uploaded | skipped |"
+    )
+    return
+}
+
 $resourceGroupExists = az group exists --name $ResourceGroupName --output tsv
 if ($resourceGroupExists -eq "true") {
     Write-Host "Resource group '$ResourceGroupName' already exists. Skipping creation."
@@ -285,8 +361,6 @@ $jobExistedBeforeDeployment = Test-ResourceExistsInGroup `
     -ResourceName $JobName `
     -ResourceType "Microsoft.App/jobs"
 
-$imageRepository = "document-processor"
-$image = "$AcrName.azurecr.io/$imageRepository`:$ImageTag"
 $dbCloud = Convert-ToPostgresConnectionString `
     -HostName $PostgresServerName `
     -DatabaseName $PostgresDatabaseName `
@@ -302,46 +376,6 @@ if (-not [string]::IsNullOrWhiteSpace($ApplicationInsightsName)) {
     if ($LASTEXITCODE -ne 0) {
         $applicationInsightsConnectionString = ""
     }
-}
-
-if ($SystemEmbeddingModelOption -eq "local") {
-    Write-Host "Prefetching local embedding model into build context: $SystemEmbeddingModel"
-    $previousEmbeddingModelOption = $env:SYSTEM_EMBEDDING_MODEL_OPTION
-    $previousEmbeddingModel = $env:SYSTEM_EMBEDDING_MODEL
-    $previousPythonPath = $env:PYTHONPATH
-    try {
-        $env:SYSTEM_EMBEDDING_MODEL_OPTION = "local"
-        $env:SYSTEM_EMBEDDING_MODEL = $SystemEmbeddingModel
-        $repoSrcPath = (Resolve-Path "src").Path
-        if ([string]::IsNullOrWhiteSpace($previousPythonPath)) {
-            $env:PYTHONPATH = $repoSrcPath
-        }
-        else {
-            $env:PYTHONPATH = "$repoSrcPath$([IO.Path]::PathSeparator)$previousPythonPath"
-        }
-        python "scripts/models/prefetch_local_embedding_model.py"
-        if ($LASTEXITCODE -ne 0) {
-            throw "Local embedding model prefetch failed for '$SystemEmbeddingModel'."
-        }
-    }
-    finally {
-        Restore-EnvVar -Name "SYSTEM_EMBEDDING_MODEL_OPTION" -PreviousValue $previousEmbeddingModelOption
-        Restore-EnvVar -Name "SYSTEM_EMBEDDING_MODEL" -PreviousValue $previousEmbeddingModel
-        Restore-EnvVar -Name "PYTHONPATH" -PreviousValue $previousPythonPath
-    }
-}
-
-Write-Host "Building document processor image in ACR: $image"
-az acr build `
-  --registry $AcrName `
-  --image "$imageRepository`:$ImageTag" `
-  --file "src/services/document_processor/Dockerfile" `
-  . `
-  --no-logs `
-  --only-show-errors `
-  --output none
-if ($LASTEXITCODE -ne 0) {
-    throw "ACR build failed for document processor image '$image'."
 }
 
 Write-Host "Deploying document processor ACA job: $JobName"

--- a/infra/scripts/deploy_email_scheduler.ps1
+++ b/infra/scripts/deploy_email_scheduler.ps1
@@ -22,7 +22,8 @@ param(
     [string]$CronExpression = "*/5 * * * *",
     [string]$ImageTag = "latest",
     [string]$EnvFilePath = ".env",
-    [switch]$SkipEnvFile
+    [switch]$SkipEnvFile,
+    [switch]$BuildOnly
 )
 
 Set-StrictMode -Version Latest
@@ -192,6 +193,30 @@ function Write-WorkflowSummary {
         Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 }
 
+function Publish-EmailSchedulerImage {
+    param(
+        [Parameter(Mandatory = $true)][string]$RegistryName,
+        [Parameter(Mandatory = $true)][string]$Tag
+    )
+
+    $repository = "aijuristiction-api"
+    $imageReference = "$RegistryName.azurecr.io/$repository`:$Tag"
+    Write-Host "Building email scheduler image in ACR: $imageReference"
+    az acr build `
+      --registry $RegistryName `
+      --image "$repository`:$Tag" `
+      --file "api/aijuristiction-api/Dockerfile" `
+      . `
+      --no-logs `
+      --only-show-errors `
+      --output none | ForEach-Object { Write-Host $_ }
+    if ($LASTEXITCODE -ne 0) {
+        throw "ACR build failed for email scheduler image '$imageReference'."
+    }
+
+    return $imageReference
+}
+
 Assert-ToolInstalled -ToolName "az"
 Assert-ToolInstalled -ToolName "python"
 
@@ -246,24 +271,41 @@ if ([string]::IsNullOrWhiteSpace($EmailSmtpHost)) { $EmailSmtpHost = "mail.webho
 if ([string]::IsNullOrWhiteSpace($EmailSmtpPort)) { $EmailSmtpPort = "587" }
 if ([string]::IsNullOrWhiteSpace($EmailSmtpUseTls)) { $EmailSmtpUseTls = "true" }
 if ([string]::IsNullOrWhiteSpace($EmailSmtpUsername)) { $EmailSmtpUsername = "no-reply@jurisdigta.eu" }
-$JobName = Resolve-AcaJobName -Name "JobName" -Value $JobName -DefaultValue "email-scheduler"
-$CronExpression = Resolve-AcaCronExpression -Name "CronExpression" -Value $CronExpression -DefaultValue "*/5 * * * *"
+if (-not $BuildOnly) {
+    $JobName = Resolve-AcaJobName -Name "JobName" -Value $JobName -DefaultValue "email-scheduler"
+    $CronExpression = Resolve-AcaCronExpression -Name "CronExpression" -Value $CronExpression -DefaultValue "*/5 * * * *"
+}
 
 Require-Value -Name "SubscriptionId" -Value $SubscriptionId
-Require-Value -Name "ResourceGroupName" -Value $ResourceGroupName
-Require-Value -Name "Location" -Value $Location
-Require-Value -Name "ContainerAppEnvironmentName" -Value $ContainerAppEnvironmentName
 Require-Value -Name "AcrName" -Value $AcrName
-Require-Value -Name "ManagedIdentityName" -Value $ManagedIdentityName
-Require-Value -Name "PostgresServerName" -Value $PostgresServerName
-Require-Value -Name "PostgresDatabaseName" -Value $PostgresDatabaseName
-Require-Value -Name "PostgresAdminUsername" -Value $PostgresAdminUsername
-Require-Value -Name "PostgresAdminPassword" -Value $PostgresAdminPassword
-if ($EmailTransport.Trim().ToLowerInvariant() -eq "smtp") {
-    Require-Value -Name "EmailSmtpPassword" -Value $EmailSmtpPassword
+if (-not $BuildOnly) {
+    Require-Value -Name "ResourceGroupName" -Value $ResourceGroupName
+    Require-Value -Name "Location" -Value $Location
+    Require-Value -Name "ContainerAppEnvironmentName" -Value $ContainerAppEnvironmentName
+    Require-Value -Name "ManagedIdentityName" -Value $ManagedIdentityName
+    Require-Value -Name "PostgresServerName" -Value $PostgresServerName
+    Require-Value -Name "PostgresDatabaseName" -Value $PostgresDatabaseName
+    Require-Value -Name "PostgresAdminUsername" -Value $PostgresAdminUsername
+    Require-Value -Name "PostgresAdminPassword" -Value $PostgresAdminPassword
+    if ($EmailTransport.Trim().ToLowerInvariant() -eq "smtp") {
+        Require-Value -Name "EmailSmtpPassword" -Value $EmailSmtpPassword
+    }
 }
 
 az account set --subscription $SubscriptionId | Out-Null
+$image = Publish-EmailSchedulerImage -RegistryName $AcrName -Tag $ImageTag
+
+if ($BuildOnly) {
+    Write-Host "Email scheduler image build complete. Deployment was not requested."
+    Write-WorkflowSummary -Lines @(
+        "## ACR image build summary",
+        "| Image | Result | Deployment |",
+        "| --- | --- | --- |",
+        "| $image | uploaded | skipped |"
+    )
+    return
+}
+
 $resourceGroupExists = az group exists --name $ResourceGroupName --output tsv
 if ($resourceGroupExists -eq "true") {
     Write-Host "Resource group '$ResourceGroupName' already exists. Skipping creation."
@@ -278,8 +320,6 @@ $jobExistedBeforeDeployment = Test-ResourceExistsInGroup `
     -ResourceName $JobName `
     -ResourceType "Microsoft.App/jobs"
 
-$imageRepository = "aijuristiction-api"
-$image = "$AcrName.azurecr.io/$imageRepository`:$ImageTag"
 $dbCloud = Convert-ToPostgresConnectionString `
     -HostName $PostgresServerName `
     -DatabaseName $PostgresDatabaseName `
@@ -312,19 +352,6 @@ try {
 finally {
     Restore-EnvVar -Name "DB_OPTION" -PreviousValue $previousDbOption
     Restore-EnvVar -Name "DB_CLOUD" -PreviousValue $previousDbCloud
-}
-
-Write-Host "Building email scheduler image in ACR: $image"
-az acr build `
-  --registry $AcrName `
-  --image "$imageRepository`:$ImageTag" `
-  --file "api/aijuristiction-api/Dockerfile" `
-  . `
-  --no-logs `
-  --only-show-errors `
-  --output none
-if ($LASTEXITCODE -ne 0) {
-    throw "ACR build failed for email scheduler image '$image'."
 }
 
 Write-Host "Deploying email scheduler ACA job: $JobName"

--- a/infra/scripts/deploy_laws_collector.ps1
+++ b/infra/scripts/deploy_laws_collector.ps1
@@ -23,7 +23,8 @@ param(
     [string]$LawsCollectorMaxRunningTime = "",
     [string]$ImageTag = "latest",
     [string]$EnvFilePath = ".env",
-    [switch]$SkipEnvFile
+    [switch]$SkipEnvFile,
+    [switch]$BuildOnly
 )
 
 Set-StrictMode -Version Latest
@@ -199,6 +200,60 @@ function Write-WorkflowSummary {
         Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 }
 
+function Publish-LawsCollectorImage {
+    param(
+        [Parameter(Mandatory = $true)][string]$RegistryName,
+        [Parameter(Mandatory = $true)][string]$Tag,
+        [Parameter(Mandatory = $true)][string]$EmbeddingModelOption,
+        [Parameter(Mandatory = $true)][string]$EmbeddingModel
+    )
+
+    $repository = "laws-collector"
+    $imageReference = "$RegistryName.azurecr.io/$repository`:$Tag"
+
+    if ($EmbeddingModelOption -eq "local") {
+        Write-Host "Prefetching local embedding model into build context: $EmbeddingModel"
+        $previousEmbeddingModelOption = $env:SYSTEM_EMBEDDING_MODEL_OPTION
+        $previousEmbeddingModel = $env:SYSTEM_EMBEDDING_MODEL
+        $previousPythonPath = $env:PYTHONPATH
+        try {
+            $env:SYSTEM_EMBEDDING_MODEL_OPTION = "local"
+            $env:SYSTEM_EMBEDDING_MODEL = $EmbeddingModel
+            $repoSrcPath = (Resolve-Path "src").Path
+            $env:PYTHONPATH = if ([string]::IsNullOrWhiteSpace($previousPythonPath)) {
+                $repoSrcPath
+            }
+            else {
+                "$repoSrcPath$([IO.Path]::PathSeparator)$previousPythonPath"
+            }
+            python "scripts/models/prefetch_local_embedding_model.py" | ForEach-Object { Write-Host $_ }
+            if ($LASTEXITCODE -ne 0) {
+                throw "Local embedding model prefetch failed for '$EmbeddingModel'."
+            }
+        }
+        finally {
+            Restore-EnvVar -Name "SYSTEM_EMBEDDING_MODEL_OPTION" -PreviousValue $previousEmbeddingModelOption
+            Restore-EnvVar -Name "SYSTEM_EMBEDDING_MODEL" -PreviousValue $previousEmbeddingModel
+            Restore-EnvVar -Name "PYTHONPATH" -PreviousValue $previousPythonPath
+        }
+    }
+
+    Write-Host "Building laws collector image in ACR: $imageReference"
+    az acr build `
+      --registry $RegistryName `
+      --image "$repository`:$Tag" `
+      --file "src/services/laws_collector/Dockerfile" `
+      . `
+      --no-logs `
+      --only-show-errors `
+      --output none | ForEach-Object { Write-Host $_ }
+    if ($LASTEXITCODE -ne 0) {
+        throw "ACR build failed for laws collector image '$imageReference'."
+    }
+
+    return $imageReference
+}
+
 Assert-ToolInstalled -ToolName "az"
 Assert-ToolInstalled -ToolName "python"
 
@@ -243,27 +298,48 @@ $WorkerMaxProbes = Resolve-InputValue -ExplicitValue $WorkerMaxProbes -EnvFileVa
 $LawsCollectorMaxRunningTime = Resolve-InputValue -ExplicitValue $LawsCollectorMaxRunningTime -EnvFileValue $envLawsCollectorMaxRunningTime -EnvironmentValue $env:LAWS_COLLECTOR_MAX_RUNNING_TIME
 
 Require-Value -Name "SubscriptionId" -Value $SubscriptionId
-Require-Value -Name "ResourceGroupName" -Value $ResourceGroupName
-Require-Value -Name "Location" -Value $Location
-Require-Value -Name "ContainerAppEnvironmentName" -Value $ContainerAppEnvironmentName
 Require-Value -Name "AcrName" -Value $AcrName
-Require-Value -Name "ManagedIdentityName" -Value $ManagedIdentityName
-Require-Value -Name "PostgresServerName" -Value $PostgresServerName
-Require-Value -Name "PostgresDatabaseName" -Value $PostgresDatabaseName
-Require-Value -Name "PostgresAdminUsername" -Value $PostgresAdminUsername
-Require-Value -Name "PostgresAdminPassword" -Value $PostgresAdminPassword
-if ([string]::IsNullOrWhiteSpace($LawsCollectorImport)) { $LawsCollectorImport = "zip" }
-if ($LawsCollectorImport -notin @("one_law_url", "zip")) {
-    throw "LawsCollectorImport must be one of: one_law_url, zip."
+if (-not $BuildOnly) {
+    Require-Value -Name "ResourceGroupName" -Value $ResourceGroupName
+    Require-Value -Name "Location" -Value $Location
+    Require-Value -Name "ContainerAppEnvironmentName" -Value $ContainerAppEnvironmentName
+    Require-Value -Name "ManagedIdentityName" -Value $ManagedIdentityName
+    Require-Value -Name "PostgresServerName" -Value $PostgresServerName
+    Require-Value -Name "PostgresDatabaseName" -Value $PostgresDatabaseName
+    Require-Value -Name "PostgresAdminUsername" -Value $PostgresAdminUsername
+    Require-Value -Name "PostgresAdminPassword" -Value $PostgresAdminPassword
 }
-if ([string]::IsNullOrWhiteSpace($StorageContainerName)) { $StorageContainerName = "laws-collection-sk" }
 if ([string]::IsNullOrWhiteSpace($SystemEmbeddingModelOption)) { $SystemEmbeddingModelOption = "local" }
 if ([string]::IsNullOrWhiteSpace($SystemEmbeddingModel)) { $SystemEmbeddingModel = "all-MiniLM-L6-v2" }
-$CronExpression = Resolve-AcaCronExpression -Name "CronExpression" -Value $CronExpression -DefaultValue "0 0 * * *"
-$WorkerMaxProbes = Resolve-PositiveInteger -Name "WorkerMaxProbes" -Value $WorkerMaxProbes -DefaultValue 1
-$LawsCollectorMaxRunningTime = Resolve-NonNegativeInteger -Name "LawsCollectorMaxRunningTime" -Value $LawsCollectorMaxRunningTime -DefaultValue 60
+if (-not $BuildOnly) {
+    if ([string]::IsNullOrWhiteSpace($LawsCollectorImport)) { $LawsCollectorImport = "zip" }
+    if ($LawsCollectorImport -notin @("one_law_url", "zip")) {
+        throw "LawsCollectorImport must be one of: one_law_url, zip."
+    }
+    if ([string]::IsNullOrWhiteSpace($StorageContainerName)) { $StorageContainerName = "laws-collection-sk" }
+    $CronExpression = Resolve-AcaCronExpression -Name "CronExpression" -Value $CronExpression -DefaultValue "0 0 * * *"
+    $WorkerMaxProbes = Resolve-PositiveInteger -Name "WorkerMaxProbes" -Value $WorkerMaxProbes -DefaultValue 1
+    $LawsCollectorMaxRunningTime = Resolve-NonNegativeInteger -Name "LawsCollectorMaxRunningTime" -Value $LawsCollectorMaxRunningTime -DefaultValue 60
+}
 
 az account set --subscription $SubscriptionId | Out-Null
+$image = Publish-LawsCollectorImage `
+    -RegistryName $AcrName `
+    -Tag $ImageTag `
+    -EmbeddingModelOption $SystemEmbeddingModelOption `
+    -EmbeddingModel $SystemEmbeddingModel
+
+if ($BuildOnly) {
+    Write-Host "Laws collector image build complete. Deployment was not requested."
+    Write-WorkflowSummary -Lines @(
+        "## ACR image build summary",
+        "| Image | Result | Deployment |",
+        "| --- | --- | --- |",
+        "| $image | uploaded | skipped |"
+    )
+    return
+}
+
 $resourceGroupExists = az group exists --name $ResourceGroupName --output tsv
 if ($resourceGroupExists -eq "true") {
     Write-Host "Resource group '$ResourceGroupName' already exists. Skipping creation."
@@ -278,8 +354,6 @@ $containerAppExistedBeforeDeployment = Test-ResourceExistsInGroup `
     -ResourceName $ContainerAppName `
     -ResourceType "Microsoft.App/jobs"
 
-$imageRepository = "laws-collector"
-$image = "$AcrName.azurecr.io/$imageRepository`:$ImageTag"
 $dbCloud = Convert-ToPostgresConnectionString `
     -HostName $PostgresServerName `
     -DatabaseName $PostgresDatabaseName `
@@ -297,33 +371,6 @@ if (-not [string]::IsNullOrWhiteSpace($ApplicationInsightsName)) {
     }
 }
 
-if ($SystemEmbeddingModelOption -eq "local") {
-    Write-Host "Prefetching local embedding model into build context: $SystemEmbeddingModel"
-    $previousEmbeddingModelOption = $env:SYSTEM_EMBEDDING_MODEL_OPTION
-    $previousEmbeddingModel = $env:SYSTEM_EMBEDDING_MODEL
-    $previousPythonPath = $env:PYTHONPATH
-    try {
-        $env:SYSTEM_EMBEDDING_MODEL_OPTION = "local"
-        $env:SYSTEM_EMBEDDING_MODEL = $SystemEmbeddingModel
-        $repoSrcPath = (Resolve-Path "src").Path
-        if ([string]::IsNullOrWhiteSpace($previousPythonPath)) {
-            $env:PYTHONPATH = $repoSrcPath
-        }
-        else {
-            $env:PYTHONPATH = "$repoSrcPath$([IO.Path]::PathSeparator)$previousPythonPath"
-        }
-        python "scripts/models/prefetch_local_embedding_model.py"
-        if ($LASTEXITCODE -ne 0) {
-            throw "Local embedding model prefetch failed for '$SystemEmbeddingModel'."
-        }
-    }
-    finally {
-        Restore-EnvVar -Name "SYSTEM_EMBEDDING_MODEL_OPTION" -PreviousValue $previousEmbeddingModelOption
-        Restore-EnvVar -Name "SYSTEM_EMBEDDING_MODEL" -PreviousValue $previousEmbeddingModel
-        Restore-EnvVar -Name "PYTHONPATH" -PreviousValue $previousPythonPath
-    }
-}
-
 Write-Host "Applying laws schema migrations to Azure PostgreSQL..."
 $previousLawsDbBackend = $env:LAWS_DB_BACKEND
 $previousLawsDbCloud = $env:LAWS_DB_CLOUD
@@ -338,19 +385,6 @@ try {
 finally {
     Restore-EnvVar -Name "LAWS_DB_BACKEND" -PreviousValue $previousLawsDbBackend
     Restore-EnvVar -Name "LAWS_DB_CLOUD" -PreviousValue $previousLawsDbCloud
-}
-
-Write-Host "Building laws collector image in ACR: $image"
-az acr build `
-  --registry $AcrName `
-  --image "$imageRepository`:$ImageTag" `
-  --file "src/services/laws_collector/Dockerfile" `
-  . `
-  --no-logs `
-  --only-show-errors `
-  --output none
-if ($LASTEXITCODE -ne 0) {
-    throw "ACR build failed for laws collector image '$image'."
 }
 
 Write-Host "Deploying laws collector ACA job: $ContainerAppName"

--- a/scripts/validate_acr_workflow_controls.ps1
+++ b/scripts/validate_acr_workflow_controls.ps1
@@ -1,0 +1,90 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$workflowFiles = @(
+    ".github/workflows/api_build_deploy.yml",
+    ".github/workflows/web_build_deploy.yml",
+    ".github/workflows/laws_collector_build_deploy.yml",
+    ".github/workflows/email_build_deploy.yml",
+    ".github/workflows/document_processor_build_deploy.yml"
+)
+
+$createImageInputPattern = '(?ms)^      create_image:\s+description:.*?required: false\s+type: boolean\s+default: false'
+$deployInputPattern = '(?ms)^      deploy:\s+description:.*?required: false\s+type: boolean\s+default: false'
+$effectiveGate = "if: github.event_name == 'workflow_dispatch' && (inputs.create_image || inputs.deploy)"
+
+foreach ($relativePath in $workflowFiles) {
+    $path = Join-Path $repoRoot $relativePath
+    $content = Get-Content -Raw -Path $path
+    if ($content -notmatch $createImageInputPattern) {
+        throw "$relativePath must define create_image as a boolean with default false."
+    }
+    if ($content -notmatch $deployInputPattern) {
+        throw "$relativePath must define deploy as a boolean with default false."
+    }
+    if (-not $content.Contains($effectiveGate)) {
+        throw "$relativePath must gate Azure publication with create_image || deploy."
+    }
+    Write-Host "$relativePath`: workflow controls OK"
+}
+
+$buildOnlyCases = @(
+    @{
+        Script = "infra/scripts/deploy_laws_collector.ps1"
+        Extra = @{ SystemEmbeddingModelOption = "cloud"; SystemEmbeddingModel = "unused" }
+    },
+    @{
+        Script = "infra/scripts/deploy_email_scheduler.ps1"
+        Extra = @{}
+    },
+    @{
+        Script = "infra/scripts/deploy_document_processor.ps1"
+        Extra = @{ SystemEmbeddingModelOption = "cloud"; SystemEmbeddingModel = "unused" }
+    }
+)
+
+foreach ($case in $buildOnlyCases) {
+    $global:AcrWorkflowValidationAzCalls = [System.Collections.Generic.List[string]]::new()
+    function global:az {
+        $global:AcrWorkflowValidationAzCalls.Add(($args -join " "))
+        $global:LASTEXITCODE = 0
+    }
+    function global:python {
+        $global:LASTEXITCODE = 0
+    }
+
+    try {
+        $arguments = @{
+            SkipEnvFile = $true
+            BuildOnly = $true
+            SubscriptionId = "00000000-0000-0000-0000-000000000000"
+            AcrName = "validationacr"
+            ImageTag = "offline-validation"
+        }
+        foreach ($entry in $case.Extra.GetEnumerator()) {
+            $arguments[$entry.Key] = $entry.Value
+        }
+
+        & (Join-Path $repoRoot $case.Script) @arguments
+
+        $calls = $global:AcrWorkflowValidationAzCalls
+        if ($calls.Count -ne 2 -or $calls[0] -notmatch '^account set ' -or $calls[1] -notmatch '^acr build ') {
+            throw "$($case.Script) build-only mode invoked unexpected Azure operations: $($calls -join '; ')"
+        }
+        if (($calls -join " ") -match 'group|postgres|containerapp|deployment') {
+            throw "$($case.Script) build-only mode attempted a deployment mutation: $($calls -join '; ')"
+        }
+        Write-Host "$($case.Script): build-only isolation OK"
+    }
+    finally {
+        Remove-Item Function:\az -ErrorAction SilentlyContinue
+        Remove-Item Function:\python -ErrorAction SilentlyContinue
+        Remove-Variable AcrWorkflowValidationAzCalls -Scope Global -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Host "ACR workflow control validation passed."


### PR DESCRIPTION
Closes #603

## What changed

- adds a boolean `create_image` input, defaulting to `false`, to all five ACR-backed workflows
- makes `deploy=true` force effective image creation
- supports image publication without Container Apps/Jobs deployment
- removes automatic document-processor publication/deployment on push and normalizes manual deploy defaults to `false`
- adds build-only modes to the laws collector, email scheduler, and document processor deployment scripts
- documents the test/prod workflow truth table and runnable dispatch examples
- adds an offline contract validator that mocks Azure/Python commands and proves build-only mode performs no deployment mutations

## Impact

Pull requests and pushes still run their local Docker validation builds, but do not authenticate to or upload to ACR. Manual build-only runs publish the selected tag without opening PostgreSQL firewall rules, applying migrations, or changing Container Apps/Jobs.

No personal-data flow, storage, consent, retention, or legal-risk output behavior changes.

## Validation

- `.\scripts\validate_acr_workflow_controls.ps1`
- PowerShell parser validation for all four changed scripts
- Prettier YAML parser validation for all five workflows
- `git diff --check`
