### PR TITLE
Fix Azure Foundry v1 client routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,10 +343,14 @@ To use OpenAI, set:
 To use Azure Foundry (Azure OpenAI), set:
 
 - `LLM_PROVIDER=azurefoundry`
-- `AZURE_OPENAI_ENDPOINT=https://YOUR_RESOURCE_NAME.openai.azure.com/`
+- `AZURE_OPENAI_ENDPOINT=https://YOUR_RESOURCE_NAME.openai.azure.com/` or a Microsoft Foundry project endpoint such as `https://YOUR_RESOURCE.services.ai.azure.com/api/projects/YOUR_PROJECT`
 - `AZURE_OPENAI_DEPLOYMENT=your_deployment_name`
 - `AZURE_OPENAI_API_KEY=...` (or `AZURE_OPENAI_AD_TOKEN=...`)
-- `AZURE_OPENAI_API_VERSION=2024-12-01-preview` (optional override; GPT-5-family routes use the Azure OpenAI v1 preview API)
+- `AZURE_OPENAI_API_VERSION=2024-12-01-preview` (optional override; GPT-5-family routes use the OpenAI-compatible `/openai/v1` path)
+
+GPT-5-family and explicit `v1`/`preview` routes use the standard OpenAI client against
+`<endpoint>/openai/v1` and never send the legacy `api-version` query parameter. Dated API
+versions continue to use the legacy Azure OpenAI client for backward compatibility.
 
 Or use the minimal example script:
 

--- a/docs/E2E_CONTRACT_TESTS.md
+++ b/docs/E2E_CONTRACT_TESTS.md
@@ -117,6 +117,27 @@ Set-Location frontend\aijurisdictionfronend
 npm run test:e2e -- golden-case-602-document-preview.spec.ts
 ```
 
+Run the opt-in issue #612 live browser regression against the production EU Azure Foundry
+project while keeping the API, frontend, database, files, and synthetic user local:
+
+```powershell
+.\scripts\run_issue_612_azure_foundry_e2e.ps1
+```
+
+The runner configures `azureFoundryEU / gpt-5-mini` at the project endpoint ending in
+`/api/projects/documentprocessing`, then verifies that the streamed reply succeeds through the
+OpenAI-compatible `/openai/v1` client without a legacy `api-version` query parameter. It refuses
+mock fallback and fails when the production credential is unavailable. When a static Foundry key
+or token is not configured, the runner authenticates only as the repository service principal and
+uses a short-lived Cognitive Services token; it never uses the currently signed-in Azure user.
+Evidence is written under
+`runs/e2e/issue-612-azure-foundry-v1/<UTC timestamp>/`: a sanitized JSON manifest and a final-state
+screenshot. The isolated SQLite database and files are kept under
+`runs/storage/issue-612-azure-foundry-e2e/<UTC timestamp>/`. Both paths are Git-ignored and must be
+removed within seven days. The request uses a generated identity and a fixed connectivity marker;
+no customer, legal-case, password, token, or credential content is retained. The response remains
+an AI draft requiring human review and is not used for an automated legal decision.
+
 The live-provider check must retain the configured provider gate. Missing Ollama Cloud or
 Azure Foundry credentials must not be replaced with `mock`; deterministic route fixtures are
 used only for browser/UI regression coverage.

--- a/docs/E2E_CONTRACT_TESTS.md
+++ b/docs/E2E_CONTRACT_TESTS.md
@@ -124,6 +124,12 @@ project while keeping the API, frontend, database, files, and synthetic user loc
 .\scripts\run_issue_612_azure_foundry_e2e.ps1
 ```
 
