### PR TITLE
Add reusable prepare-golden-test skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,9 @@ Custom project skills:
 - `testdocument` at `skills/testdocument/SKILL.md`
   - Purpose: generate preview PDFs for every enabled document template through the local API preview renderer and write them under `runs\testdocument\document-template-pdfs`.
   - Script: `.\skills\testdocument\scripts\test_document_templates.ps1`
+- `prepare-golden-test` at `skills/prepare-golden-test/SKILL.md`
+  - Purpose: quarantine and deterministically validate a native synthetic case-export ZIP, register it as `technical_reviewed`, and promote the same PR to `native_reviewed` only after explicit human approval.
+  - Script: `.\skills\prepare-golden-test\scripts\prepare_golden_test.ps1`
 - `start-api` at `skills/start-api/SKILL.md`
   - Purpose: start and health-check local `aijuristiction-api`.
   - Script: `.\skills\start-api\scripts\start_api.ps1`

--- a/docs/CASE_EXPORT_TEST_FIXTURES.md
+++ b/docs/CASE_EXPORT_TEST_FIXTURES.md
@@ -22,6 +22,27 @@ GET /v1/admin/cases/{case_id}/export?user_id={target_user_id}&reason={admin_reas
 
 The exported ZIP is intended as the source of truth for automated model-validation runs. It includes case metadata, user/system messages, AI model audit data, citations, warnings, source documents, rendered PDFs, and checksums where available.
 
+## Upload, quarantine, and promotion
+
+Use the repository-local `prepare-golden-test` skill for every new native export. For example:
+
+```text
+Use prepare-golden-test for issue #602 with the attached exported ZIP.
+```
+
+The skill first copies the submitted ZIP unchanged to
+`runs/model-validation/issue-<number>/<run-id>/`. This ignored directory is temporary quarantine,
+not a second fixture database. It preserves the original while archive paths, compressed sizes,
+executables, secrets/payment credentials, native schemas, internal checksums, issue facts, PDFs,
+citations, warnings, and persisted model-audit fields are checked. Validation reports, extracted PDF
+text, a retained PDF copy, and its first-page PNG also stay there. Delete the quarantine run after
+review/merge or within seven days.
+
+Only after every deterministic check passes may the unchanged ZIP be copied to
+`tests/modelsTesting/cases/` and registered in `tests/modelsTesting/index.json`. That directory is
+the only tracked golden-fixture location. Unsafe, incomplete, non-synthetic, or unrelated case
+exports must fail before tracked promotion.
+
 ## Model Testing Fixture Database
 
 Tracked golden fixtures live under `tests/modelsTesting/`.
@@ -44,3 +65,9 @@ Regression issue `#518` keeps the Slovak private loan-confirmation prompt determ
 - Keep generated fixture retention aligned with the test retention policy.
 - Mark committed fixtures as synthetic or dedicated-test-account data in `tests/modelsTesting/index.json`.
 - Legal-document fixtures must include human-review expectations and checks for document structure, parties, operative statement, and signature blocks.
+
+The preparation delivery boundary is deliberate: the skill creates a dedicated branch/worktree,
+validates and promotes a `technical_reviewed` fixture, runs tests, commits, pushes, opens a PR to
+`main`, comments on the issue, and moves the task to `In review`. It never merges automatically.
+After explicit human approval, the same PR receives a small `native_reviewed` promotion commit and
+reruns validation; the normal human-approved close-task workflow performs any later merge.

--- a/docs/E2E_TEST_EVIDENCE_RULE.md
+++ b/docs/E2E_TEST_EVIDENCE_RULE.md
@@ -10,6 +10,12 @@ Every user-facing E2E scenario must prove both the machine contract and the resu
 4. Render the first PDF page to PNG next to the final UI preview screenshot.
 5. Use ordered names: `01-audio-transcript.png`, `02-message-submitted.png`, `03-document-preview.png`, `04-generated-document.pdf`, and `05-pdf-first-page.png`.
 
+For a golden document scenario, use `prepare-golden-test` after exporting the case. Its ignored
+quarantine must retain the final-state screenshot when the scenario is user-facing, the generated
+PDF, extracted expected text, and the first-page PNG. The validator checks PDF structure and text;
+the screenshot remains visual evidence and cannot replace those checks. The tracked golden ZIP
+remains the only fixture, while extracted evidence stays transient.
+
 ## Voice scenarios
 
 - Use only an approved synthetic audio fixture; real-person recordings are prohibited.

--- a/docs/MODEL_VALIDATION_RUNNER.md
+++ b/docs/MODEL_VALIDATION_RUNNER.md
@@ -26,7 +26,7 @@ local Ollama, activate the paid Case plan through the sandbox payment flow, repl
 turns, and answer matching assistant questions from the golden transcript. An unmatched question may
 receive a conservative configured answer, but the result must contain a warning.
 
-For each run, write ignored artifacts under `runs/model-validation/<run-id>/`: transcript, warnings,
+For each run, write ignored artifacts under `runs/model-validation/issue-<number>/<run-id>/`: transcript, warnings,
 actual `provider`, `model`, `route_type`, status, fallback reason, timing/token/cost fields, exported
 ZIP/PDF text and comparison JSON. Authentication secrets and payment details must never be copied to
 fixtures or reports.
@@ -37,6 +37,18 @@ only when at least one audit entry exists and every entry contains non-empty `pr
 `route_type` and `status`. Whether the case facts were entered manually or generated synthetically
 does not change this requirement: the model identity must come from the persisted server audit, never
 from a manually typed fixture label.
+
+The canonical production route is Azure Foundry (`azurefoundry`). Invoke the reusable workflow with
+a prompt such as:
+
+```text
+Use prepare-golden-test for issue #602 with the attached exported ZIP.
+```
+
+The skill derives provider, model, route type, and status only from the persisted export audit,
+cross-checks `manifest.json.models_used`, calculates the fixture SHA-256, and generates or validates
+the registry entry deterministically. A requested route mismatch is a hard failure; missing Azure
+credentials or access for a live check must never cause a silent switch to mock or another provider.
 
 Passing deterministic checks means the output conforms to the reviewed fixture; it is not automatic
 approval of legal correctness. A qualified human must review material legal changes and any output
@@ -68,21 +80,29 @@ Use this checklist for every scenario that will become automated golden-test dat
     `ai-model-audit.json.entries`. Every audit entry must contain the actual non-empty `provider`,
     `model`, `route_type`, and `status` persisted by the server. Never type these values into the
     fixture manually.
-11. Copy the reviewed immutable ZIP to `tests/modelsTesting/cases/` using a stable filename.
-12. Register the fixture in `tests/modelsTesting/index.json`, including its SHA-256, scenario ID,
-    classification, expected route, required/forbidden assertions, citations, document type/count,
-    and similarity thresholds.
-13. Set `fixture_status` to `native_reviewed` only after the content review and model-audit checks
-    pass. Legacy or incomplete fixtures must remain marked as seeds and are not automation-ready.
+11. Run `prepare-golden-test`. It quarantines and validates the original, then copies the unchanged
+    ZIP to `tests/modelsTesting/cases/` using a stable filename.
+12. Review its deterministic `tests/modelsTesting/index.json` entry: SHA-256, source issue, scenario
+    ID, synthetic classification, actual audited route, required/forbidden assertions, legal marker
+    phrases, citations, document type/count, and similarity thresholds.
+13. The initial preparation PR must use `technical_reviewed`. A human reviews the genuine production
+    path and approves the baseline; only then may the same PR receive a small `native_reviewed`
+    promotion commit and rerun all checks. A manually assembled ZIP remains a seed or
+    `technical_reviewed` and cannot establish native production provenance.
 14. Run `.\conda\python.exe examples\model_validation_runner_demo.py --fixture <zip-path>` and
     `.\conda\python.exe -m pytest tests\test_golden_cases.py
     tests\test_models_testing_fixtures.py`.
-15. Keep every later replay export separate under ignored `runs/model-validation/<run-id>/` and
+15. Keep every later replay export separate under ignored
+    `runs/model-validation/issue-<number>/<run-id>/` and
     compare normalized text, required facts, citations, document type/count, decision/status, and
     model audit. Never compare raw PDF bytes or overwrite the reviewed golden ZIP.
 
 If any step fails, do not promote the ZIP to `native_reviewed`. Correct the synthetic case in
 JurisDigta, repeat the human review, create a new export, and update the registered checksum.
+
+The skill delivers a dedicated branch/worktree, commit, pushed branch, PR to `main`, issue comment,
+and `In review` status. It never merges the PR. Merge remains part of the separate human-approved
+close-task workflow after `native_reviewed` validation passes.
 
 ## Adding coverage
 

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -180,6 +180,12 @@ print(
     "for model answer/document comparison, including legal-document structure and human-review checks."
 )
 print(
+    "prepare_golden_test => ask `Use prepare-golden-test for issue #602 with the attached "
+    "exported ZIP.`; the skill quarantines and validates the unchanged native export, records its "
+    "persisted model audit as technical_reviewed, and requires explicit human approval before "
+    "native_reviewed. It opens a PR but never merges it."
+)
+print(
     "active_case_export => My Cases and My Profile download the authorized case ZIP, keep the Blob URL "
     "alive until the browser starts the download, and expose the request correlation_id in manifest.json "
     "for case-scoped support tracing without embedding raw logs."

--- a/skills/prepare-golden-test/SKILL.md
+++ b/skills/prepare-golden-test/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: prepare-golden-test
+description: Prepare a native JurisDigta case-export ZIP as a deterministic golden-test fixture. Use when a developer supplies an exported case ZIP and source GitHub issue, asks to prepare or promote a golden case, or invokes `/prepare-golden-test`; validate safety, native schema, checksums, PDFs, persisted model audit, source facts, assertions, review state, and registry metadata before delivery.
+---
+
+# Prepare Golden Test
+
+Prepare one exported synthetic case per dedicated branch/worktree. Treat legal correctness as a human decision: automation can create `technical_reviewed`, but only explicit human approval can promote the same PR to `native_reviewed`.
+
+## Preparation workflow
+
+1. Read the source issue, `docs/CASE_EXPORT_TEST_FIXTURES.md`, and `tests/modelsTesting/README.md`. Confirm the issue declares synthetic data and identify source facts, required/forbidden content, document type, and legal markers. Do not invent provider, model, route type, or status.
+2. Before editing, run the repository environment-profile pull, create a task-specific branch/worktree with `scripts/new_task_worktree.ps1`, and move the issue to `In progress` with `scripts/project_status.ps1`.
+3. Create a quarantine-only assertions JSON under `runs/model-validation/issue-<number>/`. Include:
+   - `case_key`, `scenario_id`, `language`, `country`, `category`, and `fixture_purpose`;
+   - non-empty `source_facts` present in both the issue and reviewed output;
+   - `answer` and `document` `must_contain`, `must_not_contain`, and similarity thresholds;
+   - `document.type` and `marker_phrases` for `document_title`, `parties`, `operative_statement`, `signature_block`, `limited_claim_scope`, and `human_review_disclosure`.
+4. Run from repository root:
+
+   ```powershell
+   .\skills\prepare-golden-test\scripts\prepare_golden_test.ps1 prepare `
+     --issue 602 `
+     --zip C:\path\case-export.zip `
+     --assertions-json runs\model-validation\issue-602\assertions.json `
+     --expected-scenario-id 01-private-loan-payment-confirmation
+   ```
+
+   The command copies the unchanged ZIP into quarantine first, rejects unsafe/incomplete content, writes a validation report plus transient PDF/text/first-page evidence, copies the approved bytes to `tests/modelsTesting/cases/`, and updates `index.json` as `technical_reviewed`.
+5. Inspect the generated registry diff. Run the skill validator, focused tests, PDF checks, and `python examples/minimal_demo.py`. Run other affected gates in proportion to the change.
+6. Commit, push, open a PR to `main`, comment `Implemented by Codex`, and move the source task to `In review`. Never merge the PR.
+
+The canonical production route defaults to `azurefoundry`. If the persisted audit does not match the requested route, stop; never substitute mock or another provider.
+
+## Human promotion
+
+After a human reviews the genuine production conversation, document, PDF, checksums, and model audit, save their approval evidence in ignored quarantine as JSON:
+
+```json
+{
+  "reviewer": "github-handle",
+  "approval_reference": "https://github.com/OWNER/REPO/pull/123#pullrequestreview-456",
+  "approved_at": "2026-08-09T12:00:00Z",
+  "production_path_confirmed": true
+}
+```
+
+Then update the same branch/PR:
+
+```powershell
+.\skills\prepare-golden-test\scripts\prepare_golden_test.ps1 promote `
+  --issue 602 `
+  --case-key issue-602-private-loan-payment-confirmation `
+  --human-approval-json runs\model-validation\issue-602\approval.json
+```
+
+Promotion revalidates the unchanged fixture and requires native export provenance plus the explicit approval record. A manually assembled ZIP can remain `technical_reviewed`, but do not confirm its production path or promote it. Commit the small state change, rerun validation, and leave merge to the human-approved close-task workflow.
+
+## Safety and retention
+
+- Keep `runs/model-validation/issue-<number>/<run-id>/` ignored and delete it after review/merge or within seven days.
+- Keep only immutable approved ZIPs under `tests/modelsTesting/cases/`; quarantine is not a second golden database.
+- Reject traversal, archive bombs, executables, secrets, tokens, payment credentials, unrelated cases, missing audits, invalid PDFs, and non-synthetic inputs before tracked promotion.
+- Compare normalized text and assertions, not raw PDF bytes or exact model wording. Model output is never proof of legal correctness.

--- a/skills/prepare-golden-test/agents/openai.yaml
+++ b/skills/prepare-golden-test/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Prepare Golden Test"
+  short_description: "Validate and stage native golden-case exports"
+  default_prompt: "Use $prepare-golden-test to validate and stage a native case-export ZIP for a source issue."

--- a/skills/prepare-golden-test/scripts/prepare_golden_test.ps1
+++ b/skills/prepare-golden-test/scripts/prepare_golden_test.ps1
@@ -1,0 +1,26 @@
+param(
+    [Parameter(Position = 0, Mandatory = $true)]
+    [ValidateSet("prepare", "promote")]
+    [string]$Command,
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Arguments
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..\..")).Path
+$Python = Join-Path $RepoRoot "conda\python.exe"
+$Script = Join-Path $PSScriptRoot "prepare_golden_test.py"
+
+if (-not (Test-Path $Python)) {
+    throw "Repository conda runtime not found at $Python. Create the task worktree with scripts/new_task_worktree.ps1."
+}
+
+Push-Location $RepoRoot
+try {
+    & $Python $Script $Command @Arguments
+    exit $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}

--- a/skills/prepare-golden-test/scripts/prepare_golden_test.py
+++ b/skills/prepare-golden-test/scripts/prepare_golden_test.py
@@ -1,0 +1,883 @@
+#!/usr/bin/env python3
+"""Safely validate and promote native JurisDigta golden-case exports."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+import hashlib
+import io
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import subprocess
+import sys
+from typing import Any, Iterable
+import unicodedata
+from zipfile import BadZipFile, ZipFile, ZipInfo
+
+import pymupdf
+from pypdf import PdfReader
+
+
+REQUIRED_FILES = {
+    "manifest.json",
+    "case.json",
+    "messages.jsonl",
+    "ai-model-audit.json",
+    "citations.json",
+    "warnings.json",
+    "sha256sums.txt",
+}
+REQUIRED_MARKERS = {
+    "document_title",
+    "parties",
+    "operative_statement",
+    "signature_block",
+    "limited_claim_scope",
+    "human_review_disclosure",
+}
+TEXT_SUFFIXES = {".json", ".jsonl", ".txt", ".md", ".html", ".htm", ".csv", ".xml"}
+EXECUTABLE_SUFFIXES = {
+    ".bat",
+    ".cmd",
+    ".com",
+    ".dll",
+    ".exe",
+    ".jar",
+    ".js",
+    ".msi",
+    ".ps1",
+    ".scr",
+    ".sh",
+    ".vbs",
+}
+MAX_MEMBERS = 512
+MAX_MEMBER_BYTES = 25 * 1024 * 1024
+MAX_ARCHIVE_BYTES = 100 * 1024 * 1024
+MAX_COMPRESSION_RATIO = 100
+SYNTHETIC_TERMS = ("synthetic", "syntetick", "fiktiv", "testovac")
+SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+EMAIL_RE = re.compile(r"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b")
+IBAN_RE = re.compile(r"\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b")
+CARD_RE = re.compile(r"(?<!\d)(?:\d[ -]?){13,19}(?!\d)")
+SECRET_PATTERNS = (
+    re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+    re.compile(r"\b(?:ghp|github_pat|sk-proj|sk-live|sk-test)_[A-Za-z0-9_-]{12,}\b"),
+    re.compile(
+        r'(?i)["\'](?:api[_-]?key|access[_-]?token|refresh[_-]?token|password|client[_-]?secret)'
+        r'["\']\s*:\s*["\'](?!unknown|redacted)[^"\']{6,}["\']'
+    ),
+)
+
+
+class ValidationFailure(RuntimeError):
+    """Raised after a redacted validation report has been written."""
+
+    def __init__(self, errors: Iterable[str]) -> None:
+        self.errors = tuple(errors)
+        super().__init__("; ".join(self.errors))
+
+
+def _canonical(value: str) -> str:
+    decomposed = unicodedata.normalize("NFKD", value)
+    plain = "".join(char for char in decomposed if not unicodedata.combining(char))
+    return re.sub(r"\s+", " ", plain.casefold()).strip()
+
+
+def _route_key(value: object) -> str:
+    return re.sub(r"[^a-z0-9]+", "", str(value).casefold())
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest().upper()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest().upper()
+
+
+def _read_json_path(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationFailure((f"invalid_json_file:{path}:{exc}",)) from exc
+    if not isinstance(value, dict):
+        raise ValidationFailure((f"expected_json_object:{path}",))
+    return value
+
+
+def _read_json_member(archive: ZipFile, name: str) -> dict[str, Any]:
+    try:
+        value = json.loads(archive.read(name).decode("utf-8-sig"))
+    except (KeyError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValidationFailure((f"invalid_json_member:{name}:{exc}",)) from exc
+    if not isinstance(value, dict):
+        raise ValidationFailure((f"expected_json_object:{name}",))
+    return value
+
+
+def _object_list(payload: dict[str, Any], key: str, source: str) -> list[dict[str, Any]]:
+    value = payload.get(key)
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise ValidationFailure((f"expected_object_list:{source}:{key}",))
+    return value
+
+
+def _safe_member(info: ZipInfo) -> str | None:
+    name = info.filename
+    if "\\" in name or "\x00" in name:
+        return f"unsafe_archive_path:{name!r}"
+    path = PurePosixPath(name)
+    if path.is_absolute() or ".." in path.parts or not path.parts:
+        return f"unsafe_archive_path:{name!r}"
+    if re.match(r"^[A-Za-z]:", name):
+        return f"unsafe_archive_path:{name!r}"
+    if path.suffix.casefold() in EXECUTABLE_SUFFIXES:
+        return f"unexpected_executable:{name}"
+    if info.file_size > MAX_MEMBER_BYTES:
+        return f"archive_member_too_large:{name}"
+    ratio = info.file_size / max(info.compress_size, 1)
+    if ratio > MAX_COMPRESSION_RATIO and info.file_size > 1024 * 1024:
+        return f"archive_compression_ratio_exceeded:{name}"
+    return None
+
+
+def _luhn_valid(candidate: str) -> bool:
+    digits = [int(char) for char in candidate if char.isdigit()]
+    if not 13 <= len(digits) <= 19 or len(set(digits)) == 1:
+        return False
+    checksum = 0
+    parity = len(digits) % 2
+    for index, digit in enumerate(digits):
+        if index % 2 == parity:
+            digit *= 2
+            if digit > 9:
+                digit -= 9
+        checksum += digit
+    return checksum % 10 == 0
+
+
+def _scan_sensitive_text(text: str, issue_body: str) -> list[str]:
+    errors: list[str] = []
+    for pattern in SECRET_PATTERNS:
+        if pattern.search(text):
+            errors.append("secret_or_token_pattern_detected")
+    if IBAN_RE.search(text):
+        errors.append("payment_iban_detected")
+    if any(_luhn_valid(match.group()) for match in CARD_RE.finditer(text)):
+        errors.append("payment_card_number_detected")
+    issue_emails = {item.casefold() for item in EMAIL_RE.findall(issue_body)}
+    for email in EMAIL_RE.findall(text):
+        normalized = email.casefold()
+        if normalized not in issue_emails and not normalized.endswith((".test", "@example.com")):
+            errors.append("email_not_declared_by_source_issue")
+            break
+    return errors
+
+
+def _fetch_issue(issue: int, repo: str, issue_json: Path | None) -> dict[str, Any]:
+    if issue_json is not None:
+        payload = _read_json_path(issue_json)
+    else:
+        result = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "view",
+                str(issue),
+                "--repo",
+                repo,
+                "--json",
+                "number,title,body,url",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        if result.returncode != 0:
+            raise ValidationFailure((f"source_issue_fetch_failed:{result.stderr.strip()}",))
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise ValidationFailure(("source_issue_fetch_invalid_json",)) from exc
+    if int(payload.get("number", -1)) != issue:
+        raise ValidationFailure(("source_issue_number_mismatch",))
+    body = str(payload.get("body") or "")
+    if not body.strip():
+        raise ValidationFailure(("source_issue_body_missing",))
+    if not any(term in _canonical(body) for term in SYNTHETIC_TERMS):
+        raise ValidationFailure(("source_issue_missing_synthetic_data_declaration",))
+    payload.setdefault("url", f"https://github.com/{repo}/issues/{issue}")
+    return payload
+
+
+def _validate_assertions(assertions: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for key in ("case_key", "scenario_id", "language", "country", "category", "fixture_purpose"):
+        if not str(assertions.get(key) or "").strip():
+            errors.append(f"assertions.{key}_missing")
+    for key in ("case_key", "scenario_id"):
+        value = str(assertions.get(key) or "")
+        if value and not SLUG_RE.fullmatch(value):
+            errors.append(f"assertions.{key}_must_be_slug")
+    facts = assertions.get("source_facts")
+    if not isinstance(facts, list) or not facts or any(not str(item).strip() for item in facts):
+        errors.append("assertions.source_facts_missing")
+    for output_name in ("answer", "document"):
+        output = assertions.get(output_name)
+        if not isinstance(output, dict):
+            errors.append(f"assertions.{output_name}_missing")
+            continue
+        required = output.get("must_contain")
+        forbidden = output.get("must_not_contain")
+        if not isinstance(required, list) or not required:
+            errors.append(f"assertions.{output_name}.must_contain_missing")
+        if not isinstance(forbidden, list):
+            errors.append(f"assertions.{output_name}.must_not_contain_missing")
+        threshold = output.get("similarity_min")
+        if not isinstance(threshold, (int, float)) or not 0.0 <= float(threshold) <= 1.0:
+            errors.append(f"assertions.{output_name}.similarity_min_invalid")
+    document = assertions.get("document")
+    if isinstance(document, dict):
+        if not str(document.get("type") or "").strip():
+            errors.append("assertions.document.type_missing")
+        markers = document.get("marker_phrases")
+        if not isinstance(markers, dict):
+            errors.append("assertions.document.marker_phrases_missing")
+        else:
+            missing = REQUIRED_MARKERS.difference(markers)
+            errors.extend(f"assertions.document.marker_missing:{item}" for item in sorted(missing))
+            for marker, phrases in markers.items():
+                if marker in REQUIRED_MARKERS and (
+                    not isinstance(phrases, list)
+                    or not phrases
+                    or any(not str(item).strip() for item in phrases)
+                ):
+                    errors.append(f"assertions.document.marker_phrases_empty:{marker}")
+    return errors
+
+
+def _parse_checksums(payload: str) -> tuple[dict[str, str], list[str]]:
+    checksums: dict[str, str] = {}
+    errors: list[str] = []
+    for line_number, line in enumerate(payload.splitlines(), start=1):
+        match = re.fullmatch(r"([0-9a-fA-F]{64})  ([^\r\n]+)", line)
+        if not match:
+            errors.append(f"invalid_checksum_line:{line_number}")
+            continue
+        name = match.group(2)
+        if name in checksums:
+            errors.append(f"duplicate_checksum_path:{name}")
+        checksums[name] = match.group(1).upper()
+    return checksums, errors
+
+
+def _render_pdf_evidence(
+    payload: bytes, evidence_root: Path, ordinal: int
+) -> tuple[str, list[str]]:
+    errors: list[str] = []
+    try:
+        reader = PdfReader(io.BytesIO(payload), strict=True)
+        if not reader.pages:
+            return "", [f"pdf_has_no_pages:{ordinal}"]
+        text = "\n".join(page.extract_text() or "" for page in reader.pages).strip()
+    except Exception as exc:  # pypdf intentionally exposes many parser exception types
+        return "", [f"invalid_pdf_structure:{ordinal}:{type(exc).__name__}"]
+    if not text:
+        errors.append(f"pdf_text_empty:{ordinal}")
+    try:
+        document = pymupdf.open(stream=payload, filetype="pdf")
+        pixmap = document[0].get_pixmap(matrix=pymupdf.Matrix(1.5, 1.5), alpha=False)
+        (evidence_root / f"document-{ordinal:02d}-first-page.png").write_bytes(
+            pixmap.tobytes("png")
+        )
+        document.close()
+    except Exception as exc:
+        errors.append(f"pdf_first_page_render_failed:{ordinal}:{type(exc).__name__}")
+    (evidence_root / f"document-{ordinal:02d}.pdf").write_bytes(payload)
+    (evidence_root / f"document-{ordinal:02d}-extracted.txt").write_text(text, encoding="utf-8")
+    return text, errors
+
+
+def _validate_export(
+    *,
+    zip_path: Path,
+    issue_payload: dict[str, Any],
+    assertions: dict[str, Any],
+    expected_route: str,
+    expected_scenario_id: str | None,
+    evidence_root: Path,
+    require_native_provenance: bool,
+) -> tuple[dict[str, Any], list[str]]:
+    errors = _validate_assertions(assertions)
+    issue_body = str(issue_payload["body"])
+    if expected_scenario_id and assertions.get("scenario_id") != expected_scenario_id:
+        errors.append("expected_scenario_id_mismatch")
+    evidence_root.mkdir(parents=True, exist_ok=True)
+    try:
+        archive = ZipFile(zip_path)
+    except (OSError, BadZipFile) as exc:
+        raise ValidationFailure((f"invalid_zip:{type(exc).__name__}",)) from exc
+
+    with archive:
+        infos = archive.infolist()
+        names = [info.filename for info in infos if not info.is_dir()]
+        if len(infos) > MAX_MEMBERS:
+            errors.append("archive_member_limit_exceeded")
+        if len(names) != len(set(names)):
+            errors.append("duplicate_archive_member")
+        if sum(info.file_size for info in infos) > MAX_ARCHIVE_BYTES:
+            errors.append("archive_uncompressed_size_exceeded")
+        errors.extend(error for info in infos if (error := _safe_member(info)) is not None)
+        missing_files = REQUIRED_FILES.difference(names)
+        errors.extend(f"required_file_missing:{name}" for name in sorted(missing_files))
+        if missing_files or any(error.startswith("unsafe_archive_path") for error in errors):
+            return {}, sorted(set(errors))
+
+        manifest = _read_json_member(archive, "manifest.json")
+        case = _read_json_member(archive, "case.json")
+        audit_payload = _read_json_member(archive, "ai-model-audit.json")
+        citations_payload = _read_json_member(archive, "citations.json")
+        warnings_payload = _read_json_member(archive, "warnings.json")
+        if manifest.get("schema") != "jurisdigta.case-export.v1":
+            errors.append("native_manifest_schema_invalid")
+        if case.get("schema") != "jurisdigta.case-export.case.v1":
+            errors.append("case_schema_invalid")
+        case_id = str(manifest.get("case_id") or "")
+        if not case_id or str(case.get("case_id") or "") != case_id:
+            errors.append("manifest_case_id_mismatch")
+        if manifest.get("user_id") != case.get("user_id"):
+            errors.append("manifest_user_id_mismatch")
+        if manifest.get("artifact_count") != len(names):
+            errors.append("manifest_artifact_count_mismatch")
+
+        checksums, checksum_errors = _parse_checksums(
+            archive.read("sha256sums.txt").decode("utf-8-sig")
+        )
+        errors.extend(checksum_errors)
+        expected_checksum_names = set(names).difference({"sha256sums.txt"})
+        if set(checksums) != expected_checksum_names:
+            errors.append("internal_checksum_member_set_mismatch")
+        for name, expected in checksums.items():
+            if name in names and _sha256_bytes(archive.read(name)) != expected:
+                errors.append(f"internal_checksum_mismatch:{name}")
+
+        try:
+            message_lines = [
+                json.loads(line)
+                for line in archive.read("messages.jsonl").decode("utf-8-sig").splitlines()
+                if line.strip()
+            ]
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ValidationFailure((f"messages_jsonl_invalid:{exc}",)) from exc
+        if any(not isinstance(item, dict) for item in message_lines):
+            errors.append("messages_jsonl_object_required")
+            messages: list[dict[str, Any]] = []
+        else:
+            messages = message_lines
+        roles = Counter(str(item.get("role") or "") for item in messages)
+        if not roles["user"] or not roles["assistant"]:
+            errors.append("transcript_requires_user_and_assistant")
+        if manifest.get("message_count") != len(messages):
+            errors.append("manifest_message_count_mismatch")
+        assistant_text = "\n".join(
+            str(item.get("content") or "") for item in messages if item.get("role") == "assistant"
+        )
+
+        audit_entries = _object_list(audit_payload, "entries", "ai-model-audit.json")
+        if not audit_entries:
+            errors.append("model_audit_missing")
+        route_fields = ("provider", "model", "route_type", "status")
+        for index, entry in enumerate(audit_entries):
+            for field in route_fields:
+                if (
+                    not str(entry.get(field) or "").strip()
+                    or _route_key(entry.get(field)) == "unknown"
+                ):
+                    errors.append(f"model_audit[{index}].{field}_missing")
+            if entry.get("case_id") not in (None, "", case_id):
+                errors.append(f"model_audit[{index}].case_id_mismatch")
+        actual_routes = sorted(
+            {
+                (
+                    str(entry.get("provider") or ""),
+                    str(entry.get("model") or ""),
+                    str(entry.get("route_type") or ""),
+                    str(entry.get("status") or ""),
+                )
+                for entry in audit_entries
+            }
+        )
+        expected_key = _route_key(expected_route)
+        if expected_key and not any(
+            expected_key in {_route_key(provider), _route_key(route_type)}
+            for provider, _, route_type, _ in actual_routes
+        ):
+            errors.append("persisted_model_route_does_not_match_expected_route")
+        manifest_routes = {
+            (
+                str(item.get("provider") or ""),
+                str(item.get("model") or ""),
+                str(item.get("route_type") or ""),
+                str(item.get("status") or ""),
+            )
+            for item in manifest.get("models_used", [])
+            if isinstance(item, dict)
+        }
+        if set(actual_routes) != manifest_routes:
+            errors.append("manifest_models_used_mismatch")
+        if manifest.get("ai_model_audit_count") != len(audit_entries):
+            errors.append("manifest_model_audit_count_mismatch")
+
+        citations = _object_list(citations_payload, "items", "citations.json")
+        warnings = _object_list(warnings_payload, "items", "warnings.json")
+        if manifest.get("citation_count") != len(citations):
+            errors.append("manifest_citation_count_mismatch")
+        if any(not str(item.get("code") or "").strip() for item in warnings):
+            errors.append("warning_code_missing")
+
+        documents = manifest.get("documents")
+        if not isinstance(documents, list) or any(not isinstance(item, dict) for item in documents):
+            errors.append("manifest_documents_invalid")
+            document_entries: list[dict[str, Any]] = []
+        else:
+            document_entries = documents
+        if manifest.get("document_count") != len(document_entries):
+            errors.append("manifest_document_count_mismatch")
+        document_texts: list[str] = []
+        generated_count = 0
+        pdf_count = 0
+        for index, document in enumerate(document_entries, start=1):
+            source = str(document.get("source_artifact") or "")
+            if not source or source not in names:
+                errors.append(f"document_source_missing:{index}")
+            elif PurePosixPath(source).suffix.casefold() in TEXT_SUFFIXES:
+                document_texts.append(archive.read(source).decode("utf-8-sig", errors="replace"))
+            if document.get("kind") != "generated_document":
+                continue
+            generated_count += 1
+            rendered = str(document.get("rendered_pdf_artifact") or "")
+            if (
+                not rendered
+                or rendered not in names
+                or PurePosixPath(rendered).suffix.casefold() != ".pdf"
+            ):
+                errors.append(f"generated_document_pdf_missing:{index}")
+                continue
+            pdf_count += 1
+            pdf_text, pdf_errors = _render_pdf_evidence(
+                archive.read(rendered), evidence_root, pdf_count
+            )
+            document_texts.append(pdf_text)
+            errors.extend(pdf_errors)
+        if generated_count == 0:
+            errors.append("generated_document_missing")
+
+        combined_output = "\n".join([assistant_text, *document_texts])
+        issue_normalized = _canonical(issue_body)
+        output_normalized = _canonical(combined_output)
+        for fact in assertions.get("source_facts", []):
+            normalized = _canonical(str(fact))
+            if normalized not in issue_normalized:
+                errors.append(f"source_fact_not_in_issue:{fact}")
+            if normalized not in output_normalized:
+                errors.append(f"source_fact_not_in_output:{fact}")
+
+        for output_name, output_text in (
+            ("answer", assistant_text),
+            ("document", "\n".join(document_texts)),
+        ):
+            rules = assertions.get(output_name, {})
+            normalized_output = _canonical(output_text)
+            for required in rules.get("must_contain", []):
+                if _canonical(str(required)) not in normalized_output:
+                    errors.append(f"{output_name}_required_content_missing:{required}")
+            for forbidden in rules.get("must_not_contain", []):
+                if _canonical(str(forbidden)) in normalized_output:
+                    errors.append(f"{output_name}_forbidden_content_present:{forbidden}")
+        markers = assertions.get("document", {}).get("marker_phrases", {})
+        normalized_documents = _canonical("\n".join(document_texts))
+        for marker in REQUIRED_MARKERS:
+            phrases = markers.get(marker, []) if isinstance(markers, dict) else []
+            if phrases and not any(
+                _canonical(str(phrase)) in normalized_documents for phrase in phrases
+            ):
+                errors.append(f"legal_document_marker_missing:{marker}")
+
+        scan_texts: list[str] = [issue_body, assistant_text, *document_texts]
+        for info in infos:
+            if info.is_dir() or PurePosixPath(info.filename).suffix.casefold() not in TEXT_SUFFIXES:
+                continue
+            if info.file_size <= 2 * 1024 * 1024:
+                scan_texts.append(archive.read(info.filename).decode("utf-8-sig", errors="replace"))
+        for text in scan_texts:
+            errors.extend(_scan_sensitive_text(text, issue_body))
+
+        exported_by = str(manifest.get("exported_by") or "")
+        correlation_id = str(manifest.get("correlation_id") or "")
+        generated_at = str(manifest.get("generated_at") or "")
+        native_provenance = bool(
+            (exported_by == "case-owner" or exported_by.startswith("admin:"))
+            and correlation_id
+            and generated_at
+            and not checksum_errors
+        )
+        if require_native_provenance and not native_provenance:
+            errors.append("native_production_export_provenance_missing")
+
+        metadata = {
+            "case_id": case_id,
+            "actual_audited_routes": [
+                {
+                    "provider": provider,
+                    "model": model,
+                    "route_type": route_type,
+                    "status": status,
+                }
+                for provider, model, route_type, status in actual_routes
+            ],
+            "document_count": len(document_entries),
+            "generated_document_count": generated_count,
+            "rendered_pdf_count": pdf_count,
+            "citation_count": len(citations),
+            "citation_sources": sorted(
+                {
+                    str(item.get("source_type") or item.get("type") or "unknown")
+                    for item in citations
+                }
+            ),
+            "warning_count": len(warnings),
+            "native_production_export_provenance": native_provenance,
+            "exported_by": exported_by,
+        }
+        return metadata, sorted(set(errors))
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def _run_directory(root: Path, issue: int, run_id: str) -> Path:
+    path = root / f"issue-{issue}" / run_id
+    path.mkdir(parents=True, exist_ok=False)
+    return path
+
+
+def _default_run_id(zip_sha: str) -> str:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{stamp}-{zip_sha[:12].lower()}"
+
+
+def _registry_entry(
+    *,
+    assertions: dict[str, Any],
+    issue_payload: dict[str, Any],
+    fixture_name: str,
+    fixture_sha: str,
+    metadata: dict[str, Any],
+) -> dict[str, Any]:
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    document_rules = dict(assertions["document"])
+    document_rules["legal_document_markers"] = sorted(REQUIRED_MARKERS)
+    return {
+        "case_key": assertions["case_key"],
+        "scenario_id": assertions["scenario_id"],
+        "fixture_status": "technical_reviewed",
+        "zip_path": f"cases/{fixture_name}",
+        "sha256": fixture_sha,
+        "source_issue": issue_payload["url"],
+        "language": assertions["language"],
+        "country": assertions["country"],
+        "category": assertions["category"],
+        "data_classification": "synthetic_test_fixture",
+        "fixture_purpose": assertions["fixture_purpose"],
+        "actual_audited_routes": metadata["actual_audited_routes"],
+        "production_path_evidence": {
+            "native_export_claim_present": metadata["native_production_export_provenance"],
+            "exported_by": metadata["exported_by"],
+            "human_confirmation_required": True,
+        },
+        "review": {
+            "state": "technical_reviewed",
+            "technical_reviewed_at": now,
+            "native_review_requires_human_approval": True,
+        },
+        "source_facts": assertions["source_facts"],
+        "documents": {
+            "type": assertions["document"]["type"],
+            "count": metadata["document_count"],
+            "generated_count": metadata["generated_document_count"],
+            "rendered_pdf_count": metadata["rendered_pdf_count"],
+        },
+        "citations": {
+            "count": metadata["citation_count"],
+            "source_types": metadata["citation_sources"],
+        },
+        "warnings_count": metadata["warning_count"],
+        "expected_outputs": {
+            "answer": assertions["answer"],
+            "document": document_rules,
+        },
+    }
+
+
+def _load_registry(path: Path) -> dict[str, Any]:
+    registry = _read_json_path(path)
+    if registry.get("schema_version") != "jurisdigta.models-testing.index.v1":
+        raise ValidationFailure(("registry_schema_invalid",))
+    if not isinstance(registry.get("cases"), list):
+        raise ValidationFailure(("registry_cases_invalid",))
+    return registry
+
+
+def _prepare(args: argparse.Namespace) -> int:
+    source_zip = args.zip.resolve()
+    if not source_zip.is_file():
+        raise ValidationFailure((f"source_zip_missing:{source_zip}",))
+    fixture_sha = _sha256_file(source_zip)
+    run_id = args.run_id or _default_run_id(fixture_sha)
+    run_root = _run_directory(args.quarantine_root, args.issue, run_id)
+    quarantined_zip = run_root / "original-case-export.zip"
+    shutil.copyfile(source_zip, quarantined_zip)
+    if _sha256_file(quarantined_zip) != fixture_sha:
+        raise ValidationFailure(("quarantine_copy_checksum_mismatch",))
+
+    report_path = run_root / "validation-report.json"
+    report: dict[str, Any] = {
+        "schema": "jurisdigta.golden-preparation-report.v1",
+        "source_issue": args.issue,
+        "run_id": run_id,
+        "fixture_sha256": fixture_sha,
+        "review_state": "technical_reviewed",
+        "quarantine_only": True,
+        "retention_delete_by": (datetime.now(timezone.utc) + timedelta(days=args.retention_days))
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "passed": False,
+        "errors": [],
+    }
+    try:
+        issue_payload = _fetch_issue(args.issue, args.repo, args.issue_json)
+        assertions = _read_json_path(args.assertions_json)
+        metadata, errors = _validate_export(
+            zip_path=quarantined_zip,
+            issue_payload=issue_payload,
+            assertions=assertions,
+            expected_route=args.expected_production_route,
+            expected_scenario_id=args.expected_scenario_id,
+            evidence_root=run_root / "evidence",
+            require_native_provenance=False,
+        )
+        report["checks"] = metadata
+        report["errors"] = errors
+        if errors:
+            raise ValidationFailure(errors)
+
+        stable_name = args.stable_name or f"{assertions['case_key']}-case-export.zip"
+        if not stable_name.endswith(".zip"):
+            stable_name += ".zip"
+        if not SLUG_RE.fullmatch(stable_name[:-4]):
+            raise ValidationFailure(("stable_name_must_be_lowercase_slug_zip",))
+        registry = _load_registry(args.registry)
+        cases: list[dict[str, Any]] = registry["cases"]
+        case_key = assertions["case_key"]
+        conflicts = [item for item in cases if item.get("case_key") == case_key]
+        if conflicts and any(item.get("sha256") != fixture_sha for item in conflicts):
+            raise ValidationFailure(("case_key_already_registered_with_different_fixture",))
+        if conflicts and any(item.get("fixture_status") == "native_reviewed" for item in conflicts):
+            raise ValidationFailure(("cannot_downgrade_native_reviewed_fixture",))
+        entry = _registry_entry(
+            assertions=assertions,
+            issue_payload=issue_payload,
+            fixture_name=stable_name,
+            fixture_sha=fixture_sha,
+            metadata=metadata,
+        )
+        registry["cases"] = sorted(
+            [item for item in cases if item.get("case_key") != case_key] + [entry],
+            key=lambda item: str(item.get("case_key") or ""),
+        )
+        fixture_path = args.fixture_root / "cases" / stable_name
+        fixture_path.parent.mkdir(parents=True, exist_ok=True)
+        if fixture_path.exists() and _sha256_file(fixture_path) != fixture_sha:
+            raise ValidationFailure(("fixture_destination_exists_with_different_checksum",))
+        shutil.copyfile(quarantined_zip, fixture_path)
+        _write_json_atomic(args.registry, registry)
+        report["passed"] = True
+        report["quarantine_only"] = False
+        report["promoted_fixture"] = str(fixture_path)
+        report["registry_case_key"] = case_key
+        _write_json_atomic(report_path, report)
+        print(f"Prepared technical_reviewed fixture: {fixture_path}")
+        print(f"Validation report: {report_path}")
+        return 0
+    except ValidationFailure as exc:
+        report["errors"] = list(exc.errors)
+        _write_json_atomic(report_path, report)
+        raise
+
+
+def _approval(path: Path) -> dict[str, Any]:
+    approval = _read_json_path(path)
+    errors: list[str] = []
+    if not str(approval.get("reviewer") or "").strip():
+        errors.append("human_approval_reviewer_missing")
+    reference = str(approval.get("approval_reference") or "")
+    if not re.match(r"^https://github\.com/[^/]+/[^/]+/pull/\d+", reference):
+        errors.append("human_approval_reference_invalid")
+    approved_at = str(approval.get("approved_at") or "")
+    try:
+        parsed = datetime.fromisoformat(approved_at.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            errors.append("human_approval_timestamp_requires_timezone")
+    except ValueError:
+        errors.append("human_approval_timestamp_invalid")
+    if approval.get("production_path_confirmed") is not True:
+        errors.append("human_approval_must_confirm_production_path")
+    if errors:
+        raise ValidationFailure(errors)
+    return approval
+
+
+def _promote(args: argparse.Namespace) -> int:
+    registry = _load_registry(args.registry)
+    cases: list[dict[str, Any]] = registry["cases"]
+    matches = [item for item in cases if item.get("case_key") == args.case_key]
+    if len(matches) != 1:
+        raise ValidationFailure(("registered_case_key_not_found_or_ambiguous",))
+    entry = matches[0]
+    if entry.get("fixture_status") != "technical_reviewed":
+        raise ValidationFailure(("promotion_requires_technical_reviewed_state",))
+    approval = _approval(args.human_approval_json)
+    fixture_path = args.fixture_root / str(entry["zip_path"])
+    if not fixture_path.is_file() or _sha256_file(fixture_path) != entry.get("sha256"):
+        raise ValidationFailure(("registered_fixture_checksum_mismatch",))
+    issue_payload = _fetch_issue(args.issue, args.repo, args.issue_json)
+    source_issue = str(entry.get("source_issue") or "")
+    if not source_issue.endswith(f"/issues/{args.issue}"):
+        raise ValidationFailure(("promotion_source_issue_mismatch",))
+    document_rules = dict(entry["expected_outputs"]["document"])
+    document_rules.pop("legal_document_markers", None)
+    assertions = {
+        "case_key": entry["case_key"],
+        "scenario_id": entry["scenario_id"],
+        "language": entry["language"],
+        "country": entry["country"],
+        "category": entry["category"],
+        "fixture_purpose": entry["fixture_purpose"],
+        "source_facts": entry["source_facts"],
+        "answer": entry["expected_outputs"]["answer"],
+        "document": document_rules,
+    }
+    expected_route = str(entry["actual_audited_routes"][0]["provider"])
+    run_id = args.run_id or _default_run_id(str(entry["sha256"]))
+    run_root = _run_directory(args.quarantine_root, args.issue, f"promotion-{run_id}")
+    metadata, errors = _validate_export(
+        zip_path=fixture_path,
+        issue_payload=issue_payload,
+        assertions=assertions,
+        expected_route=expected_route,
+        expected_scenario_id=str(entry["scenario_id"]),
+        evidence_root=run_root / "evidence",
+        require_native_provenance=True,
+    )
+    if errors:
+        _write_json_atomic(
+            run_root / "validation-report.json",
+            {"passed": False, "review_state": "technical_reviewed", "errors": errors},
+        )
+        raise ValidationFailure(errors)
+    entry["fixture_status"] = "native_reviewed"
+    entry["review"] = {
+        **entry.get("review", {}),
+        "state": "native_reviewed",
+        "native_reviewed_at": approval["approved_at"],
+        "human_reviewer": approval["reviewer"],
+        "approval_reference": approval["approval_reference"],
+        "production_path_confirmed": True,
+    }
+    entry["production_path_evidence"] = {
+        **entry.get("production_path_evidence", {}),
+        "human_confirmation_required": False,
+        "human_confirmation_reference": approval["approval_reference"],
+    }
+    _write_json_atomic(args.registry, registry)
+    report_path = run_root / "validation-report.json"
+    _write_json_atomic(
+        report_path,
+        {
+            "schema": "jurisdigta.golden-preparation-report.v1",
+            "passed": True,
+            "review_state": "native_reviewed",
+            "fixture_sha256": entry["sha256"],
+            "checks": metadata,
+            "approval_reference": approval["approval_reference"],
+        },
+    )
+    print(f"Promoted {args.case_key} to native_reviewed.")
+    print(f"Validation report: {report_path}")
+    return 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    def common(subparser: argparse.ArgumentParser) -> None:
+        subparser.add_argument("--issue", type=int, required=True)
+        subparser.add_argument("--repo", default="mmaideveloper/aijurisdictionagents")
+        subparser.add_argument("--issue-json", type=Path)
+        subparser.add_argument(
+            "--registry", type=Path, default=Path("tests/modelsTesting/index.json")
+        )
+        subparser.add_argument("--fixture-root", type=Path, default=Path("tests/modelsTesting"))
+        subparser.add_argument(
+            "--quarantine-root", type=Path, default=Path("runs/model-validation")
+        )
+        subparser.add_argument("--run-id")
+
+    prepare = subparsers.add_parser("prepare", help="Validate and register technical_reviewed")
+    common(prepare)
+    prepare.add_argument("--zip", type=Path, required=True)
+    prepare.add_argument("--assertions-json", type=Path, required=True)
+    prepare.add_argument("--expected-scenario-id")
+    prepare.add_argument("--expected-production-route", default="azurefoundry")
+    prepare.add_argument("--stable-name")
+    prepare.add_argument("--retention-days", type=int, default=7)
+    prepare.set_defaults(handler=_prepare)
+
+    promote = subparsers.add_parser("promote", help="Promote after explicit human approval")
+    common(promote)
+    promote.add_argument("--case-key", required=True)
+    promote.add_argument("--human-approval-json", type=Path, required=True)
+    promote.set_defaults(handler=_promote)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if getattr(args, "retention_days", 1) < 1:
+        print("ERROR: retention_days_must_be_positive", file=sys.stderr)
+        return 2
+    try:
+        return int(args.handler(args))
+    except ValidationFailure as exc:
+        for error in exc.errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/modelsTesting/README.md
+++ b/tests/modelsTesting/README.md
@@ -21,17 +21,36 @@ Each case is stored as a ZIP under `cases/` and registered in `index.json`. The 
 - Legal-document fixtures must assert human review before signing, filing, or reliance.
 - If a fixture includes personal-looking values, mark them as synthetic in `index.json`.
 
-## Adding A Case
+## Adding a case
 
-1. Create or obtain a sanitized ZIP export for one scenario.
-2. Add the ZIP under `tests/modelsTesting/cases/`.
-3. Add one entry to `tests/modelsTesting/index.json`.
-4. Include expected answer/document assertions, similarity thresholds, and legal-document checks.
-5. Run:
+Provide the native ZIP and source issue to the repository-local skill:
+
+```text
+Use prepare-golden-test for issue #602 with the attached exported ZIP.
+```
+
+The skill copies the unchanged input to ignored
+`runs/model-validation/issue-<number>/<run-id>/`, validates it, and only then promotes it to
+`tests/modelsTesting/cases/` and updates `index.json`. Quarantine holds transient reports and
+PDF/text/first-page evidence; it is not a second golden database and must be deleted after
+review/merge or within seven days.
+
+Every new entry starts as `technical_reviewed` after automated safety, checksum, schema, document,
+PDF, source-fact, assertion, citation/warning, and persisted model-audit checks pass. A human must
+then review the genuine production case/export path and explicitly approve the baseline. The same
+PR receives a small promotion commit to `native_reviewed` and reruns validation. A manually
+assembled ZIP may remain a development seed or `technical_reviewed`, but it cannot become
+`native_reviewed` because it does not prove the production conversation, document, PDF, checksum,
+and model-audit path.
+
+Run:
 
 ```powershell
 .\conda\python.exe -m pytest tests\test_models_testing_fixtures.py
 ```
+
+The skill opens the dedicated PR and moves the issue to `In review`, but never merges. A later
+human-approved close-task workflow performs the merge.
 
 The runner in `aijurisdictionagents.golden_cases` supports both the native export from issue #471
 (`manifest.json`, `messages.jsonl`, `ai-model-audit.json`, documents and warnings) and the older
@@ -56,8 +75,8 @@ created through JurisDigta using the process below before marking scenario 01 le
    export manifest, transcript, model audit, warnings and generated PDF. Confirm
    `manifest.json.models_used` and `ai-model-audit.json.entries` identify the actual provider, model,
    route type and status used for the case. Do not enter these values manually.
-6. Store the reviewed ZIP under `cases/`, update its SHA-256 and rules in `index.json`, and set
-   `fixture_status` to `native_reviewed`.
+6. Use `prepare-golden-test` to create the initial `technical_reviewed` PR. Promote the same PR to
+   `native_reviewed` only after explicit human approval and a successful validation rerun.
 
 The export contains personal-looking synthetic data and model audit metadata, so retain only the
 minimum fixture, never credentials or payment details. Failed/live outputs belong under ignored

--- a/tests/modelsTesting/index.json
+++ b/tests/modelsTesting/index.json
@@ -22,6 +22,7 @@
       "parties",
       "operative_statement",
       "signature_block",
+      "limited_claim_scope",
       "human_review_disclosure"
     ]
   },

--- a/tests/test_models_testing_fixtures.py
+++ b/tests/test_models_testing_fixtures.py
@@ -1,7 +1,10 @@
 import hashlib
 import json
 from pathlib import Path
+from io import BytesIO
 from zipfile import ZipFile
+
+from pypdf import PdfReader
 
 
 FIXTURE_ROOT = Path(__file__).resolve().parent / "modelsTesting"
@@ -34,12 +37,30 @@ def test_model_testing_fixture_index_is_valid() -> None:
         assert case["expected_outputs"]["answer"]["similarity_min"] >= 0.7
         assert case["expected_outputs"]["document"]["similarity_min"] >= 0.8
         assert "signature_block" in case["expected_outputs"]["document"]["legal_document_markers"]
-        assert "human_review_disclosure" in case["expected_outputs"]["document"]["legal_document_markers"]
+        assert (
+            "human_review_disclosure"
+            in case["expected_outputs"]["document"]["legal_document_markers"]
+        )
+        if case["fixture_status"] in {"technical_reviewed", "native_reviewed"}:
+            assert case["actual_audited_routes"]
+            assert case["review"]["state"] == case["fixture_status"]
+            assert case["documents"]["generated_count"] >= 1
+            assert case["documents"]["rendered_pdf_count"] >= 1
+            assert case["source_facts"]
+            assert (
+                "limited_claim_scope"
+                in case["expected_outputs"]["document"]["legal_document_markers"]
+            )
+        if case["fixture_status"] == "technical_reviewed":
+            assert case["review"]["native_review_requires_human_approval"] is True
+        if case["fixture_status"] == "native_reviewed":
+            assert case["review"]["production_path_confirmed"] is True
+            assert case["review"]["approval_reference"].startswith("https://github.com/")
 
 
 def test_model_testing_fixture_zips_contain_required_case_files() -> None:
     index = json.loads(INDEX_PATH.read_text(encoding="utf-8"))
-    required_files = {
+    legacy_required_files = {
         "case-export.json",
         "fixed-assistant-answer.txt",
         "generated-document.txt",
@@ -51,7 +72,36 @@ def test_model_testing_fixture_zips_contain_required_case_files() -> None:
         zip_path = FIXTURE_ROOT / case["zip_path"]
         with ZipFile(zip_path) as archive:
             names = set(archive.namelist())
-            assert required_files.issubset(names)
+            if "manifest.json" in names:
+                assert {
+                    "manifest.json",
+                    "case.json",
+                    "messages.jsonl",
+                    "ai-model-audit.json",
+                    "citations.json",
+                    "warnings.json",
+                    "sha256sums.txt",
+                }.issubset(names)
+                manifest = json.loads(archive.read("manifest.json"))
+                assert manifest["schema"] == "jurisdigta.case-export.v1"
+                audit = json.loads(archive.read("ai-model-audit.json"))
+                assert audit["entries"]
+                for entry in audit["entries"]:
+                    assert all(
+                        entry.get(field) for field in ("provider", "model", "route_type", "status")
+                    )
+                generated = [
+                    item for item in manifest["documents"] if item["kind"] == "generated_document"
+                ]
+                assert generated
+                for document in generated:
+                    assert document["source_artifact"] in names
+                    rendered = document["rendered_pdf_artifact"]
+                    assert rendered in names
+                    assert PdfReader(BytesIO(archive.read(rendered)), strict=True).pages
+                continue
+
+            assert legacy_required_files.issubset(names)
             case_export = json.loads(archive.read("case-export.json").decode("utf-8-sig"))
             answer = archive.read("fixed-assistant-answer.txt").decode("utf-8-sig")
             document = archive.read("generated-document.txt").decode("utf-8-sig")

--- a/tests/test_prepare_golden_test_skill.py
+++ b/tests/test_prepare_golden_test_skill.py
@@ -1,0 +1,451 @@
+from __future__ import annotations
+
+from hashlib import sha256
+import io
+import json
+from pathlib import Path
+import subprocess
+import sys
+from zipfile import ZIP_DEFLATED, ZipFile
+
+from reportlab.pdfgen import canvas
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "prepare-golden-test"
+    / "scripts"
+    / "prepare_golden_test.py"
+)
+
+
+def _json_bytes(payload: object) -> bytes:
+    return (json.dumps(payload, ensure_ascii=False, indent=2) + "\n").encode()
+
+
+def _pdf_bytes() -> bytes:
+    output = io.BytesIO()
+    pdf = canvas.Canvas(output)
+    lines = [
+        "Potvrdenie o splateni pozicky",
+        "Peter Vzorovy a Jan Testovaci",
+        "3 000 EUR je uplne splatena.",
+        "Naroky z tejto konkretnej pozicky su vysporiadane.",
+        "Podpis veritela",
+        "Pred podpisom skontrolujte clovekom.",
+    ]
+    for index, line in enumerate(lines):
+        pdf.drawString(72, 760 - index * 24, line)
+    pdf.save()
+    return output.getvalue()
+
+
+def _write_export(path: Path, *, audit: bool = True, exported_by: str = "case-owner") -> None:
+    case_id = "golden-case-602"
+    audit_entries = (
+        [
+            {
+                "usage_id": "usage-1",
+                "case_id": case_id,
+                "provider": "azurefoundry",
+                "model": "gpt-4o-mini",
+                "route_type": "external",
+                "status": "success",
+            }
+        ]
+        if audit
+        else []
+    )
+    models_used = (
+        [
+            {
+                "provider": "azurefoundry",
+                "model": "gpt-4o-mini",
+                "route_type": "external",
+                "status": "success",
+                "usage_count": 1,
+            }
+        ]
+        if audit
+        else []
+    )
+    document_text = (
+        "Potvrdenie o splatení pôžičky\n"
+        "Veriteľ Peter Vzorový a dlžník Ján Testovací.\n"
+        "Suma 3 000 EUR je úplne splatená. Veriteľ nemá ďalšie nároky "
+        "z tejto konkrétnej pôžičky.\nPodpis veriteľa.\n"
+        "Pred podpisom skontrolujte človekom."
+    )
+    files = {
+        "case.json": _json_bytes(
+            {
+                "schema": "jurisdigta.case-export.case.v1",
+                "case_id": case_id,
+                "user_id": "synthetic-user-602",
+                "title": "Synthetic loan confirmation",
+            }
+        ),
+        "messages.jsonl": (
+            json.dumps(
+                {
+                    "role": "user",
+                    "content": "Priprav potvrdenie pre Petra Vzorového na 3 000 EUR.",
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
+            + json.dumps(
+                {
+                    "role": "assistant",
+                    "content": (
+                        "Potvrdenie pre Peter Vzorový na 3 000 EUR je pripravené; "
+                        "pred podpisom ho skontrolujte človekom."
+                    ),
+                },
+                ensure_ascii=False,
+            )
+        ).encode(),
+        "ai-model-audit.json": _json_bytes(
+            {
+                "schema": "jurisdigta.case-export.ai-model-audit.v1",
+                "case_id": case_id,
+                "entries": audit_entries,
+            }
+        ),
+        "citations.json": _json_bytes(
+            {
+                "schema": "jurisdigta.case-export.citations.v1",
+                "case_id": case_id,
+                "items": [{"source_type": "law", "title": "Synthetic legal source"}],
+            }
+        ),
+        "warnings.json": _json_bytes(
+            {
+                "schema": "jurisdigta.case-export.warnings.v1",
+                "case_id": case_id,
+                "items": [],
+            }
+        ),
+        "documents/generated/01-confirmation.txt": document_text.encode(),
+        "documents/generated/rendered-pdf/01-confirmation.pdf": _pdf_bytes(),
+    }
+    manifest = {
+        "schema": "jurisdigta.case-export.v1",
+        "generated_at": "2026-08-09T10:00:00Z",
+        "exported_by": exported_by,
+        "correlation_id": "synthetic-correlation-602",
+        "case_id": case_id,
+        "user_id": "synthetic-user-602",
+        "case_title": "Synthetic loan confirmation",
+        "artifact_count": len(files) + 2,
+        "message_count": 2,
+        "document_count": 1,
+        "ai_model_audit_count": len(audit_entries),
+        "models_used": models_used,
+        "citation_count": 1,
+        "documents": [
+            {
+                "doc_id": "document-1",
+                "kind": "generated_document",
+                "source_artifact": "documents/generated/01-confirmation.txt",
+                "rendered_pdf_artifact": ("documents/generated/rendered-pdf/01-confirmation.pdf"),
+            }
+        ],
+    }
+    files["manifest.json"] = _json_bytes(manifest)
+    files["sha256sums.txt"] = "".join(
+        f"{sha256(payload).hexdigest()}  {name}\n" for name, payload in sorted(files.items())
+    ).encode()
+    with ZipFile(path, "w", ZIP_DEFLATED) as archive:
+        for name, payload in sorted(files.items()):
+            archive.writestr(name, payload)
+
+
+def _write_inputs(root: Path) -> tuple[Path, Path, Path]:
+    issue = root / "issue.json"
+    issue.write_text(
+        json.dumps(
+            {
+                "number": 602,
+                "url": "https://github.com/mmaideveloper/aijurisdictionagents/issues/602",
+                "title": "Synthetic golden case",
+                "body": (
+                    "Všetky údaje sú fiktívne a syntetické. Peter Vzorový prijal "
+                    "3 000 EUR od Jána Testovacieho. Má ísť o potvrdenie, že suma je "
+                    "úplne splatená iba z tejto konkrétnej pôžičky, s podpisom a "
+                    "kontrolou človekom."
+                ),
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    assertions = root / "assertions.json"
+    assertions.write_text(
+        json.dumps(
+            {
+                "case_key": "issue-602-private-loan-confirmation",
+                "scenario_id": "01-private-loan-payment-confirmation",
+                "language": "sk-SK",
+                "country": "SK",
+                "category": "legal_document_generation",
+                "fixture_purpose": "Validate a synthetic private-loan payment confirmation.",
+                "source_facts": ["Peter Vzorový", "3 000 EUR", "úplne splatená"],
+                "answer": {
+                    "must_contain": ["Peter Vzorový", "3 000 EUR", "skontrolujte človekom"],
+                    "must_not_contain": ["CASE_UPDATE_JSON"],
+                    "similarity_min": 0.82,
+                },
+                "document": {
+                    "type": "private_loan_payment_confirmation",
+                    "must_contain": ["Ján Testovací", "3 000 EUR", "Podpis veriteľa"],
+                    "must_not_contain": ["všetkých budúcich nárokov"],
+                    "similarity_min": 0.9,
+                    "marker_phrases": {
+                        "document_title": ["Potvrdenie o splatení pôžičky"],
+                        "parties": ["Peter Vzorový", "Ján Testovací"],
+                        "operative_statement": ["úplne splatená"],
+                        "signature_block": ["Podpis veriteľa"],
+                        "limited_claim_scope": ["z tejto konkrétnej pôžičky"],
+                        "human_review_disclosure": ["skontrolujte človekom"],
+                    },
+                },
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    registry = root / "modelsTesting" / "index.json"
+    registry.parent.mkdir()
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": "jurisdigta.models-testing.index.v1",
+                "cases": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return issue, assertions, registry
+
+
+def _run(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+
+def _prepare_command(
+    root: Path, export: Path, issue: Path, assertions: Path, registry: Path, run_id: str
+) -> list[str]:
+    return [
+        "prepare",
+        "--issue",
+        "602",
+        "--zip",
+        str(export),
+        "--issue-json",
+        str(issue),
+        "--assertions-json",
+        str(assertions),
+        "--registry",
+        str(registry),
+        "--fixture-root",
+        str(root / "modelsTesting"),
+        "--quarantine-root",
+        str(root / "runs"),
+        "--run-id",
+        run_id,
+    ]
+
+
+def test_prepare_registers_unchanged_technical_fixture_and_pdf_evidence(tmp_path: Path) -> None:
+    issue, assertions, registry = _write_inputs(tmp_path)
+    export = tmp_path / "export.zip"
+    _write_export(export)
+
+    result = _run(
+        tmp_path,
+        *_prepare_command(tmp_path, export, issue, assertions, registry, "valid-run"),
+    )
+
+    assert result.returncode == 0, result.stderr
+    index = json.loads(registry.read_text(encoding="utf-8"))
+    entry = index["cases"][0]
+    fixture = tmp_path / "modelsTesting" / entry["zip_path"]
+    assert fixture.read_bytes() == export.read_bytes()
+    assert entry["fixture_status"] == "technical_reviewed"
+    assert entry["actual_audited_routes"][0]["provider"] == "azurefoundry"
+    assert entry["documents"]["rendered_pdf_count"] == 1
+    assert (tmp_path / "runs" / "issue-602" / "valid-run" / "validation-report.json").is_file()
+    assert (
+        tmp_path / "runs" / "issue-602" / "valid-run" / "evidence" / "document-01.pdf"
+    ).is_file()
+    assert (
+        tmp_path / "runs" / "issue-602" / "valid-run" / "evidence" / "document-01-first-page.png"
+    ).is_file()
+
+
+def test_prepare_rejects_archive_traversal_before_fixture_promotion(tmp_path: Path) -> None:
+    issue, assertions, registry = _write_inputs(tmp_path)
+    export = tmp_path / "unsafe.zip"
+    _write_export(export)
+    with ZipFile(export, "a", ZIP_DEFLATED) as archive:
+        archive.writestr("../outside.txt", "unsafe")
+
+    result = _run(
+        tmp_path,
+        *_prepare_command(tmp_path, export, issue, assertions, registry, "unsafe-run"),
+    )
+
+    assert result.returncode == 2
+    assert "unsafe_archive_path" in result.stderr
+    assert json.loads(registry.read_text(encoding="utf-8"))["cases"] == []
+    assert not (tmp_path / "modelsTesting" / "cases").exists()
+
+
+def test_prepare_rejects_missing_persisted_model_audit(tmp_path: Path) -> None:
+    issue, assertions, registry = _write_inputs(tmp_path)
+    export = tmp_path / "no-audit.zip"
+    _write_export(export, audit=False)
+
+    result = _run(
+        tmp_path,
+        *_prepare_command(tmp_path, export, issue, assertions, registry, "no-audit-run"),
+    )
+
+    assert result.returncode == 2
+    assert "model_audit_missing" in result.stderr
+    assert json.loads(registry.read_text(encoding="utf-8"))["cases"] == []
+
+
+def test_promote_requires_explicit_human_approval_and_revalidates(tmp_path: Path) -> None:
+    issue, assertions, registry = _write_inputs(tmp_path)
+    export = tmp_path / "export.zip"
+    _write_export(export)
+    prepared = _run(
+        tmp_path,
+        *_prepare_command(tmp_path, export, issue, assertions, registry, "prepare-run"),
+    )
+    assert prepared.returncode == 0, prepared.stderr
+
+    missing = _run(
+        tmp_path,
+        "promote",
+        "--issue",
+        "602",
+        "--case-key",
+        "issue-602-private-loan-confirmation",
+        "--issue-json",
+        str(issue),
+        "--human-approval-json",
+        str(tmp_path / "missing-approval.json"),
+        "--registry",
+        str(registry),
+        "--fixture-root",
+        str(tmp_path / "modelsTesting"),
+        "--quarantine-root",
+        str(tmp_path / "runs"),
+    )
+    assert missing.returncode == 2
+    assert json.loads(registry.read_text(encoding="utf-8"))["cases"][0]["fixture_status"] == (
+        "technical_reviewed"
+    )
+
+    approval = tmp_path / "approval.json"
+    approval.write_text(
+        json.dumps(
+            {
+                "reviewer": "human-reviewer",
+                "approval_reference": (
+                    "https://github.com/mmaideveloper/aijurisdictionagents/pull/700"
+                    "#pullrequestreview-123"
+                ),
+                "approved_at": "2026-08-09T12:00:00Z",
+                "production_path_confirmed": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    promoted = _run(
+        tmp_path,
+        "promote",
+        "--issue",
+        "602",
+        "--case-key",
+        "issue-602-private-loan-confirmation",
+        "--issue-json",
+        str(issue),
+        "--human-approval-json",
+        str(approval),
+        "--registry",
+        str(registry),
+        "--fixture-root",
+        str(tmp_path / "modelsTesting"),
+        "--quarantine-root",
+        str(tmp_path / "runs"),
+        "--run-id",
+        "human-approved",
+    )
+    assert promoted.returncode == 0, promoted.stderr
+    entry = json.loads(registry.read_text(encoding="utf-8"))["cases"][0]
+    assert entry["fixture_status"] == "native_reviewed"
+    assert entry["review"]["human_reviewer"] == "human-reviewer"
+
+
+def test_manually_assembled_export_cannot_become_native_reviewed(tmp_path: Path) -> None:
+    issue, assertions, registry = _write_inputs(tmp_path)
+    export = tmp_path / "manual-export.zip"
+    _write_export(export, exported_by="manually-assembled")
+    prepared = _run(
+        tmp_path,
+        *_prepare_command(tmp_path, export, issue, assertions, registry, "manual-prepare"),
+    )
+    assert prepared.returncode == 0, prepared.stderr
+
+    approval = tmp_path / "approval.json"
+    approval.write_text(
+        json.dumps(
+            {
+                "reviewer": "human-reviewer",
+                "approval_reference": (
+                    "https://github.com/mmaideveloper/aijurisdictionagents/pull/701"
+                    "#pullrequestreview-124"
+                ),
+                "approved_at": "2026-08-09T12:00:00Z",
+                "production_path_confirmed": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    promoted = _run(
+        tmp_path,
+        "promote",
+        "--issue",
+        "602",
+        "--case-key",
+        "issue-602-private-loan-confirmation",
+        "--issue-json",
+        str(issue),
+        "--human-approval-json",
+        str(approval),
+        "--registry",
+        str(registry),
+        "--fixture-root",
+        str(tmp_path / "modelsTesting"),
+        "--quarantine-root",
+        str(tmp_path / "runs"),
+        "--run-id",
+        "manual-human-approved",
+    )
+
+    assert promoted.returncode == 2
+    assert "native_production_export_provenance_missing" in promoted.stderr
+    entry = json.loads(registry.read_text(encoding="utf-8"))["cases"][0]
+    assert entry["fixture_status"] == "technical_reviewed"


### PR DESCRIPTION
## Summary

- add the repository-local `prepare-golden-test` skill and generated OpenAI interface metadata
- quarantine and deterministically validate native case-export ZIPs before tracked promotion
- derive model provider/model/route/status only from persisted audit data
- enforce `technical_reviewed` → explicit human approval → `native_reviewed` without automatic merge
- validate PDF structure/text and retain transient first-page evidence
- update golden-fixture tests, documentation, the project skill catalog, and the minimal demo

Issue #602 is covered by a representative native-export acceptance test; no manually assembled ZIP is promoted as native evidence.

## Validation

- skill `quick_validate.py`
- Ruff on the skill and focused tests
- MyPy on the deterministic Python validator
- 11 focused golden-case/fixture tests
- `python examples/minimal_demo.py`
- tracked pre-commit hook (Ruff + MyPy)

Closes #610