### PR TITLE
Add architecture change workflow skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,19 @@ If the user asks to close a task:
 
 Custom project skills:
 
+- `architecture-change` at `skills/architecture-change/SKILL.md`
+  - Purpose: coordinate the architecture lifecycle from use case through implementation readiness and conformance review.
+- `generate-use-case` at `skills/generate-use-case/SKILL.md`
+  - Purpose: create and refine traceable, stakeholder-reviewed use cases.
+- `generate-add` at `skills/generate-add/SKILL.md`
+  - Purpose: create Architecture Design Documents from reviewed use cases and repository evidence.
+- `generate-c4` at `skills/generate-c4/SKILL.md`
+  - Purpose: create source-backed C4 context, container, component, dynamic, deployment, and supporting views.
+- `generate-adr` at `skills/generate-adr/SKILL.md`
+  - Purpose: create, update, review, and supersede Architecture Decision Records.
+- `review-architecture-conformance` at `skills/review-architecture-conformance/SKILL.md`
+  - Purpose: review implementations against authoritative use cases, ADDs, C4 views, and ADRs.
+
 - `idea-task` at `skills/idea-task/SKILL.md`
   - Purpose: shape rough ideas into a validated draft, ask focused clarification questions, and hand off to `prepare-task` once ready.
   - Script: chat skill (no launcher script required)

--- a/docs/ARCHITECTURE_CHANGE_WORKFLOW.md
+++ b/docs/ARCHITECTURE_CHANGE_WORKFLOW.md
@@ -1,0 +1,72 @@
+# Architecture Change Workflow
+
+Repository-local Codex skills provide a repeatable architecture practice that can later be adapted to AGEL governance.
+
+## Flow
+
+```text
+Use Case -> ADD draft -> C4 views -> ADRs -> reconcile ADD/C4 -> Implementation -> Conformance review
+```
+
+The flow is iterative. C4 work can expose a missing decision; an accepted ADR can require an ADD or target-view update. Implementation starts only after blocking questions and compliance conflicts are resolved.
+
+## Skills
+
+| Skill | Responsibility |
+|---|---|
+| `$architecture-change` | Coordinate lifecycle, traceability, gates, and readiness |
+| `$generate-use-case` | Draft/refine stakeholder behavior and requirements |
+| `$generate-add` | Describe the overall architecture design |
+| `$generate-c4` | Generate the appropriate source-backed C4 view |
+| `$generate-adr` | Record one independently changeable decision |
+| `$review-architecture-conformance` | Compare implementation with authoritative artifacts |
+
+One C4 skill supports multiple views because evidence, naming, state, boundaries, and validation rules are shared. Templates are provided for context, container, component, dynamic, and deployment views. Create only the views needed to answer a concrete stakeholder question.
+
+## Default Artifact Layout
+
+```text
+architecture/
+  use-cases/UC-NNN-<slug>.md
+  design/ADD-NNN-<slug>.md
+  diagrams/<system>/<system>-<state>-<view>.mmd
+  diagrams/<system>/<system>-<state>-<view>-evidence.md
+  decisions/ADR-NNN-<slug>.md
+  reviews/ACR-NNN-<slug>.md
+```
+
+Existing repository layouts may be preserved, but each artifact must use stable identifiers and reciprocal repository-relative links.
+
+## Lifecycle and Authority
+
+- A use case remains `Draft` until stakeholder feedback is incorporated. `Reviewed` or `Approved` requires a cited authoritative source.
+- An ADD remains `Draft` or `In Review` until its approval is evidenced.
+- An ADR remains `Proposed` until an authorized decision source accepts or rejects it. Accepted decision history is immutable; changes use superseding ADRs.
+- Proposed artifacts inform analysis but do not bind implementation.
+- A conformance review reports drift; it does not silently rewrite code or architecture decisions.
+
+## Evidence and Compliance
+
+Material claims are labeled `Confirmed`, `Assumption`, `To verify`, or `Unknown`. Architecture artifacts must not contain real personal/health data, credentials, secrets, or sensitive operational details.
+
+Every stage evaluates GDPR and EU AI Act applicability, including data minimization, lawful basis or consent, purpose limitation, retention/deletion, transparency, traceability, and meaningful human oversight. An unresolved compliance conflict blocks implementation readiness.
+
+## Minimal Training Run
+
+```text
+Use $architecture-change for “case document sharing”. Start with a draft use case only and list stakeholder questions.
+```
+
+After review:
+
+```text
+Use $generate-add with UC-001. Create only the C4 views that answer a concrete design question, and list ADR candidates.
+```
+
+After implementation:
+
+```text
+Use $review-architecture-conformance to compare this branch with UC-001, ADD-001, linked C4 views, and accepted ADRs.
+```
+
+The repository skill sync and discovery demonstration remains available through `python examples/project_skills_demo.py`. The default `python examples/minimal_demo.py` prints the architecture workflow contract as part of its output.