+For explicitly temporary Azure infrastructure credentials stored in the ignored `.env.dev`, use:
+
+```powershell
+.\scripts\run_issue_612_azure_foundry_e2e.ps1 -EnvFilePath .env.dev
+```
+
 The runner configures `azureFoundryEU / gpt-5-mini` at the project endpoint ending in
 `/api/projects/documentprocessing`, then verifies that the streamed reply succeeds through the
 OpenAI-compatible `/openai/v1` client without a legacy `api-version` query parameter. It refuses

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -27,6 +27,11 @@ print(
     "/openai/v1 path without a legacy api-version query parameter."
 )
 print(
+    "azure_foundry_v1_live_e2e => run scripts/run_issue_612_azure_foundry_e2e.ps1; "
+    "it uses isolated synthetic local state, the production EU Foundry connection, and "
+    "retains a sanitized final screenshot for at most seven days."
+)
+print(
     "web_mfa_reuse => MFA_REUSE_WINDOW_HOURS=12 skips repeat MFA for 12 hours after successful "
     "verification on a verified browser; a new browser for a TOTP-enabled account offers both "
     "authenticator and email verification, while logout still ends the active session."

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -23,6 +23,10 @@ print(
     "startup; effective/selectable request dependencies are read-only to avoid PostgreSQL deadlocks."
 )
 print(
+    "azure_foundry_v1 => GPT-5 and explicit v1/preview routes use the OpenAI-compatible "
+    "/openai/v1 path without a legacy api-version query parameter."
+)
+print(
     "web_mfa_reuse => MFA_REUSE_WINDOW_HOURS=12 skips repeat MFA for 12 hours after successful "
     "verification on a verified browser; a new browser for a TOTP-enabled account offers both "
     "authenticator and email verification, while logout still ends the active session."

--- a/frontend/aijurisdictionfronend/e2e/issue-612-azure-foundry-v1-live.spec.ts
+++ b/frontend/aijurisdictionfronend/e2e/issue-612-azure-foundry-v1-live.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs";
+
+type LiveE2EManifest = {
+  synthetic_only: boolean;
+  user: { userId: string; email: string; name: string };
+  case_id: string;
+  provider: string;
+  model: string;
+  model_profile_id: string;
+};
+
+const manifestPath = process.env.ISSUE_612_E2E_MANIFEST?.trim();
+const screenshotPath = process.env.ISSUE_612_E2E_SCREENSHOT?.trim();
+const hasLiveSetup = Boolean(manifestPath && screenshotPath && fs.existsSync(manifestPath));
+
+test.skip(!hasLiveSetup, "Run scripts/run_issue_612_azure_foundry_e2e.ps1 to prepare live synthetic state.");
+test.setTimeout(180_000);
+
+test("streams a production Azure Foundry gpt-5-mini reply without api-version on /v1", async ({ page }) => {
+  const manifest = JSON.parse(fs.readFileSync(manifestPath!, "utf-8")) as LiveE2EManifest;
+  expect(manifest.synthetic_only).toBe(true);
+
+  await page.addInitScript((user) => {
+    window.sessionStorage.setItem("jurisdigta.web.auth.user.v1", JSON.stringify(user));
+    window.localStorage.setItem("aj_frontend_lang", "sk");
+  }, manifest.user);
+
+  await page.goto("/app/assistant", { waitUntil: "domcontentloaded" });
+  await expect(page.locator(".case-item").filter({ hasText: "Issue 612 Azure Foundry v1 E2E" })).toBeVisible();
+  await expect(page.locator(".assistant-model-disclosure")).toContainText(manifest.provider);
+  await expect(page.locator(".assistant-model-disclosure")).toContainText(manifest.model);
+
+  const prompt =
+    "This is a synthetic connectivity test with no legal or personal data. " +
+    "Reply with the exact marker ISSUE-612-AZURE-FOUNDRY-V1-OK and one short sentence.";
+  await page.locator(".assistant-composer__input").fill(prompt);
+  await page.locator(".assistant-composer__send").click();
+
+  const thread = page.locator(".assistant-thread__viewport");
+  await expect(thread).toContainText("ISSUE-612-AZURE-FOUNDRY-V1-OK", { timeout: 160_000 });
+  await expect(thread).not.toContainText("api-version query parameter is not allowed");
+  await expect(thread).not.toContainText("Asistent nemohol dokončiť požiadavku");
+
+  await page.screenshot({ path: screenshotPath!, fullPage: true });
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aijurisdictionagents"
-version = "1.0.260431"
+version = "1.0.260432"
 description = "Multi-agent legal discussion scaffold."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/prepare_issue_612_azure_foundry_e2e.py
+++ b/scripts/prepare_issue_612_azure_foundry_e2e.py
@@ -1,0 +1,140 @@
+"""Prepare isolated synthetic state for the issue #612 live Azure Foundry E2E."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from aijurisdictionagents.api_db import ApiDatabaseStore
+
+
+DEFAULT_ENDPOINT = (
+    "https://ai-mmatonok4721ai562138909778.services.ai.azure.com/"
+    "api/projects/documentprocessing"
+)
+DEFAULT_MODEL = "gpt-5-mini"
+SYNTHETIC_EMAIL = "issue-612-foundry-e2e@example.test"
+SYNTHETIC_PASSWORD = "Issue-612-synthetic-only!"
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-path", type=Path, required=True)
+    parser.add_argument("--blob-root", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--endpoint", default=DEFAULT_ENDPOINT)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _arguments()
+    load_dotenv(args.repo_root / ".env", override=False)
+
+    api_key = os.getenv("AZURE_OPENAI_API_KEY", "").strip()
+    ad_token = os.getenv("AZURE_OPENAI_AD_TOKEN", "").strip()
+    if not api_key and not ad_token:
+        raise RuntimeError(
+            "Production Azure Foundry E2E requires AZURE_OPENAI_API_KEY or "
+            "AZURE_OPENAI_AD_TOKEN; mock fallback is forbidden."
+        )
+
+    endpoint = args.endpoint.strip().rstrip(",/")
+    model = args.model.strip()
+    if not endpoint.startswith("https://"):
+        raise ValueError("Azure Foundry endpoint must use HTTPS.")
+    if not model:
+        raise ValueError("Azure Foundry model is required.")
+
+    store = ApiDatabaseStore(db_path=args.db_path, blob_root=args.blob_root)
+    store.initialize()
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    user = store.create_user(
+        email=SYNTHETIC_EMAIL,
+        password=SYNTHETIC_PASSWORD,
+        full_name="Issue 612 Synthetic E2E User",
+        data_processing_consent_at=now,
+        data_processing_consent_version="issue-612-live-e2e-v1",
+    )
+    store.update_admin_user(user_id=user.user_id, role="admin", is_enabled=True)
+
+    provider = store.upsert_ai_model_provider(
+        provider_id="azure_foundry",
+        provider_code="azure_foundry",
+        provider_type="azurefoundry",
+        display_name="azureFoundryEU",
+        base_url=endpoint,
+        api_version="",
+        region="westeurope",
+        data_zone="eu",
+        is_external=True,
+        is_local=False,
+        health_check_url=endpoint,
+        enabled=True,
+    )
+    profile_id = "issue_612_azure_foundry_gpt_5_mini"
+    store.upsert_ai_model_profile(
+        model_profile_id=profile_id,
+        provider_id=provider.provider_id,
+        model_code=model,
+        deployment_name=model,
+        context_window_tokens=128_000,
+        eu_data_zone_capable=True,
+        enabled=True,
+    )
+    secret_type = "api_key" if api_key else "azure_ad_token"
+    store.upsert_ai_model_credential(
+        provider_id=provider.provider_id,
+        secret_value=api_key or ad_token,
+        credential_name="issue-612-live-e2e",
+        secret_type=secret_type,
+        enabled=True,
+    )
+    store.upsert_ai_model_user_override(
+        user_id=user.user_id,
+        model_profile_id=profile_id,
+        admin_user_id=user.user_id,
+        reason="Synthetic live E2E validation for issue #612.",
+    )
+    case = store.create_case(
+        user_id=user.user_id,
+        company_id=None,
+        title="Issue 612 Azure Foundry v1 E2E",
+    )
+
+    args.manifest.parent.mkdir(parents=True, exist_ok=True)
+    args.manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "created_at": now,
+                "synthetic_only": True,
+                "user": {
+                    "userId": user.user_id,
+                    "email": user.email,
+                    "name": user.full_name,
+                },
+                "case_id": case.case_id,
+                "provider": "azureFoundryEU",
+                "endpoint": endpoint,
+                "model": model,
+                "model_profile_id": profile_id,
+                "credential_type": secret_type,
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    print(f"Prepared sanitized E2E manifest: {args.manifest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_issue_612_azure_foundry_e2e.ps1
+++ b/scripts/run_issue_612_azure_foundry_e2e.ps1
@@ -1,0 +1,186 @@
+param(
+    [string]$Endpoint = "https://ai-mmatonok4721ai562138909778.services.ai.azure.com/api/projects/documentprocessing",
+    [string]$Model = "gpt-5-mini",
+    [int]$ApiPort = 8080,
+    [int]$FrontendPort = 5189
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+
+function Import-SelectedDotEnvValues {
+    param([string]$Path, [string[]]$Names)
+    if (-not (Test-Path $Path)) {
+        return
+    }
+    foreach ($line in Get-Content $Path) {
+        $trimmed = $line.Trim()
+        if (-not $trimmed -or $trimmed.StartsWith("#") -or -not $trimmed.Contains("=")) {
+            continue
+        }
+        $parts = $trimmed.Split("=", 2)
+        $name = $parts[0].Trim()
+        if ($name -notin $Names -or [Environment]::GetEnvironmentVariable($name, "Process")) {
+            continue
+        }
+        $value = $parts[1].Trim().Trim('"').Trim("'")
+        [Environment]::SetEnvironmentVariable($name, $value, "Process")
+    }
+}
+
+Import-SelectedDotEnvValues -Path (Join-Path $repoRoot ".env") -Names @(
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_OPENAI_AD_TOKEN",
+    "AZURE_CLIENT_ID",
+    "AZURE_CLIENT_SECRET",
+    "AZURE_TENANT_ID",
+    "AZURE_SUBSCRIPTION_ID"
+)
+
+if (-not $env:AZURE_OPENAI_API_KEY -and -not $env:AZURE_OPENAI_AD_TOKEN) {
+    if (Get-Command az -ErrorAction SilentlyContinue) {
+        & (Join-Path $repoRoot "infra\scripts\login_service_principal.ps1")
+        if ($LASTEXITCODE -ne 0) {
+            throw "Azure service-principal login failed."
+        }
+        $env:AZURE_OPENAI_AD_TOKEN = az account get-access-token `
+            --resource https://cognitiveservices.azure.com `
+            --query accessToken `
+            --output tsv `
+            --only-show-errors
+    } else {
+        foreach ($requiredName in @("AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_TENANT_ID")) {
+            if (-not [Environment]::GetEnvironmentVariable($requiredName, "Process")) {
+                throw "$requiredName is required to obtain a short-lived production Foundry token."
+            }
+        }
+        $tokenResponse = Invoke-RestMethod `
+            -Method Post `
+            -Uri "https://login.microsoftonline.com/$env:AZURE_TENANT_ID/oauth2/v2.0/token" `
+            -ContentType "application/x-www-form-urlencoded" `
+            -Body @{
+                client_id = $env:AZURE_CLIENT_ID
+                client_secret = $env:AZURE_CLIENT_SECRET
+                grant_type = "client_credentials"
+                scope = "https://cognitiveservices.azure.com/.default"
+            }
+        $env:AZURE_OPENAI_AD_TOKEN = $tokenResponse.access_token
+    }
+    if (-not $env:AZURE_OPENAI_AD_TOKEN) {
+        throw "A short-lived Azure Foundry access token could not be obtained."
+    }
+}
+
+$pythonCandidates = @(
+    (Join-Path $repoRoot "conda\python.exe"),
+    (Join-Path $repoRoot ".conda\python.exe"),
+    (Join-Path $repoRoot "conda\Scripts\python.exe"),
+    (Join-Path $repoRoot ".conda\Scripts\python.exe")
+)
+$python = $pythonCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $python) {
+    throw "Task conda Python was not found. Create the task worktree runtime first."
+}
+if (-not (Get-Command npx -ErrorAction SilentlyContinue)) {
+    throw "npx is required for the Playwright E2E."
+}
+
+try {
+    Invoke-WebRequest -UseBasicParsing -Uri "http://127.0.0.1:$ApiPort/health" -TimeoutSec 2 | Out-Null
+    throw "Port $ApiPort already hosts an API. Stop it so this test can use its isolated database."
+} catch {
+    if ($_.Exception.Message -like "Port $ApiPort already hosts*") {
+        throw
+    }
+}
+
+$runId = (Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ")
+$runRoot = Join-Path $repoRoot "runs\e2e\issue-612-azure-foundry-v1\$runId"
+$storageRoot = Join-Path $repoRoot "runs\storage\issue-612-azure-foundry-e2e\$runId"
+$dbPath = Join-Path $storageRoot "sqlite\api.sqlite3"
+$blobRoot = Join-Path $storageRoot "files"
+$manifestPath = Join-Path $runRoot "manifest.json"
+$screenshotPath = Join-Path $runRoot "01-final-success.png"
+New-Item -ItemType Directory -Path $runRoot -Force | Out-Null
+
+$env:DB_OPTION = "local"
+$env:STORAGE_OPTION = "local"
+$env:DB_LOCAL = $dbPath
+$env:STORE_LOCAL = $blobRoot
+$env:AZURE_OPENAI_ENDPOINT = $Endpoint.TrimEnd([char[]]",/")
+$env:AZURE_OPENAI_DEPLOYMENT = $Model
+$env:JURISDIGTA_ADMIN_EMAILS = "issue-612-foundry-e2e@example.test"
+$env:JURISDIGTA_UNLIMITED_ACCESS_EMAILS = "issue-612-foundry-e2e@example.test"
+$env:ISSUE_612_E2E_MANIFEST = $manifestPath
+$env:ISSUE_612_E2E_SCREENSHOT = $screenshotPath
+$env:VITE_API_BASE_URL = "http://127.0.0.1:$ApiPort"
+$env:VITE_API_KEY = "aijuris"
+$env:FRONTEND_E2E_PORT = "$FrontendPort"
+
+$apiPid = $null
+try {
+    & $python (Join-Path $repoRoot "scripts\prepare_issue_612_azure_foundry_e2e.py") `
+        --db-path $dbPath `
+        --blob-root $blobRoot `
+        --manifest $manifestPath `
+        --endpoint $env:AZURE_OPENAI_ENDPOINT `
+        --model $Model `
+        --repo-root $repoRoot
+    if ($LASTEXITCODE -ne 0) {
+        throw "Synthetic E2E state preparation failed."
+    }
+
+    & (Join-Path $repoRoot "skills\start-api\scripts\start_api.ps1") `
+        -LlmProvider azurefoundry `
+        -Port $ApiPort `
+        -DatabaseOption local `
+        -StorageOption local `
+        -DbLocal $dbPath `
+        -StoreLocal $blobRoot `
+        -Background `
+        -SkipLogTail
+    $pidFile = Join-Path $repoRoot "runs\api-local.pid"
+    $apiPid = [int](Get-Content $pidFile -Raw)
+
+    $apiReady = $false
+    foreach ($attempt in 1..30) {
+        try {
+            $health = Invoke-WebRequest -UseBasicParsing -Uri "http://127.0.0.1:$ApiPort/health" -TimeoutSec 2
+            if ($health.StatusCode -eq 200) {
+                $apiReady = $true
+                break
+            }
+        } catch {
+            Start-Sleep -Seconds 1
+        }
+    }
+    if (-not $apiReady) {
+        throw "Local issue #612 API did not become healthy on port $ApiPort."
+    }
+
+    $frontendDir = Join-Path $repoRoot "frontend\aijurisdictionfronend"
+    if (-not (Test-Path (Join-Path $frontendDir "node_modules\.bin\playwright.cmd"))) {
+        npm --prefix $frontendDir ci
+        if ($LASTEXITCODE -ne 0) {
+            throw "Frontend npm install failed."
+        }
+    }
+    Push-Location $frontendDir
+    try {
+        npx playwright test e2e/issue-612-azure-foundry-v1-live.spec.ts --project=chromium
+        if ($LASTEXITCODE -ne 0) {
+            throw "Issue #612 Azure Foundry E2E failed."
+        }
+    } finally {
+        Pop-Location
+    }
+
+    Write-Output "Issue #612 production Azure Foundry E2E passed."
+    Write-Output "Sanitized manifest: $manifestPath"
+    Write-Output "Final screenshot: $screenshotPath"
+    Write-Output "Retention: remove this synthetic run after at most 7 days."
+} finally {
+    if ($apiPid -and (Get-Process -Id $apiPid -ErrorAction SilentlyContinue)) {
+        Stop-Process -Id $apiPid -Force
+    }
+}

--- a/scripts/run_issue_612_azure_foundry_e2e.ps1
+++ b/scripts/run_issue_612_azure_foundry_e2e.ps1
@@ -1,6 +1,7 @@
 param(
     [string]$Endpoint = "https://ai-mmatonok4721ai562138909778.services.ai.azure.com/api/projects/documentprocessing",
     [string]$Model = "gpt-5-mini",
+    [string]$EnvFilePath = ".env",
     [int]$ApiPort = 8080,
     [int]$FrontendPort = 5189
 )
@@ -28,7 +29,12 @@ function Import-SelectedDotEnvValues {
     }
 }
 
-Import-SelectedDotEnvValues -Path (Join-Path $repoRoot ".env") -Names @(
+$resolvedEnvFilePath = if ([IO.Path]::IsPathRooted($EnvFilePath)) {
+    $EnvFilePath
+} else {
+    Join-Path $repoRoot $EnvFilePath
+}
+Import-SelectedDotEnvValues -Path $resolvedEnvFilePath -Names @(
     "AZURE_OPENAI_API_KEY",
     "AZURE_OPENAI_AD_TOKEN",
     "AZURE_CLIENT_ID",
@@ -39,7 +45,7 @@ Import-SelectedDotEnvValues -Path (Join-Path $repoRoot ".env") -Names @(
 
 if (-not $env:AZURE_OPENAI_API_KEY -and -not $env:AZURE_OPENAI_AD_TOKEN) {
     if (Get-Command az -ErrorAction SilentlyContinue) {
-        & (Join-Path $repoRoot "infra\scripts\login_service_principal.ps1")
+        & (Join-Path $repoRoot "infra\scripts\login_service_principal.ps1") -EnvFilePath $EnvFilePath
         if ($LASTEXITCODE -ne 0) {
             throw "Azure service-principal login failed."
         }

--- a/src/aijurisdictionagents/__init__.py
+++ b/src/aijurisdictionagents/__init__.py
@@ -1,3 +1,3 @@
 """AI jurisdiction agents package."""
 
-__version__ = "1.0.260431"
+__version__ = "1.0.260432"

--- a/src/aijurisdictionagents/llm/azure_foundry_client.py
+++ b/src/aijurisdictionagents/llm/azure_foundry_client.py
@@ -5,10 +5,11 @@ from dataclasses import dataclass
 import logging
 import ssl
 import time
-from typing import Iterable, Sequence
+from typing import Any, Iterable, Sequence, cast
 
 import httpx
-from openai import APITimeoutError, AzureOpenAI
+from openai import APITimeoutError, AzureOpenAI, OpenAI
+from openai.types.chat import ChatCompletionMessageParam
 import truststore
 
 from .base import ModelProcessingTimeout, elapsed_seconds, log_llm_request, log_llm_response
@@ -32,16 +33,23 @@ class AzureFoundryClient:
         self._config = config
         _clear_blank_azure_openai_auth_env()
         http_client = _build_system_trust_http_client()
-        client_kwargs = _build_azure_client_kwargs(config)
-        if config.azure_ad_token:
+        if _uses_v1_api(config.api_version):
+            self._client: OpenAI | AzureOpenAI = OpenAI(
+                base_url=_build_v1_base_url(config.endpoint),
+                api_key=config.azure_ad_token or config.api_key,
+                http_client=http_client,
+            )
+        elif config.azure_ad_token:
             self._client = AzureOpenAI(
-                **client_kwargs,
+                azure_endpoint=config.endpoint,
+                api_version=config.api_version.strip(),
                 azure_ad_token=config.azure_ad_token,
                 http_client=http_client,
             )
         else:
             self._client = AzureOpenAI(
-                **client_kwargs,
+                azure_endpoint=config.endpoint,
+                api_version=config.api_version.strip(),
                 api_key=config.api_key,
                 http_client=http_client,
             )
@@ -53,7 +61,7 @@ class AzureFoundryClient:
         conversation: Sequence[Message],
         documents: Sequence[Document],
     ) -> str:
-        messages = [{"role": "system", "content": system_prompt}]
+        messages: list[dict[str, Any]] = [{"role": "system", "content": system_prompt}]
         if documents:
             messages.append({"role": "system", "content": _render_documents(documents)})
 
@@ -76,7 +84,7 @@ class AzureFoundryClient:
             response = self._client.chat.completions.create(
                 model=self._config.deployment,
                 temperature=self._config.temperature,
-                messages=messages,
+                messages=cast(Iterable[ChatCompletionMessageParam], messages),
             )
         except APITimeoutError as exc:
             raise ModelProcessingTimeout(
@@ -156,17 +164,15 @@ def _clear_blank_azure_openai_auth_env() -> None:
     _optional_env("AZURE_OPENAI_AD_TOKEN")
 
 
-def _build_azure_client_kwargs(config: AzureFoundryConfig) -> dict[str, str]:
-    api_version = config.api_version.strip()
-    if api_version.lower() in {"v1", "preview"}:
-        return {
-            "base_url": f"{config.endpoint.rstrip('/')}/openai/v1",
-            "api_version": "preview",
-        }
-    return {
-        "azure_endpoint": config.endpoint,
-        "api_version": api_version,
-    }
+def _uses_v1_api(api_version: str) -> bool:
+    return api_version.strip().lower() in {"v1", "preview"}
+
+
+def _build_v1_base_url(endpoint: str) -> str:
+    normalized = endpoint.rstrip("/")
+    if normalized.endswith("/openai/v1"):
+        return normalized
+    return f"{normalized}/openai/v1"
 
 
 def _build_system_trust_http_client() -> httpx.Client:
@@ -174,7 +180,7 @@ def _build_system_trust_http_client() -> httpx.Client:
     return httpx.Client(verify=context)
 
 
-def _client_timeout_seconds(client: AzureOpenAI) -> float | None:
+def _client_timeout_seconds(client: OpenAI | AzureOpenAI) -> float | None:
     timeout = getattr(client, "timeout", None)
     read_timeout = getattr(timeout, "read", None)
     return float(read_timeout) if isinstance(read_timeout, (int, float)) else None

--- a/tests/test_azure_foundry_client.py
+++ b/tests/test_azure_foundry_client.py
@@ -43,17 +43,22 @@ def test_azure_foundry_client_clears_blank_sdk_auth_env(monkeypatch) -> None:
     assert os.getenv("AZURE_OPENAI_AD_TOKEN") is None
 
 
-def test_azure_foundry_client_uses_v1_preview_base_url_for_preview_api(monkeypatch) -> None:
+def test_azure_foundry_client_uses_openai_client_for_project_v1_api_key(monkeypatch) -> None:
     captured: dict[str, str] = {}
 
-    class FakeAzureOpenAI:
+    class FakeOpenAI:
         def __init__(self, **kwargs: str) -> None:
             captured.update(kwargs)
 
-    monkeypatch.setattr(azure_foundry_client, "AzureOpenAI", FakeAzureOpenAI)
+    class UnexpectedAzureOpenAI:
+        def __init__(self, **kwargs: str) -> None:
+            raise AssertionError(f"AzureOpenAI must not be used for v1: {kwargs}")
+
+    monkeypatch.setattr(azure_foundry_client, "OpenAI", FakeOpenAI)
+    monkeypatch.setattr(azure_foundry_client, "AzureOpenAI", UnexpectedAzureOpenAI)
 
     config = azure_foundry_client.AzureFoundryConfig(
-        endpoint="https://example.openai.azure.com/",
+        endpoint="https://example.services.ai.azure.com/api/projects/legal/",
         deployment="gpt-5-mini",
         api_version="preview",
         temperature=0.2,
@@ -63,6 +68,66 @@ def test_azure_foundry_client_uses_v1_preview_base_url_for_preview_api(monkeypat
 
     azure_foundry_client.AzureFoundryClient(config)
 
-    assert captured["base_url"] == "https://example.openai.azure.com/openai/v1"
-    assert captured["api_version"] == "preview"
+    assert captured["base_url"] == (
+        "https://example.services.ai.azure.com/api/projects/legal/openai/v1"
+    )
+    assert captured["api_key"] == "test-key"
+    assert "api_version" not in captured
     assert "azure_endpoint" not in captured
+
+
+def test_azure_foundry_client_uses_bearer_token_as_v1_api_key(monkeypatch) -> None:
+    captured: dict[str, str] = {}
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs: str) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(azure_foundry_client, "OpenAI", FakeOpenAI)
+
+    config = azure_foundry_client.AzureFoundryConfig(
+        endpoint="https://example.openai.azure.com/openai/v1/",
+        deployment="gpt-5-mini",
+        api_version="v1",
+        temperature=0.2,
+        api_key=None,
+        azure_ad_token="test-entra-token",
+    )
+
+    azure_foundry_client.AzureFoundryClient(config)
+
+    assert captured["base_url"] == "https://example.openai.azure.com/openai/v1"
+    assert captured["api_key"] == "test-entra-token"
+    assert "api_version" not in captured
+    assert "azure_ad_token" not in captured
+
+
+def test_azure_foundry_client_keeps_legacy_dated_azure_api(monkeypatch) -> None:
+    captured: dict[str, str] = {}
+
+    class FakeAzureOpenAI:
+        def __init__(self, **kwargs: str) -> None:
+            captured.update(kwargs)
+
+    class UnexpectedOpenAI:
+        def __init__(self, **kwargs: str) -> None:
+            raise AssertionError(f"OpenAI must not be used for a dated Azure API: {kwargs}")
+
+    monkeypatch.setattr(azure_foundry_client, "AzureOpenAI", FakeAzureOpenAI)
+    monkeypatch.setattr(azure_foundry_client, "OpenAI", UnexpectedOpenAI)
+
+    config = azure_foundry_client.AzureFoundryConfig(
+        endpoint="https://example.openai.azure.com/",
+        deployment="gpt-4o-mini",
+        api_version="2024-12-01-preview",
+        temperature=0.2,
+        api_key="test-key",
+        azure_ad_token=None,
+    )
+
+    azure_foundry_client.AzureFoundryClient(config)
+
+    assert captured["azure_endpoint"] == "https://example.openai.azure.com/"
+    assert captured["api_version"] == "2024-12-01-preview"
+    assert captured["api_key"] == "test-key"
+    assert "base_url" not in captured


### PR DESCRIPTION
## Summary

- use the standard `OpenAI` client for Microsoft Foundry/Azure OpenAI `/openai/v1` routes
- stop sending the forbidden `api-version` query parameter for GPT-5, `v1`, and `preview` routes
- preserve legacy `AzureOpenAI` behavior for dated Azure API versions
- preserve API-key and Microsoft Entra bearer-token authentication
- document Foundry project endpoints and update the minimal runnable example
- bump the system core revision from `1.0.260431` to `1.0.260432`

## Root cause

The backend combined a modern `<endpoint>/openai/v1` base URL with `AzureOpenAI(api_version="preview")`. The SDK appended `?api-version=preview`, which the v1 endpoint rejects with HTTP 400.

## Validation

- `python -m pytest tests/test_azure_foundry_client.py -q`
- `python -m ruff check src/aijurisdictionagents/llm/azure_foundry_client.py tests/test_azure_foundry_client.py examples/minimal_demo.py`
- `python -m mypy src/aijurisdictionagents/llm/azure_foundry_client.py`
- `python examples/minimal_demo.py`

## Compliance

No new personal data is collected, retained, or logged. Provider selection, consent controls, auditability, and human-oversight behavior are unchanged.

Closes #612