### PR TITLE
Fix generated-document Playwright locator ambiguity

### DIFF
--- a/frontend/aijurisdictionfronend/README.md
+++ b/frontend/aijurisdictionfronend/README.md
@@ -38,6 +38,17 @@ npm run test:e2e
 
 The suite starts Vite locally and uses mocked JurisDigta API responses. Deployment workflows run this Playwright gate before deployment so a failed document-preview, document-download, or document-listing regression blocks release. If the default Playwright port is already in use, set `FRONTEND_E2E_PORT`, for example `FRONTEND_E2E_PORT=5190 npm run test:e2e`. Issue #503 is covered by `e2e/assistant-live-document-preview.spec.ts`, which verifies the live assistant response path and the post-refresh case-history path both show the formatted JurisDigta document preview, generated PDF action, and citation source. Issues #530 and #574 are covered by `e2e/assistant-branding.spec.ts`, which verifies the localized SK/EN/DE navbar, sidebar brand, and browser title after persisted direct loads, live language changes, and client-side navigation.
 
+Run the focused generated-document download/listing regression with:
+
+```bash
+npm run test:e2e -- e2e/generated-document-download.spec.ts
+```
+
+The generated-document test scopes the open-document button to its sidebar document item and
+asserts the filename-specific delete button separately. Keep these controls distinct when their
+accessible names share the same filename; do not use positional Playwright selectors to hide an
+ambiguous role query.
+
 The issue #574 test writes locale screenshots to
 `runs/e2e/issue-574-assistant-branding-{sk,en,de}.png` using synthetic account and API data.
 

--- a/frontend/aijurisdictionfronend/e2e/generated-document-download.spec.ts
+++ b/frontend/aijurisdictionfronend/e2e/generated-document-download.spec.ts
@@ -87,7 +87,20 @@ test("generated documents are downloadable and listed for the selected case", as
   await caseButton.click();
 
   await expect(page.getByRole("heading", { name: /dokumenty|documents/i })).toBeVisible();
-  await expect(page.getByRole("button", { name: /splnomocnenie_ESolutions_SK\.pdf/i })).toBeVisible();
+  const generatedFilename = "splnomocnenie_ESolutions_SK.pdf";
+  const sidebarDocumentItem = page.locator(".sidebar-document-item").filter({
+    has: page.locator(".sidebar-document-link", { hasText: generatedFilename })
+  });
+  const sidebarDocumentLink = sidebarDocumentItem.locator("button.sidebar-document-link");
+  const sidebarDeleteButton = sidebarDocumentItem.getByRole("button", {
+    name: `Delete document ${generatedFilename}`,
+    exact: true
+  });
+
+  await expect(sidebarDocumentItem).toHaveCount(1);
+  await expect(sidebarDocumentLink).toHaveCount(1);
+  await expect(sidebarDocumentLink).toBeVisible();
+  await expect(sidebarDeleteButton).toBeVisible();
 
   const documentActions = page.getByLabel("Generated documents");
   await expect(documentActions.getByRole("link", { name: /splnomocnenie_ESolutions_SK\.pdf/i })).toBeVisible();


### PR DESCRIPTION
Closes #604

## What changed

- scopes the generated-document open-button assertion to the matching sidebar document item
- asserts the filename-specific delete button independently
- preserves the delete control's descriptive accessible name
- documents the focused regression command and semantic locator guidance

## Root cause

The previous role/name query matched both the open-document button and the delete button because both accessible names contained the same filename. Playwright strict mode therefore rejected the ambiguous locator.

No production UI, personal-data handling, or legal-risk behavior changes.

## Validation

- `npm run lint` (no errors; seven existing Fast Refresh warnings)
- `npm run test` (129 passed)
- `npm run test:e2e -- e2e/generated-document-download.spec.ts` (1 passed)
- `npm run test:e2e -- --workers=1` (21 passed)
- `npm run build`
- `git diff --check`

The default six-worker E2E run overloaded the local Windows Vite server and produced navigation timeouts; the complete serial run passed.