--- a/docs/PROJECT_SKILLS.md
+++ b/docs/PROJECT_SKILLS.md
@@ -11,6 +11,14 @@ This repository vendors the Codex skills needed for local development so they ar
 - `start-mobile-app`: project-native Flutter mobile launcher
 - `laws-collector`: starts and verifies the local laws collector worker loop
 - `prepare-task`: prepares ideas or GitHub Project tasks for implementation by reviewing repository context, asking required questions, and updating or creating the task description
+- `architecture-change`: coordinates Use Case -> ADD -> C4 -> ADR -> implementation readiness -> conformance review
+- `generate-use-case`: drafts and refines source-backed stakeholder use cases
+- `generate-add`: creates Architecture Design Documents from reviewed use cases and evidence
+- `generate-c4`: creates context, container, component, dynamic, deployment, and supporting data-flow views
+- `generate-adr`: creates and governs source-backed architecture decisions
+- `review-architecture-conformance`: reviews implementation against authoritative architecture artifacts
+
+See `docs/ARCHITECTURE_CHANGE_WORKFLOW.md` for artifact paths, lifecycle rules, compliance gates, and training prompts.
 
 ## Repository plugin
 

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -8,6 +8,12 @@ from aijurisdictionagents.api_db.e2e_test_users import provision_e2e_test_users
 from aijurisdictionagents.llm.base import read_positive_finite_env_seconds
 
 print(
+    "architecture_change_skills => Use Case -> ADD draft -> C4 views -> ADRs -> "
+    "reconcile ADD/C4 -> Implementation -> Conformance review; artifacts remain "
+    "source-backed and GDPR/EU AI Act gated."
+)
+
+print(
     "local_model_timeout => "
     f"deadline={read_positive_finite_env_seconds('LOCAL_LLM_REQUEST_TIMEOUT_SECONDS', 600)}s, "
     f"visible_progress={read_positive_finite_env_seconds('LOCAL_LLM_REQUEST_VISIBLE_PROGRESS', 15)}s; "

--- a/skills/architecture-change/SKILL.md
+++ b/skills/architecture-change/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: architecture-change
+description: Coordinate a traceable architecture change from stakeholder use case through Architecture Design Document (ADD), C4 views, Architecture Decision Records (ADRs), implementation readiness, and post-implementation conformance review. Use when starting or governing a significant architecture change, checking which artifacts are required, or continuing a change from an existing UC, ADD, C4, or ADR reference.
+---
+
+# Architecture Change
+
+Coordinate the workflow; delegate artifact authoring to the focused repository skills.
+
+## Workflow
+
+1. Read `AGENTS.md`, relevant repository sources, and supplied stakeholder evidence.
+2. Assign or resolve a change slug and maintain the traceability contract in [references/artifact-contract.md](references/artifact-contract.md).
+3. Run `$generate-use-case`. Keep the use case `Draft` until stakeholder feedback is incorporated; require `Reviewed` before design baselining.
+4. Run `$generate-add` from reviewed use cases and source evidence. Record uncertainties instead of inventing facts.
+5. Run `$generate-c4` for only the views needed to answer stakeholder questions. Do not require every C4 level.
+6. Run `$generate-adr` once per independently changeable decision discovered during ADD/C4 work.
+7. After ADR acceptance, reconcile the ADD and affected target-state C4 views. Proposed ADRs may inform drafts but are not binding.
+8. Declare implementation readiness only when blocking questions are closed, compliance gates pass, accepted decisions are linked, and acceptance criteria are testable.
+9. After implementation, run `$review-architecture-conformance` and resolve or explicitly accept deviations.
+
+## Required Gates
+
+- Evidence: label every material claim `Confirmed`, `Assumption`, `To verify`, or `Unknown`.
+- Privacy and regulation: address GDPR data minimization, lawful basis/consent where applicable, retention/deletion, transparency, traceability, and human oversight. Stop on an unresolved compliance conflict.
+- Safety and security: do not place personal/health data, credentials, secrets, or sensitive operational details in artifacts.
+- Governance: never claim stakeholder, architecture-board, security, privacy, or clinical approval without an authoritative source.
+- Implementation: architecture work does not authorize code changes. Follow the repository task, branch, worktree, validation, documentation, and versioning rules separately.
+
+## Default Output Layout
+
+```text
+architecture/
+  use-cases/
+  design/
+  diagrams/<system-slug>/
+  decisions/
+  reviews/
+```
+
+Preserve an established repository layout when one already exists and note the mapping.
+
+## Completion Summary
+
+Report artifact paths, lifecycle state, evidence gaps, accepted versus proposed decisions, compliance outcome, implementation readiness, and the next responsible action.

--- a/skills/architecture-change/agents/openai.yaml
+++ b/skills/architecture-change/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Architecture Change"
+  short_description: "Coordinate architecture artifacts end to end"
+  default_prompt: "Use $architecture-change to guide this change from use case through architecture decisions and implementation readiness."

--- a/skills/architecture-change/references/artifact-contract.md
+++ b/skills/architecture-change/references/artifact-contract.md
@@ -1,0 +1,21 @@
+# Architecture Artifact Contract
+
+Use stable identifiers and repository-relative links.
+
+| Artifact | Identifier | Default path | Lifecycle |
+|---|---|---|---|
+| Use case | `UC-NNN` | `architecture/use-cases/UC-NNN-<slug>.md` | Draft, Reviewed, Approved, Retired |
+| Architecture Design Document | `ADD-NNN` | `architecture/design/ADD-NNN-<slug>.md` | Draft, In Review, Approved, Superseded |
+| C4 view | `<system>-<state>-<view>` | `architecture/diagrams/<system>/` | Conceptual, Current, Transition, Target |
+| Decision | `ADR-NNN` | `architecture/decisions/ADR-NNN-<slug>.md` | Proposed, Accepted, Rejected, Deprecated, Superseded |
+| Conformance review | `ACR-NNN` | `architecture/reviews/ACR-NNN-<slug>.md` | Draft, Complete |
+
+Each artifact must include:
+
+- status, owner when known, date, and scope;
+- links to upstream and downstream artifacts;
+- evidence and uncertainty labels;
+- GDPR/EU AI Act applicability and safeguards;
+- unresolved questions and follow-up owners when known.
+
+Use the next unused number in the relevant folder. Never renumber an existing artifact.

--- a/skills/generate-add/SKILL.md
+++ b/skills/generate-add/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: generate-add
+description: Create, update, and review a source-backed Architecture Design Document (ADD) from reviewed use cases, repository evidence, constraints, quality attributes, C4 views, and ADRs. Use when a change needs an overall technical design, an ADD reference must be revised, or implementation readiness must be assessed without writing code.
+---
+
+# Generate ADD
+
+## Workflow
+
+1. Read `AGENTS.md`, reviewed use cases, existing architecture, relevant code, deployment sources, diagrams, and decisions.
+2. Resolve the next `ADD-NNN` or the referenced ADD. Never reuse or renumber identifiers.
+3. Copy [assets/add-template.md](assets/add-template.md) and apply [references/add-quality.md](references/add-quality.md).
+4. Define scope, drivers, constraints, system context, responsibilities, data flows, interfaces, deployment, operations, risks, and migration/rollback.
+5. Link C4 views rather than embedding several abstraction levels in one diagram. Request `$generate-c4` only for views that answer a concrete stakeholder question.
+6. Identify independently changeable choices as ADR candidates. Link proposed ADRs; treat only accepted ADRs as constraints.
+7. Run the privacy, security, clinical/legal safety, and human-oversight assessment. Stop on an unresolved compliance conflict.
+8. Save under `architecture/design/ADD-NNN-<slug>.md` unless an established layout exists.
+
+## Rules
+
+- Do not invent owners, technologies, protocols, service levels, classifications, approvals, or data flows.
+- Distinguish current, transition, target, and conceptual states.
+- Include failure modes and operational ownership, not only the happy path.
+- Keep real personal/health data, credentials, secrets, and sensitive endpoints out of the document.
+- Keep status `Draft` or `In Review` until authoritative approval is cited.
+
+## Completion
+
+Report the document path, linked use cases, required C4 views, ADR candidates, compliance blockers, open questions, and implementation-readiness result.

--- a/skills/generate-add/agents/openai.yaml
+++ b/skills/generate-add/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Generate ADD"
+  short_description: "Create an architecture design document"
+  default_prompt: "Use $generate-add to create an Architecture Design Document from approved use cases and repository evidence."

--- a/skills/generate-add/assets/add-template.md
+++ b/skills/generate-add/assets/add-template.md
@@ -1,0 +1,115 @@
+# ADD-<NNN>: <Architecture design title>
+
+## Record
+
+- Status: Draft
+- State described: <Current/Transition/Target/Conceptual>
+- Owner: <owner or Unknown>
+- Date: <YYYY-MM-DD>
+- Related use cases: <UC links>
+- Related diagrams: <C4 links or To create>
+- Related decisions: <ADR links or None>
+
+## Executive Summary
+
+<Problem, architectural response, intended outcome, and material uncertainty.>
+
+## Scope and Non-goals
+
+### In scope
+
+- <item>
+
+### Non-goals
+
+- <item>
+
+## Architecture Drivers and Constraints
+
+| Driver/constraint | Priority | Source | Confidence |
+|---|---|---|---|
+| <item> | <Must/Should/Could> | <source> | <Confirmed/etc.> |
+
+## Current-State Context
+
+<Relevant existing behavior, boundaries, pain points, and evidence.>
+
+## Target Architecture
+
+### Responsibilities and boundaries
+
+| Element | Responsibility | Owner | Trust/data boundary | Evidence |
+|---|---|---|---|---|
+| <element> | <responsibility> | <owner/Unknown> | <boundary> | <source/confidence> |
+
+### Interfaces and integrations
+
+| Source | Destination | Purpose/data | Interface/protocol | Failure behavior |
+|---|---|---|---|---|
+| <source> | <destination> | <flow> | <known or To verify> | <behavior> |
+
+### Data architecture
+
+| Data category | System of record | Processing purpose | Residency/retention/deletion | Access/audit |
+|---|---|---|---|---|
+| <category> | <system> | <purpose> | <controls> | <controls> |
+
+### C4 views
+
+- <link and stakeholder question answered>
+
+## Quality Attribute Scenarios
+
+| Attribute | Stimulus and environment | Expected measurable response | Validation |
+|---|---|---|---|
+| <attribute> | <scenario> | <response> | <test/evidence> |
+
+## Security, Privacy, Safety, and Compliance
+
+- Threat/trust boundaries: <assessment>
+- GDPR safeguards: <minimization, lawful basis/consent, rights, retention/deletion>
+- EU AI Act safeguards: <classification, transparency, logs, oversight, limitations>
+- Clinical/legal-risk safeguards: <human authority, escalation, fail-safe behavior>
+- Compliance blockers: <None or list>
+
+## Deployment and Operations
+
+- Environments/topology: <description or diagram link>
+- Observability and privacy-safe logging: <signals and exclusions>
+- Availability, recovery, and continuity: <targets or To verify>
+- Operational ownership and support: <roles or Unknown>
+
+## Delivery, Migration, and Rollback
+
+1. <increment>
+
+- Compatibility/data migration: <plan>
+- Rollback trigger and procedure: <plan>
+
+## Decisions and Alternatives
+
+| Decision topic | ADR | Status | Design impact |
+|---|---|---|---|
+| <topic> | <link/To create> | <Proposed/Accepted> | <impact> |
+
+## Risks, Assumptions, and Open Questions
+
+| Item | Type/state | Impact | Mitigation/owner |
+|---|---|---|---|
+| <item> | <Risk/Assumption/To verify/Unknown> | <impact> | <action> |
+
+## Verification and Implementation Readiness
+
+- [ ] Reviewed use cases and acceptance criteria are linked.
+- [ ] Required C4 views are linked and evidence-backed.
+- [ ] Binding decisions are accepted and reconciled.
+- [ ] Compliance blockers are closed.
+- [ ] Test, migration, observability, rollback, and documentation work are defined.
+
+Readiness: Not ready
+
+## Evidence
+
+| Claim | Source | Confidence |
+|---|---|---|
+| <claim> | <source> | <Confirmed/etc.> |

--- a/skills/generate-add/references/add-quality.md
+++ b/skills/generate-add/references/add-quality.md
@@ -1,0 +1,11 @@
+# ADD Quality Gate
+
+- Scope traces to reviewed use cases and preserves explicit non-goals.
+- Current, transition, target, and conceptual claims are not mixed.
+- Responsibilities, boundaries, integrations, data lifecycle, and failure behavior are explicit.
+- Quality attributes use measurable scenarios.
+- C4 views answer named questions and do not replace design rationale.
+- Independently changeable choices are delegated to ADRs.
+- Security, privacy, safety, operability, migration, rollback, cost, and ownership are addressed when relevant.
+- Only accepted ADRs are binding constraints.
+- Readiness remains false while a compliance conflict or material unknown can change the design.

--- a/skills/generate-adr/SKILL.md
+++ b/skills/generate-adr/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: generate-adr
+description: Create, update, review, reject, deprecate, or supersede source-backed Architecture Decision Records (ADRs), compare viable options, and connect decisions to use cases, ADDs, C4 views, risks, compliance evidence, and implementation. Use for any significant architecture choice or ADR reference; use the separate conformance-review skill when comparing code with accepted decisions.
+---
+
+# Generate ADR
+
+## Workflow
+
+1. Read `AGENTS.md`, existing decisions, linked use cases/ADDs/C4 views, supplied evidence, and relevant code.
+2. Determine whether to create, update, review, reject, deprecate, or supersede an ADR.
+3. For a new record, select the next unused `ADR-NNN` under `architecture/decisions/` and copy [assets/adr-template.md](assets/adr-template.md).
+4. Apply [references/adr-quality.md](references/adr-quality.md). Compare viable options using the same decision drivers; do not invent weak alternatives.
+5. Record the decision, positive and negative consequences, risks, compliance effects, follow-ups, and reciprocal artifact links.
+6. Use `Proposed` until an authoritative decision source supports another state.
+7. Treat accepted ADR content as immutable history. Create a new ADR to change the decision and update reciprocal supersession links.
+8. Save as `architecture/decisions/ADR-NNN-<slug>.md` unless an established layout exists.
+
+## Rules
+
+- Keep one primary, independently changeable decision per ADR.
+- Phrase the title as the decision outcome.
+- Never claim approval without evidence.
+- Use `To classify` rather than inferring personal/health-data or AI-risk classification.
+- Exclude personal/health records, credentials, secrets, connection strings, and sensitive endpoints.
+- Update affected target-state C4/ADD artifacts after acceptance; proposed decisions may be shown only as proposals.
+- When asked to review code, use `$review-architecture-conformance` and report deviations without rewriting accepted history.
+
+## Output
+
+Return path, lifecycle action/status, selected option, unresolved questions, evidence/approval gaps, affected artifacts, and required follow-ups.

--- a/skills/generate-adr/agents/openai.yaml
+++ b/skills/generate-adr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Generate ADR"
+  short_description: "Create and review architecture decisions"
+  default_prompt: "Use $generate-adr to create, update, review, or supersede an architecture decision record."

--- a/skills/generate-adr/assets/adr-template.md
+++ b/skills/generate-adr/assets/adr-template.md
@@ -1,0 +1,76 @@
+# ADR-<NNN>: <Decision outcome>
+
+## Record
+
+- Status: Proposed
+- Date: <YYYY-MM-DD>
+- Decision owner: <role or Unknown>
+- Decision source: <board/ticket/meeting record or Not yet decided>
+- Supersedes: <ADR link or None>
+- Superseded by: None
+- Related artifacts: <UC, ADD, C4, task links>
+
+## Context
+
+<Problem, why a decision is needed now, and evidence-backed current state.>
+
+## Scope and Non-goals
+
+- In scope: <items>
+- Out of scope: <items>
+
+## Decision Drivers
+
+| Driver | Priority | Source/confidence |
+|---|---|---|
+| <driver> | <priority> | <source and Confirmed/etc.> |
+
+## Options Considered
+
+### Option A: <name>
+
+- Description: <viable option>
+- Advantages: <items>
+- Disadvantages/risks: <items>
+- Driver assessment: <assessment>
+
+### Option B: <name>
+
+- Description: <viable option>
+- Advantages: <items>
+- Disadvantages/risks: <items>
+- Driver assessment: <assessment>
+
+## Decision
+
+<Specific selected option and boundaries, or “Not yet decided” while Proposed.>
+
+## Consequences
+
+### Positive
+
+- <consequence>
+
+### Negative and trade-offs
+
+- <consequence>
+
+## Security, Privacy, Safety, and Compliance
+
+- Security/trust impact: <assessment>
+- GDPR/data-lifecycle impact: <assessment>
+- EU AI Act/human-oversight impact: <assessment>
+- Clinical/legal-risk impact: <assessment>
+- Required review/approval: <source or To obtain>
+
+## Validation and Follow-up
+
+| Action or validation | Owner | Due date | Tracking link |
+|---|---|---|---|
+| <action> | <owner/Unknown> | <date/Unknown> | <link> |
+
+## Evidence and Uncertainty
+
+| Claim/question | Source | State |
+|---|---|---|
+| <item> | <source> | <Confirmed/Assumption/To verify/Unknown> |

--- a/skills/generate-adr/references/adr-quality.md
+++ b/skills/generate-adr/references/adr-quality.md
@@ -1,0 +1,12 @@
+# ADR Quality Gate
+
+- One independently changeable decision is recorded.
+- Context explains why the decision is needed now.
+- Scope, non-goals, and decision drivers are explicit.
+- Options are viable and assessed consistently.
+- The decision is specific enough to guide implementation.
+- Positive and negative consequences are preserved.
+- Security, privacy, safety, data, availability, interoperability, operability, and cost are addressed where relevant.
+- Facts and approvals cite authoritative evidence.
+- Accepted history is not rewritten; supersession uses reciprocal links.
+- ADD and C4 impacts plus owned follow-ups are identified.

--- a/skills/generate-c4/SKILL.md
+++ b/skills/generate-c4/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: generate-c4
+description: Create, update, and review source-backed C4 architecture views using Mermaid by default. Use for system landscape, system context, container, component, dynamic, deployment, integration, or regulated-data-flow diagrams; when an ADD or ADR needs a view; or when an existing diagram must be checked for scope, evidence, consistency, and sensitive-data exposure.
+---
+
+# Generate C4
+
+Use one skill with a view parameter; do not create a separate skill for every C4 level.
+
+## Workflow
+
+1. Read `AGENTS.md`, linked use cases, ADDs, ADRs, repository sources, and existing diagrams.
+2. Identify the stakeholder question and requested state: `current`, `transition`, `target`, or `conceptual`.
+3. Select one primary view with [references/c4-selection.md](references/c4-selection.md). Split mixed abstraction levels into separate files.
+4. Build an evidence table for elements and relationships. Do not invent technologies, owners, protocols, boundaries, or flows.
+5. Copy the closest Mermaid asset: [assets/context.mmd](assets/context.mmd), [assets/container.mmd](assets/container.mmd), [assets/component.mmd](assets/component.mmd), [assets/dynamic.mmd](assets/dynamic.mmd), or [assets/deployment.mmd](assets/deployment.mmd).
+6. Add title, scope/state, legend, boundaries, directional relationship labels, and uncertainty markers.
+7. Validate syntax with an available renderer and visually inspect rendered output when practical.
+8. Save editable source and evidence under `architecture/diagrams/<system-slug>/`; keep any rendered SVG beside it.
+
+## Rules
+
+- Use business-recognizable names; put technology in a secondary label.
+- Draw external actors/systems outside the system boundary.
+- Label every material arrow with action/data and known interface/protocol.
+- Mark regulated-data and trust-boundary crossings only when evidence supports them.
+- Visually distinguish confirmed facts, proposals, and uncertainty.
+- Never include personal/health records, credentials, secrets, connection strings, or sensitive endpoint details.
+- Link the source ADD/ADR and link those artifacts back to the diagram.
+
+## Output Names
+
+```text
+architecture/diagrams/<system>/<system>-<state>-<view>.mmd
+architecture/diagrams/<system>/<system>-<state>-<view>.svg
+architecture/diagrams/<system>/<system>-<state>-<view>-evidence.md
+```
+
+Return paths, the question answered, state/view, evidence gaps, validation result, and unresolved questions.

--- a/skills/generate-c4/agents/openai.yaml
+++ b/skills/generate-c4/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Generate C4"
+  short_description: "Create source-backed C4 architecture views"
+  default_prompt: "Use $generate-c4 to create or update the appropriate source-backed C4 view for this architecture change."

--- a/skills/generate-c4/assets/component.mmd
+++ b/skills/generate-c4/assets/component.mmd
@@ -1,0 +1,12 @@
+flowchart LR
+  caller["Calling container"]
+  subgraph container["Container boundary"]
+    entry["Entry component<br/><responsibility>"]
+    core["Domain component<br/><responsibility>"]
+    adapter["Adapter component<br/><responsibility>"]
+  end
+  external["External dependency"]
+  caller -->|"<request>"| entry
+  entry -->|"<command/query>"| core
+  core -->|"<operation>"| adapter
+  adapter -->|"<interface/data>"| external

--- a/skills/generate-c4/assets/container.mmd
+++ b/skills/generate-c4/assets/container.mmd
@@ -1,0 +1,10 @@
+flowchart LR
+  user["User<br/><role>"]
+  subgraph system["System boundary"]
+    ui["Application<br/><technology if confirmed>"]
+    api["Service<br/><technology if confirmed>"]
+    store[("Data store<br/><technology if confirmed>")]
+  end
+  user -->|"<action>"| ui
+  ui -->|"<request/data>"| api
+  api -->|"<read/write>"| store

--- a/skills/generate-c4/assets/context.mmd
+++ b/skills/generate-c4/assets/context.mmd
@@ -1,0 +1,9 @@
+flowchart LR
+  %% <system> <state> system-context view
+  person["Person<br/><role>"]
+  subgraph boundary["System boundary"]
+    system["System<br/><responsibility>"]
+  end
+  external["External system<br/><responsibility>"]
+  person -->|"<action/data>"| system
+  system -->|"<action/data; interface if known>"| external

--- a/skills/generate-c4/assets/deployment.mmd
+++ b/skills/generate-c4/assets/deployment.mmd
@@ -1,0 +1,8 @@
+flowchart TB
+  subgraph zone["Environment / trust zone"]
+    subgraph node["Deployment node"]
+      workload["Workload<br/><container instance>"]
+    end
+    data[("Managed data service")]
+  end
+  workload -->|"<protocol/data>"| data

--- a/skills/generate-c4/assets/dynamic.mmd
+++ b/skills/generate-c4/assets/dynamic.mmd
@@ -1,0 +1,12 @@
+sequenceDiagram
+  autonumber
+  actor User
+  participant A as Application
+  participant B as Service
+  participant C as Dependency
+  User->>A: <trigger>
+  A->>B: <request/data>
+  B->>C: <operation/interface>
+  C-->>B: <result/error>
+  B-->>A: <response>
+  A-->>User: <observable outcome>

--- a/skills/generate-c4/references/c4-selection.md
+++ b/skills/generate-c4/references/c4-selection.md
@@ -1,0 +1,15 @@
+# C4 View Selection
+
+| Stakeholder question | Primary view |
+|---|---|
+| Who uses the system and which external systems interact with it? | System context |
+| What independently deployable/runnable parts exist and how do they communicate? | Container |
+| How is one container internally structured? | Component |
+| What happens step-by-step for one scenario? | Dynamic |
+| Where do workloads run across nodes/environments/zones? | Deployment |
+| How do several systems fit across an enterprise/domain? | System landscape |
+| Where does regulated data travel and cross trust boundaries? | Data/integration flow, explicitly labeled as a supporting view |
+
+Create only views that support a decision, review, implementation, or operational question.
+
+Evidence files must record: view/state, stakeholder question, related artifacts, element/relationship/source/confidence table, assumptions, unresolved questions, and generation date.

--- a/skills/generate-use-case/SKILL.md
+++ b/skills/generate-use-case/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: generate-use-case
+description: Create, refine, and review source-backed architecture use-case documents with actors, goals, flows, requirements, data handling, compliance controls, acceptance criteria, and stakeholder feedback. Use when the user supplies a use-case idea or reference such as UC-001, asks for a draft, or wants an existing use case updated after stakeholder discussion.
+---
+
+# Generate Use Case
+
+## Workflow
+
+1. Read `AGENTS.md`, existing use cases, supplied stakeholder notes, and relevant repository sources.
+2. Resolve the next `UC-NNN` or the referenced existing use case. Never reuse or renumber an identifier.
+3. Copy [assets/use-case-template.md](assets/use-case-template.md); replace every placeholder and remove irrelevant optional sections.
+4. Separate stakeholder facts from proposals and assumptions. Ask focused questions when ambiguity changes scope, data handling, acceptance criteria, or risk.
+5. Describe the main success flow and material alternate/error flows without prescribing architecture prematurely.
+6. Apply the GDPR/EU AI Act checklist in [references/use-case-quality.md](references/use-case-quality.md).
+7. Keep status `Draft` while feedback is unresolved. Use `Reviewed` only with a cited stakeholder review source and `Approved` only with explicit authority.
+8. Save under `architecture/use-cases/UC-NNN-<slug>.md` unless the repository has an established equivalent.
+
+## Rules
+
+- Use observable, testable language.
+- Include only the minimum personal or health data categories needed; never include real subject data.
+- Identify human decisions and automation boundaries for legal-, clinical-, or other high-impact outcomes.
+- Preserve a concise feedback/change log when updating a reviewed draft.
+- Link related ADDs, diagrams, ADRs, tasks, and evidence using repository-relative paths or authorized identifiers.
+
+## Output
+
+Return the draft path, status, assumptions, blocking questions, compliance outcome, and recommended next step (`stakeholder review` or `$generate-add`).

--- a/skills/generate-use-case/agents/openai.yaml
+++ b/skills/generate-use-case/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Generate Use Case"
+  short_description: "Draft and refine traceable use cases"
+  default_prompt: "Use $generate-use-case to draft a source-backed use case and refine it with stakeholder feedback."

--- a/skills/generate-use-case/assets/use-case-template.md
+++ b/skills/generate-use-case/assets/use-case-template.md
@@ -1,0 +1,92 @@
+# UC-<NNN>: <Outcome-oriented title>
+
+## Record
+
+- Status: Draft
+- Owner: <owner or Unknown>
+- Date: <YYYY-MM-DD>
+- Stakeholders: <roles, not personal data>
+- Related artifacts: <links or None>
+
+## Goal and Business Outcome
+
+<Why this use case exists and how success is measured.>
+
+## Scope
+
+### In scope
+
+- <item>
+
+### Out of scope
+
+- <item>
+
+## Actors and Responsibilities
+
+| Actor or system | Responsibility | Evidence/confidence |
+|---|---|---|
+| <actor> | <responsibility> | <source and Confirmed/Assumption/To verify/Unknown> |
+
+## Preconditions and Trigger
+
+- Preconditions: <conditions>
+- Trigger: <event>
+
+## Main Success Flow
+
+1. <observable interaction>
+
+## Alternate and Failure Flows
+
+| Condition | Expected behavior | Recovery or human escalation |
+|---|---|---|
+| <condition> | <behavior> | <action> |
+
+## Information and Data
+
+| Data category | Purpose | Source/recipient | Retention/deletion | Classification status |
+|---|---|---|---|---|
+| <category, no real records> | <purpose> | <flow> | <rule> | <Confirmed/To classify> |
+
+## Requirements and Constraints
+
+### Functional requirements
+
+- `FR-<NN>`: <testable requirement>
+
+### Quality attributes
+
+- `QA-<NN>`: <security, privacy, safety, availability, interoperability, operability, or performance scenario>
+
+## GDPR and EU AI Act Assessment
+
+- Personal/special-category data: <None identified/description/To classify>
+- Lawful basis or consent: <basis/To verify/Not applicable>
+- Data minimization and purpose limitation: <controls>
+- Retention, deletion, and subject rights: <controls>
+- AI role and risk classification: <assessment/To classify>
+- Transparency, traceability, and human oversight: <controls>
+- Compliance blockers: <None or list>
+
+## Acceptance Criteria
+
+- [ ] <Given/when/then or other observable criterion>
+
+## Assumptions and Open Questions
+
+| Item | State | Owner/source | Due date |
+|---|---|---|---|
+| <item> | <Assumption/To verify/Unknown> | <owner/source> | <date or Unknown> |
+
+## Evidence
+
+| Claim | Source | Confidence |
+|---|---|---|
+| <claim> | <repository path, authorized URL, or meeting/ticket ID> | <Confirmed/etc.> |
+
+## Stakeholder Feedback Log
+
+| Date | Source/reviewer role | Change or outcome |
+|---|---|---|
+| <date> | <source> | <summary> |

--- a/skills/generate-use-case/references/use-case-quality.md
+++ b/skills/generate-use-case/references/use-case-quality.md
@@ -1,0 +1,11 @@
+# Use Case Quality Gate
+
+- The goal names a measurable stakeholder outcome.
+- Actors are roles or systems, not named individuals.
+- Scope and non-goals are explicit.
+- Flows describe behavior without prematurely selecting technology.
+- Requirements and acceptance criteria are observable and uniquely labeled.
+- Data purposes, recipients, retention/deletion, consent or lawful basis, and subject rights are addressed where applicable.
+- AI-supported high-impact decisions expose limitations, traceability, and meaningful human oversight.
+- Facts, assumptions, and open questions are distinguishable and sourced.
+- Approval is supported by an authoritative review record.

--- a/skills/review-architecture-conformance/SKILL.md
+++ b/skills/review-architecture-conformance/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: review-architecture-conformance
+description: Review an implementation, code change, pull request, or deployed design against linked use cases, approved ADDs, C4 views, accepted ADRs, quality attributes, and GDPR/EU AI Act safeguards. Use when checking architecture compliance, identifying undocumented drift, assessing whether diagrams/docs need updates, or producing an Architecture Conformance Review (ACR); do not use it to approve or rewrite decisions automatically.
+---
+
+# Review Architecture Conformance
+
+## Workflow
+
+1. Read `AGENTS.md`, the change diff/code/tests/configuration, and all linked architecture artifacts.
+2. Determine the authoritative baseline: reviewed/approved use cases, approved ADD content, accepted ADRs, and applicable current/target C4 views. Proposed artifacts are advisory only.
+3. Build a requirement-to-evidence matrix using [references/review-method.md](references/review-method.md).
+4. Inspect responsibilities, dependencies, interfaces, data flows, trust boundaries, deployment, failure modes, logging, oversight, and test evidence.
+5. Classify each variance as `Conformant`, `Documented deviation`, `Undocumented drift`, `Artifact stale`, or `Not verifiable`.
+6. Report findings by severity with exact code/artifact references and a concrete remediation. Do not modify code unless separately requested and authorized.
+7. Create `architecture/reviews/ACR-NNN-<slug>.md` when the user requests a persistent review; otherwise return the review in chat.
+
+## Rules
+
+- Do not treat an accepted ADR as proof that implementation conforms.
+- Do not treat current code as authority that silently overrides an accepted decision.
+- Recommend a new/superseding ADR when reality requires a decision change.
+- Recommend artifact updates when implementation is correct but documentation is stale.
+- Verify privacy-safe logs, data minimization, retention/deletion, transparency, traceability, and human oversight where applicable.
+- Never expose personal/health data, secrets, credentials, or sensitive operational values in findings.
+- Never claim approval; identify required owners and decision points.
+
+## Output
+
+Lead with overall result and blocking findings. Include baseline artifacts, evidence matrix, findings with severity, compliance assessment, required artifact/code changes, unverifiable items, and recommended owner/action.

--- a/skills/review-architecture-conformance/agents/openai.yaml
+++ b/skills/review-architecture-conformance/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review Architecture Conformance"
+  short_description: "Compare implementation with architecture"
+  default_prompt: "Use $review-architecture-conformance to review code against linked use cases, ADDs, C4 views, and ADRs."

--- a/skills/review-architecture-conformance/references/review-method.md
+++ b/skills/review-architecture-conformance/references/review-method.md
@@ -1,0 +1,18 @@
+# Architecture Conformance Review Method
+
+Use this matrix:
+
+| Baseline requirement/decision | Authority | Implementation evidence | Result | Finding/action |
+|---|---|---|---|---|
+| <requirement> | <artifact link/status> | <file:line, test, config, runtime evidence> | <classification> | <action> |
+
+Severity:
+
+- `Critical`: credible compliance, safety, security, or irreversible data risk; stop release.
+- `High`: violates an accepted decision or core requirement; resolve before release unless authorized exception exists.
+- `Medium`: material drift, missing quality control, or stale artifact that can mislead implementation/operations.
+- `Low`: clarity, traceability, or maintainability weakness without immediate behavioral impact.
+
+Review at minimum: functional scope, component responsibilities, interfaces/dependencies, data lifecycle, trust boundaries, deployment/runtime, failure/recovery, observability, quality-attribute tests, GDPR safeguards, EU AI Act transparency/traceability/oversight, and documentation links.
+
+An exception needs scope, rationale, risk, owner, expiry/review date, and authoritative approval evidence.


### PR DESCRIPTION
## What changed
- add six repository-local architecture workflow skills
- add Use Case, ADD, ADR, and C4 Mermaid templates with traceability contracts
- add GDPR and EU AI Act gates plus post-implementation conformance review
- document the end-to-end training workflow and expose it in the minimal demo

## Why
Provide a shared, repeatable Use Case -> ADD -> C4 -> ADR -> Implementation workflow that can be practiced here and adapted to AGEL architecture governance later.

## Validation
- all six skills pass `quick_validate.py`
- `python scripts/sync_codex_skills.py --dry-run`
- `python examples/minimal_demo.py`
- `git diff --check`
- repository pre-commit checks